### PR TITLE
Fix for a crasher due to misaligned stack on x86-32.

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -315,9 +315,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
   cif->bytes += 4 * sizeof(ffi_arg);
 #endif
 
-#ifdef X86_DARWIN
   cif->bytes = (cif->bytes + 15) & ~0xF;
-#endif
 
   return FFI_OK;
 }


### PR DESCRIPTION
Full information on reproduction (using Python's ctypes available here: http://bugs.python.org/issue17423)
