### PR TITLE
Fixes for building with Emscripten

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,127 +98,141 @@ FLAGS_TO_PASS = $(AM_MAKEFLAGS)
 
 MAKEOVERRIDES=
 
+librarySOURCES = src/prep_cif.c src/types.c \
+		src/raw_api.c src/java_raw_api.c src/closures.c
+
+if USE_LIBTOOL
 toolexeclib_LTLIBRARIES = libffi.la
 noinst_LTLIBRARIES = libffi_convenience.la
-
-libffi_la_SOURCES = src/prep_cif.c src/types.c \
-		src/raw_api.c src/java_raw_api.c src/closures.c
+libffi_la_SOURCES = librarySOURCES
+else
+lib_LIBRARIES = libffi.a
+noinst_LIBRARIES = libffi_convenience.a
+libffi_a_SOURCES = librarySOURCES
+endif
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libffi.pc
 
-nodist_libffi_la_SOURCES =
+additionalSOURCES =
 
 if FFI_DEBUG
-nodist_libffi_la_SOURCES += src/debug.c
+additionalSOURCES += src/debug.c
 endif
 
 if MIPS
-nodist_libffi_la_SOURCES += src/mips/ffi.c src/mips/o32.S src/mips/n32.S
+additionalSOURCES += src/mips/ffi.c src/mips/o32.S src/mips/n32.S
 endif
 if BFIN
-nodist_libffi_la_SOURCES += src/bfin/ffi.c src/bfin/sysv.S
+additionalSOURCES += src/bfin/ffi.c src/bfin/sysv.S
 endif
 if X86
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/sysv.S
+additionalSOURCES += src/x86/ffi.c src/x86/sysv.S
 endif
 if X86_FREEBSD
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/freebsd.S
+additionalSOURCES += src/x86/ffi.c src/x86/freebsd.S
 endif
 if X86_WIN32
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/win32.S
+additionalSOURCES += src/x86/ffi.c src/x86/win32.S
 endif
 if X86_WIN64
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/win64.S
+additionalSOURCES += src/x86/ffi.c src/x86/win64.S
 endif
 if X86_DARWIN
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/darwin.S src/x86/ffi64.c src/x86/darwin64.S
+additionalSOURCES += src/x86/ffi.c src/x86/darwin.S src/x86/ffi64.c src/x86/darwin64.S
 endif
 if SPARC
-nodist_libffi_la_SOURCES += src/sparc/ffi.c src/sparc/v8.S src/sparc/v9.S
+additionalSOURCES += src/sparc/ffi.c src/sparc/v8.S src/sparc/v9.S
 endif
 if ALPHA
-nodist_libffi_la_SOURCES += src/alpha/ffi.c src/alpha/osf.S
+additionalSOURCES += src/alpha/ffi.c src/alpha/osf.S
 endif
 if IA64
-nodist_libffi_la_SOURCES += src/ia64/ffi.c src/ia64/unix.S
+additionalSOURCES += src/ia64/ffi.c src/ia64/unix.S
 endif
 if M32R
-nodist_libffi_la_SOURCES += src/m32r/sysv.S src/m32r/ffi.c
+additionalSOURCES += src/m32r/sysv.S src/m32r/ffi.c
 endif
 if M68K
-nodist_libffi_la_SOURCES += src/m68k/ffi.c src/m68k/sysv.S
+additionalSOURCES += src/m68k/ffi.c src/m68k/sysv.S
 endif
 if MOXIE
-nodist_libffi_la_SOURCES += src/moxie/ffi.c src/moxie/eabi.S
+additionalSOURCES += src/moxie/ffi.c src/moxie/eabi.S
 endif
 if MICROBLAZE
-nodist_libffi_la_SOURCES += src/microblaze/ffi.c src/microblaze/sysv.S
+additionalSOURCES += src/microblaze/ffi.c src/microblaze/sysv.S
 endif
 if POWERPC
-nodist_libffi_la_SOURCES += src/powerpc/ffi.c src/powerpc/sysv.S src/powerpc/ppc_closure.S src/powerpc/linux64.S src/powerpc/linux64_closure.S
+additionalSOURCES += src/powerpc/ffi.c src/powerpc/sysv.S src/powerpc/ppc_closure.S src/powerpc/linux64.S src/powerpc/linux64_closure.S
 endif
 if POWERPC_AIX
-nodist_libffi_la_SOURCES += src/powerpc/ffi_darwin.c src/powerpc/aix.S src/powerpc/aix_closure.S
+additionalSOURCES += src/powerpc/ffi_darwin.c src/powerpc/aix.S src/powerpc/aix_closure.S
 endif
 if POWERPC_DARWIN
-nodist_libffi_la_SOURCES += src/powerpc/ffi_darwin.c src/powerpc/darwin.S src/powerpc/darwin_closure.S
+additionalSOURCES += src/powerpc/ffi_darwin.c src/powerpc/darwin.S src/powerpc/darwin_closure.S
 endif
 if POWERPC_FREEBSD
-nodist_libffi_la_SOURCES += src/powerpc/ffi.c src/powerpc/sysv.S src/powerpc/ppc_closure.S
+additionalSOURCES += src/powerpc/ffi.c src/powerpc/sysv.S src/powerpc/ppc_closure.S
 endif
 if AARCH64
