### PR TITLE
stdcall support on Linux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,39 @@
 2014-03-16  Josh Triplett <josh@joshtriplett.org>
 
+	Add support for stdcall, thiscall, and fastcall on non-Windows x86-32.
+
+	Linux supports the stdcall calling convention, either via functions
+	explicitly declared with the stdcall attribute, or via code compiled
+	with -mrtd which effectively makes stdcall the default.
+
+	This introduces FFI_STDCALL, FFI_THISCALL, and FFI_FASTCALL on
+	non-Windows x86-32 platforms, as non-default calling conventions.
+
+	* Makefile.am: Compile in src/x86/win32.S on non-Windows x86-32.
+	* src/x86/ffitarget.h: Add FFI_STDCALL, FFI_THISCALL, and FFI_FASTCALL
+	on non-Windows x86-32.  Increase trampoline size to accomodate these
+	calling conventions, and unify some ifdeffery.
+	* src/x86/ffi.c: Add support for FFI_STDCALL, FFI_THISCALL, and
+	FFI_FASTCALL on non-Windows x86-32 platforms; update ifdeffery.
+	* src/x86/win32.S: Support compiling on non-Windows x86-32 platforms.
+	On those platforms, avoid redefining the SYSV symbols already provided
+	by src/x86/sysv.S.
+	* testsuite/libffi.call/closure_stdcall.c: Run on non-Windows.
+	#define __stdcall if needed.
+	* testsuite/libffi.call/closure_thiscall.c: Run on non-Windows.
+	#define __fastcall if needed.
+	* testsuite/libffi.call/fastthis1_win32.c: Run on non-Windows.
+	* testsuite/libffi.call/fastthis2_win32.c: Ditto.
+	* testsuite/libffi.call/fastthis3_win32.c: Ditto.
+	* testsuite/libffi.call/many2_win32.c: Ditto.
+	* testsuite/libffi.call/many_win32.c: Ditto.
+	* testsuite/libffi.call/strlen2_win32.c: Ditto.
+	* testsuite/libffi.call/strlen_win32.c: Ditto.
+	* testsuite/libffi.call/struct1_win32.c: Ditto.
+	* testsuite/libffi.call/struct2_win32.c: Ditto.
+
+2014-03-16  Josh Triplett <josh@joshtriplett.org>
+
 	* prep_cif.c: Remove unnecessary ifdef for X86_WIN32.
 	ffi_prep_cif_core had a special case for X86_WIN32, checking for
 	FFI_THISCALL in addition to the FFI_FIRST_ABI-to-FFI_LAST_ABI range

--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,7 @@ if BFIN
 nodist_libffi_la_SOURCES += src/bfin/ffi.c src/bfin/sysv.S
 endif
 if X86
-nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/sysv.S
+nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/sysv.S src/x86/win32.S
 endif
 if X86_FREEBSD
 nodist_libffi_la_SOURCES += src/x86/ffi.c src/x86/freebsd.S

