### PR TITLE
Correct the -L flag in libffi.pc.in

### DIFF
--- a/libffi.pc.in
+++ b/libffi.pc.in
@@ -1,10 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
+toolexeclibdir=@toolexeclibdir@
 includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
 
 Name: @PACKAGE_NAME@
 Description: Library supporting Foreign Function Interfaces
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lffi
+Libs: -L${toolexeclibdir} -lffi
 Cflags: -I${includedir}


### PR DESCRIPTION
use -L${toolexeclibdir} instead of -L${libdir}
to be consistent with Makefile.am

Fixes #39
