### PR TITLE
Fix PowerPC Darwin FDE encodings to use pcrel correctly.  Modernise the picbase labels.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2013-11-18  Iain Sandoe  <iain@codesourcery.com>
+
+	* src/powerpc/darwin.S (EH): Correct use of pcrel FDE encoding.
+	* src/powerpc/darwin_closure.S (EH): Likewise. Modernise picbase
+	labels.
+
 2013-11-18  Anthony Green  <green@moxielogic.com>
 
 	* src/arm/ffi.c (ffi_call): Hoist declaration of temp to top of

--- a/src/powerpc/darwin.S
+++ b/src/powerpc/darwin.S
@@ -318,11 +318,6 @@ _ffi_call_AIX:
 
 #define EH_DATA_ALIGN_FACT MODE_CHOICE(0x7c,0x78)
 
-	.static_data
-	.align LOG2_GPR_BYTES
-LLFB0$non_lazy_ptr:
-	.g_long Lstartcode
-
 	.section __TEXT,__eh_frame,coalesced,no_toc+strip_static_syms+live_support
 EH_frame1:
 	.set	L$set$0,LECIE1-LSCIE1
@@ -335,7 +330,7 @@ LSCIE1:
 	.byte	EH_DATA_ALIGN_FACT ; sleb128 -4; CIE Data Alignment Factor
 	.byte	0x41	; CIE RA Column
 	.byte	0x1	; uleb128 0x1; Augmentation size
-	.byte	0x10	; FDE Encoding (indirect pcrel)
+	.byte	0x10	; FDE Encoding (pcrel)
 	.byte	0xc	; DW_CFA_def_cfa
 	.byte	0x1	; uleb128 0x1
 	.byte	0x0	; uleb128 0x0
@@ -349,7 +344,7 @@ LSFDE1:
 	.long	L$set$1	; FDE Length
 LASFDE1:
 	.long	LASFDE1-EH_frame1 ; FDE CIE offset
-	.g_long	LLFB0$non_lazy_ptr-.	; FDE initial location
+	.g_long	Lstartcode-.	; FDE initial location
 	.set	L$set$3,LFE1-Lstartcode
 	.g_long	L$set$3	; FDE address range
 	.byte   0x0     ; uleb128 0x0; Augmentation size

--- a/src/powerpc/darwin_closure.S
+++ b/src/powerpc/darwin_closure.S
@@ -467,11 +467,6 @@ Lendcode:
 #define EH_FRAME_OFFSETA MODE_CHOICE(176,0x90)
 #define EH_FRAME_OFFSETB MODE_CHOICE(1,3)
 
-	.static_data
-	.align LOG2_GPR_BYTES
-LLFB1$non_lazy_ptr:
-	.g_long Lstartcode
-
 	.section __TEXT,__eh_frame,coalesced,no_toc+strip_static_syms+live_support
 EH_frame1:
 	.set	L$set$0,LECIE1-LSCIE1
@@ -484,7 +479,7 @@ LSCIE1:
 	.byte	EH_DATA_ALIGN_FACT ; sleb128 -4; CIE Data Alignment Factor
 	.byte	0x41	; CIE RA Column
 	.byte	0x1	; uleb128 0x1; Augmentation size
-	.byte	0x10	; FDE Encoding (indirect pcrel)
+	.byte	0x10	; FDE Encoding (pcrel)
 	.byte	0xc	; DW_CFA_def_cfa
 	.byte	0x1	; uleb128 0x1
 	.byte	0x0	; uleb128 0x0
@@ -498,7 +493,7 @@ LSFDE1:
 
 LASFDE1:
 	.long	LASFDE1-EH_frame1	; FDE CIE offset
-	.g_long	LLFB1$non_lazy_ptr-.	; FDE initial location
+	.g_long	Lstartcode-.	; FDE initial location
 	.set	L$set$3,LFE1-Lstartcode
 	.g_long	L$set$3	; FDE address range
 	.byte   0x0     ; uleb128 0x0; Augmentation size
@@ -523,12 +518,12 @@ LEFDE1:
 L_ffi_closure_helper_DARWIN$stub:
 	.indirect_symbol _ffi_closure_helper_DARWIN
 	mflr r0
-	bcl 20,31,"L00000000001$spb"
-"L00000000001$spb":
+	bcl 20,31,"L1$spb"
+"L1$spb":
 	mflr r11
-	addis r11,r11,ha16(L_ffi_closure_helper_DARWIN$lazy_ptr-"L00000000001$spb")
+	addis r11,r11,ha16(L_ffi_closure_helper_DARWIN$lazy_ptr-"L1$spb")
 	mtlr r0
-	lwzu r12,lo16(L_ffi_closure_helper_DARWIN$lazy_ptr-"L00000000001$spb")(r11)
+	lwzu r12,lo16(L_ffi_closure_helper_DARWIN$lazy_ptr-"L1$spb")(r11)
 	mtctr r12
 	bctr
 	.lazy_symbol_pointer
@@ -542,12 +537,12 @@ L_ffi_closure_helper_DARWIN$lazy_ptr:
 L_darwin64_struct_ret_by_value_p$stub:
 	.indirect_symbol _darwin64_struct_ret_by_value_p
 	mflr r0
-	bcl 20,31,"L00000000002$spb"
-"L00000000002$spb":
+	bcl 20,31,"L2$spb"
+"L2$spb":
 	mflr r11
-	addis r11,r11,ha16(L_darwin64_struct_ret_by_value_p$lazy_ptr-"L00000000002$spb")
+	addis r11,r11,ha16(L_darwin64_struct_ret_by_value_p$lazy_ptr-"L2$spb")
 	mtlr r0
-	lwzu r12,lo16(L_darwin64_struct_ret_by_value_p$lazy_ptr-"L00000000002$spb")(r11)
+	lwzu r12,lo16(L_darwin64_struct_ret_by_value_p$lazy_ptr-"L2$spb")(r11)
 	mtctr r12
 	bctr
 	.lazy_symbol_pointer
@@ -560,12 +555,12 @@ L_darwin64_struct_ret_by_value_p$lazy_ptr:
 L_darwin64_pass_struct_floats$stub:
 	.indirect_symbol _darwin64_pass_struct_floats
 	mflr r0
-	bcl 20,31,"L00000000003$spb"
-"L00000000003$spb":
+	bcl 20,31,"L3$spb"
+"L3$spb":
 	mflr r11
-	addis r11,r11,ha16(L_darwin64_pass_struct_floats$lazy_ptr-"L00000000003$spb")
+	addis r11,r11,ha16(L_darwin64_pass_struct_floats$lazy_ptr-"L3$spb")
 	mtlr r0
-	lwzu r12,lo16(L_darwin64_pass_struct_floats$lazy_ptr-"L00000000003$spb")(r11)
+	lwzu r12,lo16(L_darwin64_pass_struct_floats$lazy_ptr-"L3$spb")(r11)
 	mtctr r12
 	bctr
 	.lazy_symbol_pointer


### PR DESCRIPTION
rechecked on powerpc-darwin9 with gcc-4.8.2 and apple gcc-4.2.
