### PR TITLE
Define _GNU_SOURCE on Linux for mremap()

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -438,6 +438,11 @@ DEFAULT_MMAP_THRESHOLD       default: 256K
 
 */
 
+#if defined __linux__ && !defined _GNU_SOURCE
+/* mremap() on Linux requires this via sys/mman.h */
+#define _GNU_SOURCE 1
+#endif
+
 #ifndef WIN32
 #ifdef _WIN32
 #define WIN32 1


### PR DESCRIPTION
This was committed to CPython's libffi copy in
https://bugs.python.org/issue10309

mremap() documentation says _GNU_SOURCE needs to
be defined in order to use mremap(): see the
synopsis section at http://linux.die.net/man/2/mremap

Original commit: https://hg.python.org/cpython/rev/9986fff720a2

Original patch was written by Hallvard B Furuseth.