--- a/src/x86/ffitarget.h
+++ b/src/x86/ffitarget.h
@@ -98,6 +98,9 @@ typedef enum ffi_abi {
   /* ---- Intel x86 and AMD x86-64 - */
   FFI_SYSV,
   FFI_UNIX64,   /* Unix variants all use the same ABI for x86-64  */
+  FFI_THISCALL,
+  FFI_FASTCALL,
+  FFI_STDCALL,
   FFI_LAST_ABI,
 #if defined(__i386__) || defined(__i386)
   FFI_DEFAULT_ABI = FFI_SYSV
@@ -119,21 +122,13 @@ typedef enum ffi_abi {
 #if defined (X86_64) || (defined (__x86_64__) && defined (X86_DARWIN))
 #define FFI_TRAMPOLINE_SIZE 24
 #define FFI_NATIVE_RAW_API 0
-#else
-#ifdef X86_WIN32
-#define FFI_TRAMPOLINE_SIZE 52
-#else
-#ifdef X86_WIN64
+#elif defined(X86_WIN64)
 #define FFI_TRAMPOLINE_SIZE 29
 #define FFI_NATIVE_RAW_API 0
 #define FFI_NO_RAW_API 1
 #else
-#define FFI_TRAMPOLINE_SIZE 10
-#endif
-#endif
-#ifndef X86_WIN64
+#define FFI_TRAMPOLINE_SIZE 52
 #define FFI_NATIVE_RAW_API 1	/* x86 has native raw api support */
-#endif
 #endif
 
 #endif

--- a/src/x86/win32.S
+++ b/src/x86/win32.S
@@ -473,15 +473,21 @@ END
 
 #else
 
+#if defined(X86_WIN32)
+#define USCORE_SYMBOL(x) _##x
+#else
+#define USCORE_SYMBOL(x) x
+#endif
 	.text
  
         # This assumes we are using gas.
         .balign 16
-	.globl	_ffi_call_win32
-#ifndef __OS2__
+FFI_HIDDEN(ffi_call_win32)
+	.globl	USCORE_SYMBOL(ffi_call_win32)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_call_win32;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_call_win32:
+USCORE_SYMBOL(ffi_call_win32):
 .LFB1:
         pushl %ebp
 .LCFI0:
@@ -644,11 +650,12 @@ _ffi_call_win32:
         ret
 .ffi_call_win32_end:
         .balign 16
-	.globl	_ffi_closure_THISCALL
-#ifndef __OS2__
+FFI_HIDDEN(ffi_closure_THISCALL)
+	.globl	USCORE_SYMBOL(ffi_closure_THISCALL)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_closure_THISCALL;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_closure_THISCALL:
+USCORE_SYMBOL(ffi_closure_THISCALL):
 	pushl	%ebp
 	movl	%esp, %ebp
 	subl	$40, %esp
@@ -660,11 +667,14 @@ _ffi_closure_THISCALL:
 
         # This assumes we are using gas.
         .balign 16
-	.globl	_ffi_closure_SYSV
-#ifndef __OS2__
+FFI_HIDDEN(ffi_closure_SYSV)
+#if defined(X86_WIN32)
+	.globl	USCORE_SYMBOL(ffi_closure_SYSV)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_closure_SYSV;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_closure_SYSV:
+USCORE_SYMBOL(ffi_closure_SYSV):
+#endif
 .LFB3:
 	pushl	%ebp
 .LCFI4:
@@ -678,7 +688,7 @@ _ffi_closure_SYSV:
 	movl	%edx, 4(%esp)	/* args = __builtin_dwarf_cfa () */
 	leal	-12(%ebp), %edx
 	movl	%edx, (%esp)	/* &resp */
-	call	_ffi_closure_SYSV_inner
+	call	USCORE_SYMBOL(ffi_closure_SYSV_inner)
 	movl	-12(%ebp), %ecx
 
 0:
@@ -789,11 +799,12 @@ _ffi_closure_SYSV:
 #define RAW_CLOSURE_USER_DATA_OFFSET (RAW_CLOSURE_FUN_OFFSET + 4)
 #define CIF_FLAGS_OFFSET 20
         .balign 16
-	.globl	_ffi_closure_raw_THISCALL
-#ifndef __OS2__
+FFI_HIDDEN(ffi_closure_raw_THISCALL)
+	.globl	USCORE_SYMBOL(ffi_closure_raw_THISCALL)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_closure_raw_THISCALL;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_closure_raw_THISCALL:
+USCORE_SYMBOL(ffi_closure_raw_THISCALL):
 	pushl	%ebp
 	movl	%esp, %ebp
 	pushl	%esi
@@ -805,11 +816,13 @@ _ffi_closure_raw_THISCALL:
 	jmp	.stubraw
         # This assumes we are using gas.
         .balign 16
-	.globl	_ffi_closure_raw_SYSV
-#ifndef __OS2__
+#if defined(X86_WIN32)
+	.globl	USCORE_SYMBOL(ffi_closure_raw_SYSV)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_closure_raw_SYSV;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_closure_raw_SYSV:
+USCORE_SYMBOL(ffi_closure_raw_SYSV):
+#endif /* defined(X86_WIN32) */
 .LFB4:
 	pushl	%ebp
 .LCFI6:
@@ -925,11 +938,12 @@ _ffi_closure_raw_SYSV:
 
         # This assumes we are using gas.
 	.balign	16
-	.globl	_ffi_closure_STDCALL
-#ifndef __OS2__
+FFI_HIDDEN(ffi_closure_STDCALL)
+	.globl	USCORE_SYMBOL(ffi_closure_STDCALL)
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.def	_ffi_closure_STDCALL;	.scl	2;	.type	32;	.endef
 #endif
-_ffi_closure_STDCALL:
+USCORE_SYMBOL(ffi_closure_STDCALL):
 .LFB5:
 	pushl	%ebp
 .LCFI9:
@@ -942,7 +956,7 @@ _ffi_closure_STDCALL:
 	movl	%edx, 4(%esp)	/* args */
 	leal	-12(%ebp), %edx
 	movl	%edx, (%esp)	/* &resp */
-	call	_ffi_closure_SYSV_inner
+	call	USCORE_SYMBOL(ffi_closure_SYSV_inner)
 	movl	-12(%ebp), %ecx
 0:
 	call	1f
@@ -1034,7 +1048,7 @@ _ffi_closure_STDCALL:
 .ffi_closure_STDCALL_end:
 .LFE5:
 
-#ifndef __OS2__
+#if defined(X86_WIN32) && !defined(__OS2__)
 	.section	.eh_frame,"w"
 #endif
 .Lframe1:
@@ -1093,7 +1107,6 @@ _ffi_closure_STDCALL:
 	/* End of DW_CFA_xxx CFI instructions.  */
 	.align 4
 .LEFDE1:
-
 
 .LSFDE3:
 	.long	.LEFDE3-.LASFDE3	/* FDE Length */

--- a/testsuite/libffi.call/closure_stdcall.c
+++ b/testsuite/libffi.call/closure_stdcall.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	<twalljava@dev.java.net> */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 #include "ffitest.h"
 
 static void
@@ -23,6 +23,9 @@ closure_test_stdcall(ffi_cif* cif __UNUSED__, void* resp, void** args,
 
 }
 
+#ifndef _MSC_VER
+#define __stdcall __attribute__((stdcall))
+#endif
 typedef int (__stdcall *closure_test_type0)(int, int, int, int);
 
 int main (void)

--- a/testsuite/libffi.call/closure_thiscall.c
+++ b/testsuite/libffi.call/closure_thiscall.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	<ktietz@redhat.com> */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 #include "ffitest.h"
 
 static void
@@ -23,6 +23,9 @@ closure_test_thiscall(ffi_cif* cif __UNUSED__, void* resp, void** args,
 
 }
 
+#ifndef _MSC_VER
+#define __thiscall __attribute__((thiscall))
+#endif
 typedef int (__thiscall *closure_test_type0)(int, int, int, int);
 
 int main (void)

--- a/testsuite/libffi.call/fastthis1_win32.c
+++ b/testsuite/libffi.call/fastthis1_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.call/fastthis2_win32.c
+++ b/testsuite/libffi.call/fastthis2_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.call/fastthis3_win32.c
+++ b/testsuite/libffi.call/fastthis3_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.call/many2_win32.c
+++ b/testsuite/libffi.call/many2_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 #include <float.h>

--- a/testsuite/libffi.call/many_win32.c
+++ b/testsuite/libffi.call/many_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 #include <float.h>

--- a/testsuite/libffi.call/strlen2_win32.c
+++ b/testsuite/libffi.call/strlen2_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.call/strlen_win32.c
+++ b/testsuite/libffi.call/strlen_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.call/struct1_win32.c
+++ b/testsuite/libffi.call/struct1_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 #include "ffitest.h"
 
 typedef struct

--- a/testsuite/libffi.call/struct2_win32.c
+++ b/testsuite/libffi.call/struct2_win32.c
@@ -4,7 +4,7 @@
    PR:		none.
    Originator:	From the original ffitest.c  */
 
-/* { dg-do run { target i?86-*-cygwin* i?86-*-mingw* } } */
+/* { dg-do run { target i?86-*-* } } */
 #include "ffitest.h"
 
 typedef struct


### PR DESCRIPTION
libffi only seems to support stdcall on Windows.  However, Linux supports the stdcall calling convention, either via functions explicitly declared with the stdcall attribute, or via code compiled with -mrtd which effectively makes stdcall the default.

Currently working on a patch for this.
