### PR TITLE
Define FFI_SIZEOF_JAVA_RAW for aarch64 ILP32

### DIFF
--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -29,6 +29,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #ifndef LIBFFI_ASM
 #ifdef __ILP32__
 #define FFI_SIZEOF_ARG 8
+#define FFI_SIZEOF_JAVA_RAW  4
 typedef unsigned long long ffi_arg;
 typedef signed long long ffi_sarg;
 #else


### PR DESCRIPTION
Like x32, aarch64 ILP32 needs to define FFI_SIZEOF_JAVA_RAW.  This fixes
the java interpreter.