### PR TITLE
Add parent to symbol version LIBFFI_BASE_7.1

### DIFF
--- a/libffi.map.in
+++ b/libffi.map.in
@@ -45,7 +45,7 @@ LIBFFI_BASE_7.0 {
 LIBFFI_BASE_7.1 {
   global:
 	ffi_get_struct_offsets;
-};
+} LIBFFI_BASE_7.0;
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 LIBFFI_COMPLEX_7.0 {


### PR DESCRIPTION
The symbol version inheritance hierarchy isn't used for too much, but fix this anyway.