### PR TITLE
aarch64: Fix handling of aggregates larger than 16 bytes

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -666,6 +666,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 		   the argument is replaced by a pointer to the copy.  */
 		a = &avalue[i];
 		t = FFI_TYPE_POINTER;
+		s = sizeof (void *);
 		goto do_pointer;
 	      }
 	    else


### PR DESCRIPTION
Instead of allocating stack space for a pointer we would allocate stack
space for the actual aggregate size.