### PR TITLE
Allow building for mipsel with Android NDK r8.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-03-10  Mike Hommey <mh+mozilla@glandium.org>
+
+	* configure.ac: Allow building for mipsel with Android NDK r8.
+
 2014-03-01  Anthony Green  <green@moxielogic.com>
 
 	* Makefile.am (EXTRA_DIST): Replace old scripts with

--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ case "$host" in
   mips-sgi-irix5.* | mips-sgi-irix6.* | mips*-*-rtems*)
 	TARGET=MIPS; TARGETDIR=mips
 	;;
-  mips*-*-linux* | mips*-*-openbsd*)
+  mips*-*linux* | mips*-*-openbsd*)
 	# Support 128-bit long double for NewABI.
 	HAVE_LONG_DOUBLE='defined(__mips64)'
 	TARGET=MIPS; TARGETDIR=mips


### PR DESCRIPTION
From Mozilla bug 756740.
https://bugzilla.mozilla.org/show_bug.cgi?id=756740