-nodist_libffi_la_SOURCES += src/aarch64/sysv.S src/aarch64/ffi.c
+additionalSOURCES += src/aarch64/sysv.S src/aarch64/ffi.c
 endif
 if ARM
-nodist_libffi_la_SOURCES += src/arm/sysv.S src/arm/ffi.c
+additionalSOURCES += src/arm/sysv.S src/arm/ffi.c
 if FFI_EXEC_TRAMPOLINE_TABLE
-nodist_libffi_la_SOURCES += src/arm/trampoline.S
+additionalSOURCES += src/arm/trampoline.S
 endif
 endif
 if AVR32
-nodist_libffi_la_SOURCES += src/avr32/sysv.S src/avr32/ffi.c
+additionalSOURCES += src/avr32/sysv.S src/avr32/ffi.c
 endif
 if LIBFFI_CRIS
-nodist_libffi_la_SOURCES += src/cris/sysv.S src/cris/ffi.c
+additionalSOURCES += src/cris/sysv.S src/cris/ffi.c
 endif
 if FRV
-nodist_libffi_la_SOURCES += src/frv/eabi.S src/frv/ffi.c
+additionalSOURCES += src/frv/eabi.S src/frv/ffi.c
 endif
 if S390
-nodist_libffi_la_SOURCES += src/s390/sysv.S src/s390/ffi.c
+additionalSOURCES += src/s390/sysv.S src/s390/ffi.c
 endif
 if X86_64
-nodist_libffi_la_SOURCES += src/x86/ffi64.c src/x86/unix64.S src/x86/ffi.c src/x86/sysv.S
+additionalSOURCES += src/x86/ffi64.c src/x86/unix64.S src/x86/ffi.c src/x86/sysv.S
 endif
 if SH
-nodist_libffi_la_SOURCES += src/sh/sysv.S src/sh/ffi.c
+additionalSOURCES += src/sh/sysv.S src/sh/ffi.c
 endif
 if SH64
-nodist_libffi_la_SOURCES += src/sh64/sysv.S src/sh64/ffi.c
+additionalSOURCES += src/sh64/sysv.S src/sh64/ffi.c
 endif
 if PA_LINUX
-nodist_libffi_la_SOURCES += src/pa/linux.S src/pa/ffi.c
+additionalSOURCES += src/pa/linux.S src/pa/ffi.c
 endif
 if PA_HPUX
-nodist_libffi_la_SOURCES += src/pa/hpux32.S src/pa/ffi.c
+additionalSOURCES += src/pa/hpux32.S src/pa/ffi.c
 endif
 if TILE
-nodist_libffi_la_SOURCES += src/tile/tile.S src/tile/ffi.c
+additionalSOURCES += src/tile/tile.S src/tile/ffi.c
 endif
 if XTENSA
-nodist_libffi_la_SOURCES += src/xtensa/sysv.S src/xtensa/ffi.c
+additionalSOURCES += src/xtensa/sysv.S src/xtensa/ffi.c
 endif
 if METAG
-nodist_libffi_la_SOURCES += src/metag/sysv.S src/metag/ffi.c
+additionalSOURCES += src/metag/sysv.S src/metag/ffi.c
 endif
 
+if USE_LIBTOOL
+nodist_libffi_la_SOURCES = additionalSOURCES
 libffi_convenience_la_SOURCES = $(libffi_la_SOURCES)
 nodist_libffi_convenience_la_SOURCES = $(nodist_libffi_la_SOURCES)
 
 LTLDFLAGS = $(shell $(SHELL) $(top_srcdir)/libtool-ldflags $(LDFLAGS))
 
 libffi_la_LDFLAGS = -no-undefined -version-info `grep -v '^\#' $(srcdir)/libtool-version` $(LTLDFLAGS) $(AM_LTLDFLAGS)
+else
+nodist_libffi_a_SOURCES = additionalSOURCES
+libffi_convenience_a_SOURCES = $(libffi_a_SOURCES)
+nodist_libffi_convenience_a_SOURCES = $(nodist_libffi_a_SOURCES)
+endif
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/include -Iinclude -I$(top_srcdir)/src
 AM_CCASFLAGS = $(AM_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,6 @@ AC_SUBST(CFLAGS)
 
 AM_PROG_AS
 AM_PROG_CC_C_O
-AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
 
 # Test for 64-bit build.
@@ -534,6 +533,14 @@ AC_ARG_ENABLE(purify-safety,
   if test "$enable_purify_safety" = "yes"; then
     AC_DEFINE(USING_PURIFY, 1, [Define this if you are using Purify and want to suppress spurious messages.])
   fi)
+  
+AC_ARG_ENABLE(libtool,
+[  --disable-libtool  do not use libtool to handle libraries])
+AM_CONDITIONAL(USE_LIBTOOL, !test "x$enable_libtool" = "xno")
+
+if test "x$enable_libtool" = "xyes"; then
+AC_PROG_LIBTOOL
+fi
 
 # These variables are only ever used when we cross-build to X86_WIN32.
 # And we only support this with GCC, so...


### PR DESCRIPTION
Enable disabling of libtool on platforms where it does not work (e.g. LLVM).
Build libraries normally then.
