### PR TITLE
sparc: Define FFI_TARGET_SPECIFIC_VARIADIC for v9

### DIFF
--- a/src/sparc/ffitarget.h
+++ b/src/sparc/ffitarget.h
@@ -57,8 +57,13 @@ typedef enum ffi_abi {
 } ffi_abi;
 #endif
 
-#define FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION
-#define FFI_TARGET_HAS_COMPLEX_TYPE
+#define FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION 1
+#define FFI_TARGET_HAS_COMPLEX_TYPE 1
+
+#ifdef SPARC64
+# define FFI_TARGET_SPECIFIC_VARIADIC 1
+# define FFI_EXTRA_CIF_FIELDS  unsigned int nfixedargs
+#endif
 
 /* ---- Definitions for closures ----------------------------------------- */
 


### PR DESCRIPTION
This is a port of

  http://gcc.gnu.org/viewcvs?rev=207763&root=gcc&view=rev

aka GCC PR libffi/60073, to the rewritten Sparc codebase.
Supposedly, we should have seen failures with the existing
libffi.call/cls_double_va.c testcase, but I hadn't.
Perhaps a gcc newer than 4.6.3 is required to see that...
