### PR TITLE
Create temporary file with O_TMPFILE and O_CLOEXEC when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ EOF
 AM_MAINTAINER_MODE
 
 AC_CHECK_HEADERS(sys/mman.h)
-AC_CHECK_FUNCS(mmap)
+AC_CHECK_FUNCS([mmap mkostemp])
 AC_FUNC_MMAP_BLACKLIST
 
 dnl The -no-testsuite modules omit the test subdir.

--- a/src/closures.c
+++ b/src/closures.c
@@ -267,7 +267,13 @@ static size_t execsize = 0;
 static int
 open_temp_exec_file_name (char *name, int flags)
 {
-  int fd = mkostemp (name, flags);
+  int fd;
+
+#ifdef HAVE_MKOSTEMP
+  fd = mkostemp (name, flags);
+#else
+  fd = mkstemp (name);
+#endif
 
   if (fd != -1)
     unlink (name);


### PR DESCRIPTION
The open_temp_exec_file_dir function can create a temporary file without
file system accessible link. If the O_TMPFILE flag is not defined (old
Linux kernel or libc) the behavior is unchanged.

The open_temp_exec_file_name function now need a new argument "flags"
(like O_CLOEXEC) used for temporary file creation.

The O_TMPFILE flag allow temporary file creation without race condition.
This feature/fix prevent another process to access the (future)
executable file from the file system.

The O_CLOEXEC flag automatically close the temporary file for any
execve. This avoid transmitting (executable) file descriptor to a child
process.
