### PR TITLE
aarch64: Optimize iOS closure trampoline

### DIFF
--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -43,7 +43,7 @@ typedef enum ffi_abi
 
 #define FFI_CLOSURES 1
 #if defined (__APPLE__)
-#define FFI_TRAMPOLINE_SIZE 20
+#define FFI_TRAMPOLINE_SIZE 12
 #define FFI_TRAMPOLINE_CLOSURE_OFFSET 16
 #else
 #define FFI_TRAMPOLINE_SIZE 24

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -347,11 +347,9 @@ CNAME(ffi_closure_SYSV):
     .align 12
 CNAME(ffi_closure_trampoline_table_page):
     .rept 16384 / FFI_TRAMPOLINE_SIZE
-    adr	x17, -16384
-    adr	x16, -16380
-    ldr x16, [x16]
-    ldr x17, [x17]
-    br	x16
+    adr x16, -16384
+    ldp x17, x16, [x16]
+    br x16
     .endr
     
     .globl CNAME(ffi_closure_trampoline_table_page)


### PR DESCRIPTION
Shave off a couple of instructions as per @rth7680's suggestion in https://github.com/atgreen/libffi/pull/170