### PR TITLE
.gitignore: Ignore more generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ compile
 config.*
 configure
 depcomp
+doc/libffi.info
 *~
+fficonfig.h.in
 fficonfig.h
 include/ffi.h
 include/ffitarget.h


### PR DESCRIPTION
The build process generates doc/libffi.info and fficonfig.h.in, so add
them to .gitignore.
