### PR TITLE
MIPS N32: Fix call floating point va function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-02-09  Heiher  <r@hev.cc>
+
+	* src/mips/n32.S: Fix call floating point va function.
+
 2013-11-21  Anthony Green  <green@moxielogic.com>
 
 	* configure, Makefile.in, include/Makefile.in, include/ffi.h.in,

--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -108,10 +108,8 @@ loadregs:
 	REG_L	t6, 3*FFI_SIZEOF_ARG($fp)  # load the flags word into t6.
 
 	and	t4, t6, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg1_floatp
 	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
-	b	arg1_next
-arg1_floatp:	
+	beqz	t4, arg1_next
 	bne	t4, FFI_TYPE_FLOAT, arg1_doublep
 	l.s	$f12, 0*FFI_SIZEOF_ARG(t9)
 	b	arg1_next
@@ -121,10 +119,8 @@ arg1_next:
 	
 	SRL	t4, t6, 1*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg2_floatp
 	REG_L	a1, 1*FFI_SIZEOF_ARG(t9)
-	b	arg2_next
-arg2_floatp:
+	beqz	t4, arg2_next
 	bne	t4, FFI_TYPE_FLOAT, arg2_doublep
 	l.s	$f13, 1*FFI_SIZEOF_ARG(t9)	
 	b	arg2_next
@@ -134,10 +130,8 @@ arg2_next:
 	
 	SRL	t4, t6, 2*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg3_floatp
 	REG_L	a2, 2*FFI_SIZEOF_ARG(t9)
-	b	arg3_next
-arg3_floatp:
+	beqz	t4, arg3_next
 	bne	t4, FFI_TYPE_FLOAT, arg3_doublep
 	l.s	$f14, 2*FFI_SIZEOF_ARG(t9)	
 	b	arg3_next
@@ -147,10 +141,8 @@ arg3_next:
 	
 	SRL	t4, t6, 3*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg4_floatp
 	REG_L	a3, 3*FFI_SIZEOF_ARG(t9)
-	b	arg4_next
-arg4_floatp:
+	beqz	t4, arg4_next
 	bne	t4, FFI_TYPE_FLOAT, arg4_doublep
 	l.s	$f15, 3*FFI_SIZEOF_ARG(t9)	
 	b	arg4_next
@@ -160,10 +152,8 @@ arg4_next:
 	
 	SRL	t4, t6, 4*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg5_floatp
 	REG_L	a4, 4*FFI_SIZEOF_ARG(t9)
-	b	arg5_next
-arg5_floatp:
+	beqz	t4, arg5_next
 	bne	t4, FFI_TYPE_FLOAT, arg5_doublep
 	l.s	$f16, 4*FFI_SIZEOF_ARG(t9)	
 	b	arg5_next
@@ -173,10 +163,8 @@ arg5_next:
 	
 	SRL	t4, t6, 5*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg6_floatp
 	REG_L	a5, 5*FFI_SIZEOF_ARG(t9)
-	b	arg6_next
-arg6_floatp:
+	beqz	t4, arg6_next
 	bne	t4, FFI_TYPE_FLOAT, arg6_doublep
 	l.s	$f17, 5*FFI_SIZEOF_ARG(t9)	
 	b	arg6_next
@@ -186,10 +174,8 @@ arg6_next:
 	
 	SRL	t4, t6, 6*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg7_floatp
 	REG_L	a6, 6*FFI_SIZEOF_ARG(t9)
-	b	arg7_next
-arg7_floatp:
+	beqz	t4, arg7_next
 	bne	t4, FFI_TYPE_FLOAT, arg7_doublep
 	l.s	$f18, 6*FFI_SIZEOF_ARG(t9)	
 	b	arg7_next
@@ -199,10 +185,8 @@ arg7_next:
 	
 	SRL	t4, t6, 7*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
-	bnez	t4, arg8_floatp
 	REG_L	a7, 7*FFI_SIZEOF_ARG(t9)
-	b	arg8_next
-arg8_floatp:
+	beqz	t4, arg8_next
 	bne	t4, FFI_TYPE_FLOAT, arg8_doublep
  	l.s	$f19, 7*FFI_SIZEOF_ARG(t9)	
 	b	arg8_next


### PR DESCRIPTION
I'm not sure floating-point arguments in GPR or FPR before calling
variable number arguments function. so, load all arguments to GPR and
FPR.
