### PR TITLE
Fix build failure when using clang for Android

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -34,7 +34,7 @@
 #include <ffi_common.h>
 
 #if !FFI_MMAP_EXEC_WRIT && !FFI_EXEC_TRAMPOLINE_TABLE
-# if __gnu_linux__
+# if __gnu_linux__ && !defined(__ANDROID__)
 /* This macro indicates it may be forbidden to map anonymous memory
    with both write and execute permission.  Code compiled when this
    option is defined will attempt to map such pages once, but if it


### PR DESCRIPTION
C preprocessor of clang for Android generates **gnu_linux** define, but gcc for Android doesn't.  So we should add check it for Android
