### PR TITLE
Add FreeBSD amd64 support to ABI check

### DIFF
--- a/configure
+++ b/configure
@@ -7001,7 +7001,7 @@ mips64*-*linux*)
   rm -rf conftest*
   ;;
 
-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
+amd64-*-freebsd*|x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
 s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
   # Find out what ABI is being produced by ac_compile, and set linker
   # options accordingly.  Note that the listed cases only cover the


### PR DESCRIPTION
We've carried this patch [1] in all FreeBSD python ports that bundle libffi since ~2006. It's time it was upstreamed. I will submit a separate Python issue for their bundled version pending a future merge of libffi updates.

[1] https://svnweb.freebsd.org/ports/head/lang/python33/files/patch-Modules-_ctypes-libffi-configure?revision=340725&view=markup
