### PR TITLE
Update README with a new port

### DIFF
--- a/README
+++ b/README
@@ -113,6 +113,7 @@ tested:
 | X86-64          | Solaris          | Oracle Solaris Studio C |
 | X86-64          | Windows/Cygwin   | GCC                     |
 | X86-64          | Windows/MingW    | GCC                     |
+| X86-64          | Mac OSX          | GCC                     |
 | Xtensa          | Linux            | GCC                     |
 |-----------------+------------------+-------------------------|
 


### PR DESCRIPTION
This is in fact not a NEW port. Apple Mac devices are generally x86-64 now, x86 rarely. If GCC exists for this CPU, it means that libffi has been built too. Please review it and optionally remove line X86 Mac OSX GCC if it was a mistake.
