### PR TITLE
Linux/ppc64: Remove assumption on contents of r11 in closure

### DIFF
--- a/src/powerpc/ffi_linux64.c
+++ b/src/powerpc/ffi_linux64.c
@@ -697,7 +697,8 @@ ffi_prep_closure_loc_linux64 (ffi_closure *closure,
 
   /* Copy function address and TOC from ffi_closure_LINUX64.  */
   memcpy (tramp, (char *) ffi_closure_LINUX64, 16);
-  tramp[2] = codeloc;
+  tramp[2] = tramp[1];
+  tramp[1] = codeloc;
 #endif
 
   closure->cif = cif;

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -100,6 +100,10 @@ ffi_closure_LINUX64:
 	# load up the pointer to the parm save area
 	mr	%r5, %r12
 # else
+	# copy r2 to r11 and load TOC into r2
+	mr	%r11, %r2
+	ld	%r2, 16(%r11)
+
 	mflr	%r0
 	# Save general regs into parm save area
 	# This is the parameter save area set up by our caller.


### PR DESCRIPTION
Fix for issue #67
