### PR TITLE
mips: wrap hard float specific code into ifdef blocks

### DIFF
--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -114,6 +114,7 @@ loadregs:
 
 	and	t4, t6, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg1_next
 	bne	t4, FFI_TYPE_FLOAT, arg1_doublep
 	l.s	$f12, 0*FFI_SIZEOF_ARG(t9)
@@ -121,10 +122,11 @@ loadregs:
 arg1_doublep:	
 	l.d	$f12, 0*FFI_SIZEOF_ARG(t9)
 arg1_next:	
-	
+#endif
 	SRL	t4, t6, 1*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a1, 1*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg2_next
 	bne	t4, FFI_TYPE_FLOAT, arg2_doublep
 	l.s	$f13, 1*FFI_SIZEOF_ARG(t9)	
@@ -132,10 +134,11 @@ arg1_next:
 arg2_doublep:	
 	l.d	$f13, 1*FFI_SIZEOF_ARG(t9)	
 arg2_next:	
-	
+#endif
 	SRL	t4, t6, 2*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a2, 2*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg3_next
 	bne	t4, FFI_TYPE_FLOAT, arg3_doublep
 	l.s	$f14, 2*FFI_SIZEOF_ARG(t9)	
@@ -143,10 +146,11 @@ arg2_next:
 arg3_doublep:	
 	l.d	$f14, 2*FFI_SIZEOF_ARG(t9)	
 arg3_next:	
-	
+#endif
 	SRL	t4, t6, 3*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a3, 3*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg4_next
 	bne	t4, FFI_TYPE_FLOAT, arg4_doublep
 	l.s	$f15, 3*FFI_SIZEOF_ARG(t9)	
@@ -154,10 +158,11 @@ arg3_next:
 arg4_doublep:	
 	l.d	$f15, 3*FFI_SIZEOF_ARG(t9)	
 arg4_next:	
-	
+#endif
 	SRL	t4, t6, 4*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a4, 4*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg5_next
 	bne	t4, FFI_TYPE_FLOAT, arg5_doublep
 	l.s	$f16, 4*FFI_SIZEOF_ARG(t9)	
@@ -165,10 +170,11 @@ arg4_next:
 arg5_doublep:	
 	l.d	$f16, 4*FFI_SIZEOF_ARG(t9)	
 arg5_next:	
-	
+#endif
 	SRL	t4, t6, 5*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a5, 5*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg6_next
 	bne	t4, FFI_TYPE_FLOAT, arg6_doublep
 	l.s	$f17, 5*FFI_SIZEOF_ARG(t9)	
@@ -176,10 +182,11 @@ arg5_next:
 arg6_doublep:	
 	l.d	$f17, 5*FFI_SIZEOF_ARG(t9)	
 arg6_next:	
-	
+#endif
 	SRL	t4, t6, 6*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a6, 6*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg7_next
 	bne	t4, FFI_TYPE_FLOAT, arg7_doublep
 	l.s	$f18, 6*FFI_SIZEOF_ARG(t9)	
@@ -187,10 +194,11 @@ arg6_next:
 arg7_doublep:	
 	l.d	$f18, 6*FFI_SIZEOF_ARG(t9)	
 arg7_next:	
-	
+#endif
 	SRL	t4, t6, 7*FFI_FLAG_BITS
 	and	t4, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a7, 7*FFI_SIZEOF_ARG(t9)
+#ifndef __mips_soft_float
 	beqz	t4, arg8_next
 	bne	t4, FFI_TYPE_FLOAT, arg8_doublep
  	l.s	$f19, 7*FFI_SIZEOF_ARG(t9)	
@@ -198,6 +206,7 @@ arg7_next:
 arg8_doublep:	
  	l.d	$f19, 7*FFI_SIZEOF_ARG(t9)	
 arg8_next:	
+#endif
 
 callit:		
 	# Load the function pointer
@@ -222,6 +231,7 @@ retint:
 	b	epilogue
 
 retfloat:
+#ifndef __mips_soft_float
 	bne     t6, FFI_TYPE_FLOAT, retdouble
 	jal	t9
 	REG_L	t4, 4*FFI_SIZEOF_ARG($fp)
@@ -282,6 +292,7 @@ retstruct_f_d:
 	b	epilogue
 
 retstruct_d_soft:
+#endif
 	bne	t6, FFI_TYPE_STRUCT_D_SOFT, retstruct_f_soft
 	jal	t9
 	REG_L	t4, 4*FFI_SIZEOF_ARG($fp)
