### PR TITLE
aarch64: Fix handling of variadic closures on iOS

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -917,6 +917,15 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 	default:
 	  abort();
 	}
+
+#if defined (__APPLE__)
+      if (i + 1 == cif->aarch64_nfixedargs)
+	{
+	  state.ngrn = N_X_ARG_REG;
+	  state.nsrn = N_V_ARG_REG;
+	  state.allocating_variadic = 1;
+	}
+#endif
     }
 
   flags = cif->flags;


### PR DESCRIPTION
The closure logic was missing the Apple-specific bits.