### PR TITLE
arc: Fix build error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -172,7 +172,7 @@ if AARCH64
 nodist_libffi_la_SOURCES += src/aarch64/sysv.S src/aarch64/ffi.c
 endif
 if ARC
-nodist_libffi_la_SOURCES += src/arc/sysv.S src/arc/ffi.c
+nodist_libffi_la_SOURCES += src/arc/arcompact.S src/arc/ffi.c
 endif
 if ARM
 nodist_libffi_la_SOURCES += src/arm/sysv.S src/arm/ffi.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -852,7 +852,7 @@ src/arc/$(am__dirstamp):
 src/arc/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/arc/$(DEPDIR)
 	@: > src/arc/$(DEPDIR)/$(am__dirstamp)
-src/arc/sysv.lo: src/arc/$(am__dirstamp) \
+src/arc/arcompact.lo: src/arc/$(am__dirstamp) \
 	src/arc/$(DEPDIR)/$(am__dirstamp)
 src/arc/ffi.lo: src/arc/$(am__dirstamp) \
 	src/arc/$(DEPDIR)/$(am__dirstamp)


### PR DESCRIPTION
Hello Anthony,

First of all, thank you for merging ARC support into libffi. Unfortunately I haven't been careful enough when creating the patch, and the rename from 'sysv' to 'arcompact' (which is a better name in our case) got lost in the automake rebuild patch, instead of the patch for ARC support.

This fixes the issue.

Thanks,

Mischa
