### PR TITLE
Add -no-undefined for all windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,15 +98,6 @@ case "$host" in
 	;;
   i?86-win32* | i?86-*-cygwin* | i?86-*-mingw* | i?86-*-os2* | i?86-*-interix*)
 	TARGET=X86_WIN32; TARGETDIR=x86
-	# All mingw/cygwin/win32 builds require -no-undefined for sharedlib.
-	# We must also check with_cross_host to decide if this is a native
-	# or cross-build and select where to install dlls appropriately.
-	if test -n "$with_cross_host" &&
-	   test x"$with_cross_host" != x"no"; then
-	  AM_LTLDFLAGS='-no-undefined -bindir "$(toolexeclibdir)"';
-	else
-	  AM_LTLDFLAGS='-no-undefined -bindir "$(bindir)"';
-	fi
 	;;
   i?86-*-darwin*)
 	TARGET=X86_DARWIN; TARGETDIR=x86
@@ -189,6 +180,15 @@ case "$host" in
 
   x86_64-*-cygwin* | x86_64-*-mingw*)
 	TARGET=X86_WIN64; TARGETDIR=x86
+	;;
+
+  x86_64-*-*)
+	TARGET=X86_64; TARGETDIR=x86
+	;;
+esac
+
+case "$host" in
+  *-win32* | *-*-cygwin* | *-*-mingw* | *-*-os2* | *-*-interix*)
 	# All mingw/cygwin/win32 builds require -no-undefined for sharedlib.
 	# We must also check with_cross_host to decide if this is a native
 	# or cross-build and select where to install dlls appropriately.
@@ -198,10 +198,6 @@ case "$host" in
 	else
 	  AM_LTLDFLAGS='-no-undefined -bindir "$(bindir)"';
 	fi
-	;;
-
-  x86_64-*-*)
-	TARGET=X86_64; TARGETDIR=x86
 	;;
 esac
 


### PR DESCRIPTION
Currently this flag is only set for x86 architectures and not for x86_64 ones
