### PR TITLE
Fix usage on musl libc

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -35,7 +35,7 @@
 #include <ffi_common.h>
 
 #if !FFI_MMAP_EXEC_WRIT && !FFI_EXEC_TRAMPOLINE_TABLE
-# if __gnu_linux__ && !defined(__ANDROID__)
+# if __linux__ && !defined(__ANDROID__)
 /* This macro indicates it may be forbidden to map anonymous memory
    with both write and execute permission.  Code compiled when this
    option is defined will attempt to map such pages once, but if it


### PR DESCRIPTION
A gcc compiled on musl does not define \__gnu_linux\__, it defines \__linux\__.
Only on glibc does \__gnu_linux\__ get defined, but both define \__linux\__, so
we should check for that instead.

With this patch, libffi works perfectly, and passes its testsuite entirely
on musl libc systems.