### PR TITLE
Aligned ARM64 iOS trampoline table on 16k pages

### DIFF
--- a/generate-darwin-source-and-headers.py
+++ b/generate-darwin-source-and-headers.py
@@ -45,7 +45,7 @@ class device_platform(Platform):
     prefix = "#ifdef __arm__\n\n"
     suffix = "\n\n#endif"
     src_dir = 'arm'
-    src_files = ['sysv.S', 'trampoline.S', 'ffi.c']
+    src_files = ['sysv.S', 'ffi.c']
 
 
 class device64_platform(Platform):
@@ -162,18 +162,11 @@ def build_target(platform, platform_headers):
             platform_headers[filename].add((platform.prefix, platform.arch, platform.suffix))
 
 
-def make_tramp():
-    with open('src/arm/trampoline.S', 'w') as tramp_out:
-        p = subprocess.Popen(['bash', 'src/arm/gentramp.sh'], stdout=tramp_out)
-        p.wait()
-
-
 def generate_source_and_headers(generate_osx=True, generate_ios=True):
     copy_files('src', 'darwin_common/src', pattern='*.c')
     copy_files('include', 'darwin_common/include', pattern='*.h')
 
     if generate_ios:
-        make_tramp()
         copy_src_platform_files(simulator_platform)
         copy_src_platform_files(simulator64_platform)
         copy_src_platform_files(device_platform)

--- a/libffi.xcodeproj/project.pbxproj
+++ b/libffi.xcodeproj/project.pbxproj
@@ -23,9 +23,6 @@
 		DBFA7178187F1D9B00A76262 /* sysv_arm64.S in Sources */ = {isa = PBXBuildFile; fileRef = DBFA716D187F1D9B00A76262 /* sysv_arm64.S */; };
 		DBFA7179187F1D9B00A76262 /* ffi_armv7.c in Sources */ = {isa = PBXBuildFile; fileRef = DBFA716F187F1D9B00A76262 /* ffi_armv7.c */; };
 		DBFA717A187F1D9B00A76262 /* sysv_armv7.S in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7170187F1D9B00A76262 /* sysv_armv7.S */; };
-		DBFA717B187F1D9B00A76262 /* trampoline_armv7.S in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7171187F1D9B00A76262 /* trampoline_armv7.S */; };
-		DBFA717C187F1D9B00A76262 /* darwin64_x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7173187F1D9B00A76262 /* darwin64_x86_64.S */; };
-		DBFA717D187F1D9B00A76262 /* darwin_i386.S in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7174187F1D9B00A76262 /* darwin_i386.S */; };
 		DBFA717E187F1D9B00A76262 /* ffi64_x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7175187F1D9B00A76262 /* ffi64_x86_64.c */; };
 		DBFA717F187F1D9B00A76262 /* ffi_i386.c in Sources */ = {isa = PBXBuildFile; fileRef = DBFA7176187F1D9B00A76262 /* ffi_i386.c */; };
 		DBFA718E187F1DA100A76262 /* ffi_i386.h in Headers */ = {isa = PBXBuildFile; fileRef = DBFA7182187F1DA100A76262 /* ffi_i386.h */; };
@@ -80,9 +77,6 @@
 		DBFA716D187F1D9B00A76262 /* sysv_arm64.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = sysv_arm64.S; sourceTree = "<group>"; };
 		DBFA716F187F1D9B00A76262 /* ffi_armv7.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ffi_armv7.c; sourceTree = "<group>"; };
 		DBFA7170187F1D9B00A76262 /* sysv_armv7.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = sysv_armv7.S; sourceTree = "<group>"; };
-		DBFA7171187F1D9B00A76262 /* trampoline_armv7.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = trampoline_armv7.S; sourceTree = "<group>"; };
-		DBFA7173187F1D9B00A76262 /* darwin64_x86_64.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = darwin64_x86_64.S; sourceTree = "<group>"; };
-		DBFA7174187F1D9B00A76262 /* darwin_i386.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = darwin_i386.S; sourceTree = "<group>"; };
 		DBFA7175187F1D9B00A76262 /* ffi64_x86_64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ffi64_x86_64.c; sourceTree = "<group>"; };
 		DBFA7176187F1D9B00A76262 /* ffi_i386.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ffi_i386.c; sourceTree = "<group>"; };
 		DBFA7182187F1DA100A76262 /* ffi_i386.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffi_i386.h; sourceTree = "<group>"; };
@@ -201,7 +195,6 @@
 			children = (
 				DBFA716F187F1D9B00A76262 /* ffi_armv7.c */,
 				DBFA7170187F1D9B00A76262 /* sysv_armv7.S */,
