### PR TITLE
correct FFI_MMAP_EXEC_WRIT for darwin11 aka Mac OS X 10.7 Lion.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -345,7 +345,7 @@ case "$target" in
                  [Cannot use PROT_EXEC on this target, so, we revert to
                    alternative means])
      ;;
-     *-apple-darwin10* | *-*-freebsd* | *-*-openbsd* | *-pc-solaris*)
+     *-apple-darwin1[[01]]* | *-*-freebsd* | *-*-openbsd* | *-pc-solaris*)
        AC_DEFINE(FFI_MMAP_EXEC_WRIT, 1,
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])


### PR DESCRIPTION
FFI_MMAP_EXEC_WRIT for darwin11 should be same value as darwin10.
I've met SEGV of ruby-1.9.2 fiddle module on Mac OS X 10.7 Lion.
This change solved the problem.
- fink -  http://sourceforge.net/tracker/?func=detail&aid=3374297&group_id=17203&atid=414256
- mozilla -  https://bugzilla.mozilla.org/show_bug.cgi?id=682180