@@ -484,6 +495,7 @@ $do_closure:
 	REG_S	a7, A7_OFF2($sp)
 
 	# Store all possible float/double registers.
+#ifndef __mips_soft_float
 	s.d	$f12, F12_OFF2($sp)
 	s.d	$f13, F13_OFF2($sp)
 	s.d	$f14, F14_OFF2($sp)
@@ -492,6 +504,7 @@ $do_closure:
 	s.d	$f17, F17_OFF2($sp)
 	s.d	$f18, F18_OFF2($sp)
 	s.d	$f19, F19_OFF2($sp)
+#endif
 
 	jalr	t9
 
@@ -506,6 +519,7 @@ cls_retint:
 	b	cls_epilogue
 
 cls_retfloat:
+#ifndef __mips_soft_float
 	bne     v0, FFI_TYPE_FLOAT, cls_retdouble
 	l.s	$f0, V0_OFF2($sp)
 	b	cls_epilogue
@@ -550,6 +564,7 @@ cls_retstruct_f_d:
 	b	cls_epilogue
 	
 cls_retstruct_small2:	
+#endif
 	REG_L	v0, V0_OFF2($sp)
 	REG_L	v1, V1_OFF2($sp)
 	

--- a/src/mips/o32.S
+++ b/src/mips/o32.S
@@ -90,6 +90,7 @@ sixteen:
 	b	call_it
 
 pass_d:
+#ifndef __mips_soft_float
 	bne	t0, FFI_ARGS_D, pass_f
 	l.d	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
 	REG_L	a2,   2*FFI_SIZEOF_ARG($sp)	# passing a double
@@ -130,6 +131,7 @@ pass_f_d:
  #	bne	t0, FFI_ARGS_F_D, call_it
 	l.s	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
 	l.d	$f14, 2*FFI_SIZEOF_ARG($sp)	# passing double and float
+#endif
 
 call_it:	
 	# Load the static chain pointer
@@ -158,6 +160,7 @@ retlonglong:
 	b	epilogue
 
 retfloat:
+#ifndef __mips_soft_float
 	bne     t2, FFI_TYPE_FLOAT, retdouble
 	jalr	t9
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
@@ -170,6 +173,7 @@ retdouble:
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
 	s.d	$f0, 0(t0)
 	b	epilogue
+#endif
 	
 noretval:	
 	jalr	t9
@@ -267,12 +271,14 @@ $LCFI12:
 	REG_L	$16, 0($16)	# abi is first member.
 
 	li	$13, 1		# FFI_O32
+#ifndef __mips_soft_float
 	bne	$16, $13, 1f	# Skip fp save if FFI_O32_SOFT_FLOAT
 	
 	# Store all possible float/double registers.
 	s.d	$f12, FA_0_0_OFF2($fp)
 	s.d	$f14, FA_1_0_OFF2($fp)
 1:
+#endif
 	# prepare arguments for ffi_closure_mips_inner_O32
 	REG_L	a0, 4($15)	 # cif 
 	REG_L	a1, 8($15)	 # fun
@@ -322,12 +328,14 @@ $LCFI22:
 	REG_L	$16, 0($16)	# abi is first member.
 
 	li	$13, 1		# FFI_O32
+#ifndef __mips_soft_float
 	bne	$16, $13, 1f	# Skip fp save if FFI_O32_SOFT_FLOAT
 	
 	# Store all possible float/double registers.
 	s.d	$f12, FA_0_0_OFF2($fp)
 	s.d	$f14, FA_1_0_OFF2($fp)
 1:	
+#endif
 	# prepare arguments for ffi_closure_mips_inner_O32
 	REG_L	a0, 20($12)	 # cif pointer follows tramp.
 	REG_L	a1, 24($12)	 # fun
@@ -351,6 +359,7 @@ $do_closure:
 	beq	$8, $9, closure_done
 
 	li	$13, 1		# FFI_O32
+#ifndef __mips_soft_float
 	bne	$16, $13, 1f	# Skip fp restore if FFI_O32_SOFT_FLOAT
 
 	li	$9, FFI_TYPE_FLOAT
@@ -361,6 +370,7 @@ $do_closure:
 	l.d	$f0, V0_OFF2($fp)
 	beq	$8, $9, closure_done
 1:	
+#endif
 	REG_L	$3, V1_OFF2($fp)
 	REG_L	$2, V0_OFF2($fp)
 


### PR DESCRIPTION
The hard float parts are already protected and they never get hit,
however it's necessary to wrap them into ifdef blocks so the compiler
will not complain when building for soft float.

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>