### PR TITLE
Fix issue with builddir when calling configure with absolute path

### DIFF
--- a/m4/ax_enable_builddir.m4
+++ b/m4/ax_enable_builddir.m4
@@ -121,7 +121,8 @@ if test ".$srcdir" = ".." ; then
       test -f $srcdir/$cache_file  && mv $srcdir/$cache_file  .
       AC_MSG_RESULT(....exec $SHELL $srcdir/[$]0 "--srcdir=$srcdir" "--enable-builddir=$SUB" ${1+"[$]@"})
       case "[$]0" in # restart
-       [/\\]*) eval $SHELL "'[$]0'" "'--srcdir=$srcdir'" "'--enable-builddir=$SUB'" $ac_configure_args ;;
+       [[\\/]]* | ?:[[\\/]]*) # Asbolute name
+         eval $SHELL "'[$]0'" "'--srcdir=$srcdir'" "'--enable-builddir=$SUB'" $ac_configure_args ;;
        *) eval $SHELL "'$srcdir/[$]0'" "'--srcdir=$srcdir'" "'--enable-builddir=$SUB'" $ac_configure_args ;;
       esac ; exit $?
     fi


### PR DESCRIPTION
Calling configure with an absolute path fails on my machine:

```
$ /home/j/repos/libffi/configure 
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking target system type... x86_64-unknown-linux-gnu
continue configure in default builddir "./x86_64-unknown-linux-gnu"
....exec /bin/bash ..//home/j/repos/libffi/configure "--srcdir=.." "--enable-builddir=x86_64-unknown-linux-gnu" "linux
gnu"
/bin/bash: ..//home/j/repos/libffi/configure: No such file or directory
```

This is due to missing escaping of square brackets in m4/ax_enable_builddir.m4, which defeats the absolute path detection. The proposed patch adds escaping of square brackets, as well as detection of absolute Windows paths (not sure if that is useful here but it shouldn't hurt).
