### PR TITLE
MIPS: don't use FP instruction when building for soft-float targets

### DIFF
--- a/src/mips/o32.S
+++ b/src/mips/o32.S
@@ -82,13 +82,16 @@ sixteen:
 		
 	ADDU	$sp, 4 * FFI_SIZEOF_ARG		# adjust $sp to new args
 
+#ifndef __mips_soft_float
 	bnez	t0, pass_d			# make it quick for int
+#endif
 	REG_L	a0, 0*FFI_SIZEOF_ARG($sp)	# just go ahead and load the
 	REG_L	a1, 1*FFI_SIZEOF_ARG($sp)	# four regs.
 	REG_L	a2, 2*FFI_SIZEOF_ARG($sp)
 	REG_L	a3, 3*FFI_SIZEOF_ARG($sp)
 	b	call_it
 
+#ifndef __mips_soft_float
 pass_d:
 	bne	t0, FFI_ARGS_D, pass_f
 	l.d	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
@@ -130,6 +133,7 @@ pass_f_d:
  #	bne	t0, FFI_ARGS_F_D, call_it
 	l.s	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
 	l.d	$f14, 2*FFI_SIZEOF_ARG($sp)	# passing double and float
+#endif
 
 call_it:	
 	# Load the static chain pointer
@@ -161,14 +165,23 @@ retfloat:
 	bne     t2, FFI_TYPE_FLOAT, retdouble
 	jalr	t9
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
+#ifndef __mips_soft_float
 	s.s	$f0, 0(t0)
+#else
+	REG_S	v0, 0(t0)
+#endif
 	b	epilogue
 
 retdouble:	
 	bne	t2, FFI_TYPE_DOUBLE, noretval
 	jalr	t9
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
+#ifndef __mips_soft_float
 	s.d	$f0, 0(t0)
+#else
+	REG_S	v1, 4(t0)
+	REG_S	v0, 0(t0)
+#endif
 	b	epilogue
 	
 noretval:	
@@ -262,6 +275,7 @@ $LCFI12:
 	REG_S	a2, A2_OFF2($fp)
 	REG_S	a3, A3_OFF2($fp)
 
+#ifndef __mips_soft_float
 	# Load ABI enum to s0
 	REG_L	$16, 4($15)	# cif 
 	REG_L	$16, 0($16)	# abi is first member.
@@ -273,6 +287,8 @@ $LCFI12:
 	s.d	$f12, FA_0_0_OFF2($fp)
 	s.d	$f14, FA_1_0_OFF2($fp)
 1:
+#endif
+
 	# prepare arguments for ffi_closure_mips_inner_O32
 	REG_L	a0, 4($15)	 # cif 
 	REG_L	a1, 8($15)	 # fun
@@ -317,6 +333,7 @@ $LCFI22:
 	REG_S	a2, A2_OFF2($fp)
 	REG_S	a3, A3_OFF2($fp)
 
+#ifndef __mips_soft_float
 	# Load ABI enum to s0
 	REG_L	$16, 20($12)	# cif pointer follows tramp.
 	REG_L	$16, 0($16)	# abi is first member.
@@ -328,6 +345,8 @@ $LCFI22:
 	s.d	$f12, FA_0_0_OFF2($fp)
 	s.d	$f14, FA_1_0_OFF2($fp)
 1:	
+#endif
+
 	# prepare arguments for ffi_closure_mips_inner_O32
 	REG_L	a0, 20($12)	 # cif pointer follows tramp.
 	REG_L	a1, 24($12)	 # fun
@@ -350,6 +369,7 @@ $do_closure:
 	li	$9, FFI_TYPE_VOID
 	beq	$8, $9, closure_done
 
+#ifndef __mips_soft_float
 	li	$13, 1		# FFI_O32
 	bne	$16, $13, 1f	# Skip fp restore if FFI_O32_SOFT_FLOAT
 
@@ -361,6 +381,8 @@ $do_closure:
 	l.d	$f0, V0_OFF2($fp)
 	beq	$8, $9, closure_done
 1:	
+#endif
+
 	REG_L	$3, V1_OFF2($fp)
 	REG_L	$2, V0_OFF2($fp)
 


### PR DESCRIPTION
Users of libffi can select whether to use the O32 or O32_SOFT_FLOAT ABI
at runtime. But when we are building for a target which doesn't have FP
instructions, skip all that and always assume O32_SOFT_FLOAT. This is
important because newer binutils complain if assembler code contains FP
instructions but the target doesn't support them.

This change only affects the handwritten assembler code in mips/o32.S.
The C source and header files don't enforce O32_SOFT_FLOAT, though
FFI_DEFAULT_ABI is set appropriately. If users if this library
explicitly request FFI_O32 on a soft-float target, they may run into
problems at runtime.

Fixes #187. Based on patch by @alllexx88.