### PR TITLE
Don't make --enable-debug imply using the debug CRT in libffi

### DIFF
--- a/msvcc.sh
+++ b/msvcc.sh
@@ -105,9 +105,13 @@ do
       shift 1
     ;;
     -DFFI_DEBUG)
-      # Link against debug CRT and enable runtime error checks.
+      # Enable runtime error checks.
       args="$args -RTC1"
       defines="$defines $1"
+      shift 1
+    ;;
+    -DUSE_DEBUG_RTL)
+      # Link against debug CRT.
       md=-MDd
       shift 1
     ;;


### PR DESCRIPTION
From Mozilla bug # 1014976 (https://bugzilla.mozilla.org/show_bug.cgi?id=1014976):

The current msvcc.sh setup requires linking against the debug MSVC CRT when -DFFI_DEBUG is set, which isn't strictly necessary (and makes life difficult when trying to use a different allocator). This decouples -DFFI_DEBUG from that via adding a new -DUSE_DEBUG_RTL flag so that the non-debug CRT can be used while still maintaining runtime error checks.
