### PR TITLE
Update i386 & armv7 minimum iOS version to 7.0

### DIFF
--- a/generate-darwin-source-and-headers.py
+++ b/generate-darwin-source-and-headers.py
@@ -14,7 +14,7 @@ class simulator_platform(Platform):
     sdk = 'iphonesimulator'
     arch = 'i386'
     triple = 'i386-apple-darwin11'
-    version_min = '-miphoneos-version-min=5.1.1'
+    version_min = '-miphoneos-version-min=7.0'
 
     prefix = "#ifdef __i386__\n\n"
     suffix = "\n\n#endif"
@@ -40,7 +40,7 @@ class device_platform(Platform):
     sdk = 'iphoneos'
     arch = 'armv7'
     triple = 'arm-apple-darwin11'
-    version_min = '-miphoneos-version-min=5.1.1'
+    version_min = '-miphoneos-version-min=7.0'
 
     prefix = "#ifdef __arm__\n\n"
     suffix = "\n\n#endif"


### PR DESCRIPTION
iOS 5 (and any below 7.1) is deprecated. Apple doesn't distribute the supporting libraries for this platform anymore as of Xcode 6, so it causes a linker error.
