### PR TITLE
dlmalloc: change defined(i386) to defined(__i386__)

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -2291,7 +2291,7 @@ static size_t traverse_and_check(mstate m);
 #define treebin_at(M,i)     (&((M)->treebins[i]))
 
 /* assign tree index for size S to variable I */
-#if defined(__GNUC__) && defined(i386)
+#if defined(__GNUC__) && defined(__i386__)
 #define compute_tree_index(S, I)\
 {\
   size_t X = S >> TREEBIN_SHIFT;\
@@ -2356,7 +2356,7 @@ static size_t traverse_and_check(mstate m);
 
 /* index corresponding to given bit */
 
-#if defined(__GNUC__) && defined(i386)
+#if defined(__GNUC__) && defined(__i386__)
 #define compute_bit2idx(X, I)\
 {\
   unsigned int J;\


### PR DESCRIPTION
When compiling with --std==c99, GCC and clang don't define i386 but **i386**
