### PR TITLE
cygwin/mingw shared libs need libtool LDFLAGS = -no-undefined

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ if FFI_DEBUG
 AM_CFLAGS += -DFFI_DEBUG
 endif
 
-libffi_la_LDFLAGS = -version-info `grep -v '^\#' $(srcdir)/libtool-version` $(LTLDFLAGS) $(AM_LTLDFLAGS)
+libffi_la_LDFLAGS = -no-undefined -version-info `grep -v '^\#' $(srcdir)/libtool-version` $(LTLDFLAGS) $(AM_LTLDFLAGS)
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/include -Iinclude -I$(top_srcdir)/src -DFFI_BUILDING
 AM_CCASFLAGS = $(AM_CPPFLAGS) -g


### PR DESCRIPTION
otherwise only static libs are created.
