### PR TITLE
Upgrade license to MPL 2.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-03-10  Gervase Markham <gerv@gerv.net>
+
+	* msvcc.sh: Upgrade license to MPL 2.
+
 2014-03-01  Anthony Green  <green@moxielogic.com>
 
 	* Makefile.am (EXTRA_DIST): Replace old scripts with

--- a/msvcc.sh
+++ b/msvcc.sh
@@ -1,41 +1,8 @@
 #!/bin/sh
 
-# ***** BEGIN LICENSE BLOCK *****
-# Version: MPL 1.1/GPL 2.0/LGPL 2.1
-#
-# The contents of this file are subject to the Mozilla Public License Version
-# 1.1 (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
-# http://www.mozilla.org/MPL/
-#
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-# for the specific language governing rights and limitations under the
-# License.
-#
-# The Original Code is the MSVC wrappificator.
-#
-# The Initial Developer of the Original Code is
-# Timothy Wall <twalljava@dev.java.net>.
-# Portions created by the Initial Developer are Copyright (C) 2009
-# the Initial Developer. All Rights Reserved.
-#
-# Contributor(s):
-#   Daniel Witte <dwitte@mozilla.com>
-#
-# Alternatively, the contents of this file may be used under the terms of
-# either the GNU General Public License Version 2 or later (the "GPL"), or
-# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
-# in which case the provisions of the GPL or the LGPL are applicable instead
-# of those above. If you wish to allow use of your version of this file only
-# under the terms of either the GPL or the LGPL, and not to allow others to
-# use your version of this file under the terms of the MPL, indicate your
-# decision by deleting the provisions above and replace them with the notice
-# and other provisions required by the GPL or the LGPL. If you do not delete
-# the provisions above, a recipient may use your version of this file under
-# the terms of any one of the MPL, the GPL or the LGPL.
-#
-# ***** END LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #
 # GCC-compatible wrapper for cl.exe and ml.exe. Arguments are given in GCC


### PR DESCRIPTION
From Mozilla bug 759095. This was part of a mass change made to the Mozilla repository. I'm submitting it here in case you want it, but I'm also OK with the change being reverted if not.
https://bugzilla.mozilla.org/show_bug.cgi?id=759095
