### PR TITLE
Make testing easier outside of build directory and especially for ARC

### DIFF
--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -102,11 +102,14 @@ proc libffi-init { args } {
     global ld_library_path
     global compiler_vendor
 
-    set blddirffi [pwd]/.. 
+    if ![info exists blddirffi] {
+	set blddirffi [pwd]/..
+    }
+
     verbose "libffi $blddirffi"
 
     # Which compiler are we building with?
-    set tmp [grep ../config.log "^ax_cv_c_compiler_vendor.*$"]
+    set tmp [grep "$blddirffi/config.log" "^ax_cv_c_compiler_vendor.*$"]
     regexp -- {^[^=]*=(.*)$} $tmp nil compiler_vendor
 
     if { [string match $compiler_vendor "gnu"] } {

--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -219,6 +219,10 @@ proc libffi_target_compile { source dest type options } {
 	lappend options "c++"
     }
 
+    if { [string match "arc*-*-linux*" $target_triplet] } {
+	lappend options "libs= -lpthread"
+    }
+
     verbose "options: $options"
     return [target_compile $source $dest $type $options]
 }

--- a/testsuite/libffi.call/cls_dbls_struct.c
+++ b/testsuite/libffi.call/cls_dbls_struct.c
@@ -57,10 +57,10 @@ int main(int argc __UNUSED__, char** argv __UNUSED__)
 	CHECK(ffi_prep_closure_loc(pcl, &cif, closure_test_gn, NULL, code) == FFI_OK);
 
 	((void*(*)(Dbls))(code))(arg);
-	/* { dg-output "1.0 2.0\n" } */
+	/* { dg-output "1.0 2.0" } */
 
 	closure_test_fn(arg);
-	/* { dg-output "1.0 2.0\n" } */
+	/* { dg-output "\n1.0 2.0" } */
 
 	return 0;
 }

--- a/testsuite/libffi.call/float2.c
+++ b/testsuite/libffi.call/float2.c
@@ -22,6 +22,7 @@ int main (void)
   void *values[MAX_ARGS];
   float f;
   long double ld;
+  long double original;
 
   args[0] = &ffi_type_float;
   values[0] = &f;
@@ -49,7 +50,8 @@ int main (void)
 #endif
 
   /* These are not always the same!! Check for a reasonable delta */
-  if (fabsl(ld - ldblit(f)) < LDBL_EPSILON)
+  original = ldblit(f);
+  if (((ld > original) ? (ld - original) : (original - ld)) < LDBL_EPSILON)
     puts("long double return value tests ok!");
   else
     CHECK(0);


### PR DESCRIPTION
Sometimes it is useful when tests are executed not from build directory (when `make` scripts are not used). So the path of the build directory may be passed through `site.exp` or `runtest`.

Also there is a patch for ARC Linux targets - some tests must be linked with `pthread`.