-				DBFA7171187F1D9B00A76262 /* trampoline_armv7.S */,
 			);
 			path = arm;
 			sourceTree = "<group>";
@@ -209,8 +202,6 @@
 		DBFA7172187F1D9B00A76262 /* x86 */ = {
 			isa = PBXGroup;
 			children = (
-				DBFA7173187F1D9B00A76262 /* darwin64_x86_64.S */,
-				DBFA7174187F1D9B00A76262 /* darwin_i386.S */,
 				DBFA7175187F1D9B00A76262 /* ffi64_x86_64.c */,
 				DBFA7176187F1D9B00A76262 /* ffi_i386.c */,
 			);
@@ -377,15 +368,12 @@
 			files = (
 				DBFA717E187F1D9B00A76262 /* ffi64_x86_64.c in Sources */,
 				DBFA7179187F1D9B00A76262 /* ffi_armv7.c in Sources */,
-				DBFA717B187F1D9B00A76262 /* trampoline_armv7.S in Sources */,
 				DBFA714E187F1D8600A76262 /* closures.c in Sources */,
 				DBFA717A187F1D9B00A76262 /* sysv_armv7.S in Sources */,
-				DBFA717D187F1D9B00A76262 /* darwin_i386.S in Sources */,
 				DBFA7156187F1D8600A76262 /* prep_cif.c in Sources */,
 				DBFA717F187F1D9B00A76262 /* ffi_i386.c in Sources */,
 				DBFA7158187F1D8600A76262 /* raw_api.c in Sources */,
 				DBFA7178187F1D9B00A76262 /* sysv_arm64.S in Sources */,
-				DBFA717C187F1D9B00A76262 /* darwin64_x86_64.S in Sources */,
 				DBFA715A187F1D8600A76262 /* types.c in Sources */,
 				DBFA7177187F1D9B00A76262 /* ffi_arm64.c in Sources */,
 			);

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -356,7 +356,7 @@ CNAME(ffi_closure_SYSV):
 #endif
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
-    .align 12
+    .align 14
 CNAME(ffi_closure_trampoline_table_page):
     .rept 16384 / FFI_TRAMPOLINE_SIZE
     adr	x17, -16384

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -356,22 +356,25 @@ CNAME(ffi_closure_SYSV):
 #endif
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
-    .align 14
+#include <mach/arm/vm_param.h>
+
+	/* Must align on maximum architecture supported page size to always be able to remap. */
+	.align PAGE_MAX_SHIFT
 CNAME(ffi_closure_trampoline_table_page):
-    .rept 16384 / FFI_TRAMPOLINE_SIZE
-    adr	x17, -16384
-    adr	x16, -16380
-    ldr x16, [x16]
-    ldr x17, [x17]
-    br	x16
-    .endr
+	.rept PAGE_MAX_SIZE / FFI_TRAMPOLINE_SIZE
+	adr	x17, -PAGE_MAX_SIZE
+	adr	x16, 4-PAGE_MAX_SIZE
+	ldr x16, [x16]
+	ldr x17, [x17]
+	br	x16
+	.endr
     
-    .globl CNAME(ffi_closure_trampoline_table_page)
-    #ifdef __ELF__
-    	.type	CNAME(ffi_closure_trampoline_table_page), #function
-    	.hidden	CNAME(ffi_closure_trampoline_table_page)
-    	.size	CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
-    #endif
+	.globl CNAME(ffi_closure_trampoline_table_page)
+	#ifdef __ELF__
+		.type	CNAME(ffi_closure_trampoline_table_page), #function
+		.hidden	CNAME(ffi_closure_trampoline_table_page)
+		.size	CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
+	#endif
 #endif
 
 #ifdef FFI_GO_CLOSURES


### PR DESCRIPTION
Initial attempt to quick fix the callback issues observed on AArch64 on iOS. More fixes to PAGE_SIZE might be needed. (Ideally, where possible, getpagesize() should be used at runtime instead.)

Please note that I haven't actually run this code yet, since I don't have such a setup (yet). I have only built it in Xcode (with https://github.com/atgreen/libffi/commit/e3d2812ce43940aacae5bab2d0e965278cb1e7ea and trivial project cleanups), and verified the alignment in the binary.

Hopefully someone else will be able to verify that it actually works before I can.
