### PR TITLE
Fix alignment of FFI_TYPE_FLOAT for Apple's ARM64 ABI

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -146,6 +146,9 @@ get_basic_type_alignment (unsigned short type)
   switch (type)
     {
     case FFI_TYPE_FLOAT:
+#if defined (__APPLE__)
+      return sizeof (UINT32);
+#endif
     case FFI_TYPE_DOUBLE:
       return sizeof (UINT64);
 #if FFI_TYPE_DOUBLE != FFI_TYPE_LONGDOUBLE


### PR DESCRIPTION
This was pointed out by the `many.c` test while I was hunting for a different bug.
