### PR TITLE
s390x: ffi_closure_helper_SYSV non standard sized integers yield wrong results

### DIFF
--- a/src/s390/ffi.c
+++ b/src/s390/ffi.c
@@ -508,7 +508,7 @@ ffi_closure_helper_SYSV (ffi_cif *cif,
 			 unsigned long long *p_fpr,
 			 unsigned long *p_ov)
 {
-  unsigned long long ret_buffer;
+  unsigned long long ret_buffer = 0;
 
   void *rvalue = &ret_buffer;
   void **avalue;

--- a/src/s390/ffi.c
+++ b/src/s390/ffi.c
@@ -32,6 +32,7 @@
 #include <ffi_common.h>
 #include <stdint.h>
 #include "internal.h"
+#include <inttypes.h>
 
 /*====================== End of Includes =============================*/
 

--- a/src/s390/ffi.c
+++ b/src/s390/ffi.c
@@ -675,17 +675,27 @@ ffi_closure_helper_SYSV (ffi_cif *cif,
 	break;
 
       case FFI_TYPE_POINTER:
-      case FFI_TYPE_UINT32:
-      case FFI_TYPE_UINT16:
-      case FFI_TYPE_UINT8:
 	p_gpr[0] = *(unsigned long *) rvalue;
+      case FFI_TYPE_UINT32:
+	p_gpr[0] = (uint32_t)(*(signed long *) rvalue);
+	break;
+      case FFI_TYPE_UINT16:
+	p_gpr[0] = (uint16_t)(*(signed long *) rvalue);
+	break;
+      case FFI_TYPE_UINT8:
+	p_gpr[0] = (uint8_t)(*(unsigned long *) rvalue);
 	break;
 
       case FFI_TYPE_INT:
-      case FFI_TYPE_SINT32:
-      case FFI_TYPE_SINT16:
-      case FFI_TYPE_SINT8:
 	p_gpr[0] = *(signed long *) rvalue;
+      case FFI_TYPE_SINT32:
+	p_gpr[0] = (int32_t)(*(signed long *) rvalue);
+	break;
+      case FFI_TYPE_SINT16:
+	p_gpr[0] = (int16_t)(*(signed long *) rvalue);
+	break;
+      case FFI_TYPE_SINT8:
+	p_gpr[0] = (int8_t)(*(signed long *) rvalue);
 	break;
 
       default:


### PR DESCRIPTION
Hi,

I discovered a problem while running the pypy test suite on CPython. This led me to the ffi implementation which is (I think) not correct for the method ffi_closure_helper_SYSV. For non standard sized integers (e.g. int16_t) the variable (ret_buffer) on the stack is not initialized (leading to garbage in the return value).
Additionally the sign is not propagated.

Cheers,
Richard