### PR TITLE
Some Darwin build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ case "$target" in
                  [Cannot use PROT_EXEC on this target, so, we revert to
                    alternative means])
      ;;
-     *-apple-darwin1* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
+     *-apple-darwin* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
        AC_DEFINE(FFI_MMAP_EXEC_WRIT, 1,
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])

--- a/src/powerpc/darwin_closure.S
+++ b/src/powerpc/darwin_closure.S
@@ -353,7 +353,7 @@ Lret_type13:
 	bgt	Lstructend		; not a special small case
 	b	Lsmallstruct		; see if we need more.
 #else
-	cmpi	0,r0,4
+	cmpwi	0,r0,4
 	bgt	Lfinish		; not by value
 	lg	r3,0(r5)
 	b	Lfinish
@@ -494,8 +494,8 @@ LSFDE1:
 LASFDE1:
 	.long	LASFDE1-EH_frame1	; FDE CIE offset
 	.g_long	Lstartcode-.	; FDE initial location
-	.set	L$set$3,LFE1-Lstartcode
-	.g_long	L$set$3	; FDE address range
+	.set	L$set$2,LFE1-Lstartcode
+	.g_long	L$set$2	; FDE address range
 	.byte   0x0     ; uleb128 0x0; Augmentation size
 	.byte	0x4	; DW_CFA_advance_loc4
 	.set	L$set$3,LCFI1-LCFI0

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -41,10 +41,10 @@
    deallocate some of the stack that has been alloca'd.  */
 
 	.align	8
-	.globl	ffi_call_win64
+	.globl	C(ffi_call_win64)
 
 	SEH(.seh_proc ffi_call_win64)
-ffi_call_win64:
+C(ffi_call_win64):
 	cfi_startproc
 	/* Set up the local stack frame and install it in rbp/rsp.  */
 	movq	(%rsp), %rax
@@ -155,7 +155,7 @@ E(0b, FFI_TYPE_SMALL_STRUCT_4B)
 	.align	8
 99:	call	PLT(C(abort))
 
-.purgem epilogue
+	epilogue
 
 	cfi_endproc
 	SEH(.seh_endproc)
@@ -168,10 +168,10 @@ E(0b, FFI_TYPE_SMALL_STRUCT_4B)
 #define ffi_clo_OFF_X	(32+8+16)
 
 	.align	8
-	.globl	ffi_go_closure_win64
+	.globl	C(ffi_go_closure_win64)
 
 	SEH(.seh_proc ffi_go_closure_win64)
-ffi_go_closure_win64:
+C(ffi_go_closure_win64):
 	cfi_startproc
 	/* Save all integer arguments into the incoming reg stack space.  */
 	movq	%rcx, 8(%rsp)
@@ -187,10 +187,10 @@ ffi_go_closure_win64:
 	SEH(.seh_endproc)
 
 	.align	8
-	.globl	ffi_closure_win64
+	.globl	C(ffi_closure_win64)
 
 	SEH(.seh_proc ffi_closure_win64)
-ffi_closure_win64:
+C(ffi_closure_win64):
 	cfi_startproc
 	/* Save all integer arguments into the incoming reg stack space.  */
 	movq	%rcx, 8(%rsp)
@@ -214,7 +214,7 @@ ffi_closure_win64:
 	movsd	%xmm3, ffi_clo_OFF_X+24(%rsp)
 
 	leaq	ffi_clo_OFF_R(%rsp), %r9
-	call	ffi_closure_win64_inner
+	call	C(ffi_closure_win64_inner)
 
 	/* Load the result into both possible result registers.  */
 	movq    ffi_clo_OFF_R(%rsp), %rax


### PR DESCRIPTION
Revised with Richard's feedback;

This branch fixes up some build fails on x86_64 and powerpc darwin with various toolchains and system configurations.

tested:
powerpc{,64}-apple-darwin on OS X 10.5 with GCC-5.3 and cctools 877.9/ld64-253.9 (from my repo)
powerpc-apple-darwin on OS X 10.5 with clang-3.8 (experimental)

i686-apple-darwin with GCC-5.3 and cctools-877.8/ld64-253.9 on OS X 10.6 (m32, core)
i686-apple-darwin with clang-3.8 (experiemental) on OS X 10.6 (m32,core)

x86_64-apple-darwin with  GCC and clang-3.8 on OS X 10.6 (m64, core2)

x86-64-apple-darwin on OS X 10.8.5 with GCC 5.3 and clang-3.9 (and XCode clang).

The configury change seems appropriate for current targets of interest (anyone wanting to build with, say, ppc-darwin7 should add a line explict to that - leaving <arch>-*-darwin to apply to all modern cases)  I am trying to get away from needing darwinNN as a configury param.

NOTE1: the branch will not build with old Apple (gcc-4.2) compilers which don't support __attribute__((deprecated("with a message here"))) .. but I've decided to leave that for now.   However, I temporarily commented out the failing directive (and -Wno-psabi in the testsuite) and the code builds and tests OK with the Xcode 3.1.4 toolset (using gcc-4.2) on powerpc-darwin9.

NOTE2:  There are still quite a few [40] failing tests on i686-darwin10 (to be triaged at some later time).
