### PR TITLE
Fix handling of variadic calls on Darwin/AArch64

### DIFF
--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -47,8 +47,12 @@ typedef enum ffi_abi
 
 /* ---- Internal ---- */
 
-
+#if defined (__APPLE__)
+#define FFI_TARGET_SPECIFIC_VARIADIC
+#define FFI_EXTRA_CIF_FIELDS unsigned aarch64_flags; unsigned aarch64_nfixedargs
+#else
 #define FFI_EXTRA_CIF_FIELDS unsigned aarch64_flags
+#endif
 
 #define AARCH64_FFI_WITH_V_BIT 0
 


### PR DESCRIPTION
As per [Apple's documentation](https://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html) there are some additional ABI differences for variadic functions.
