### PR TITLE
Mark win64.S with GNU-stack note

### DIFF
--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -226,3 +226,7 @@ C(ffi_closure_win64):
 
 	cfi_endproc
 	SEH(.seh_endproc)
+
+#if defined __ELF__ && defined __linux__
+	.section	.note.GNU-stack,"",@progbits
+#endif


### PR DESCRIPTION
Fix issue #257 