### PR TITLE
Fix build error on x86 without distinct long double

### DIFF
--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -203,10 +203,12 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
     case FFI_TYPE_DOUBLE:
       classes[0] = X86_64_SSEDF_CLASS;
       return 1;
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
     case FFI_TYPE_LONGDOUBLE:
       classes[0] = X86_64_X87_CLASS;
       classes[1] = X86_64_X87UP_CLASS;
       return 2;
+#endif
     case FFI_TYPE_STRUCT:
       {
 	const int UNITS_PER_WORD = 8;


### PR DESCRIPTION
src/x86/ffi64.c: In function 'classify_argument':
src/x86/ffi64.c:205:5: error: duplicate case value
     case FFI_TYPE_LONGDOUBLE:
     ^
src/x86/ffi64.c:202:5: error: previously used here
     case FFI_TYPE_DOUBLE:
     ^
