### PR TITLE
Mips64 soft float

### DIFF
--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -474,9 +474,9 @@ Compute the offset of each element of the given structure type.
 @var{abi} is the ABI to use; this is needed because in some cases the
 layout depends on the ABI.
 
-@var{sizes} is an out parameter.  The caller is responsible for
+@var{offsets} is an out parameter.  The caller is responsible for
 providing enough space for all the results to be written -- one
-element per element type in @var{struct_type}.  If @var{sizes} is
+element per element type in @var{struct_type}.  If @var{offsets} is
 @code{NULL}, then the type will be laid out but not otherwise
 modified.  This can be useful for accessing the type's size or layout,
 as mentioned above.

--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -112,6 +112,16 @@ loadregs:
 
 	REG_L	t6, 3*FFI_SIZEOF_ARG($fp)  # load the flags word into t6.
 
+#ifdef __mips_soft_float
+	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
+	REG_L	a1, 1*FFI_SIZEOF_ARG(t9)
+	REG_L	a2, 2*FFI_SIZEOF_ARG(t9)
+	REG_L	a3, 3*FFI_SIZEOF_ARG(t9)
+	REG_L	a4, 4*FFI_SIZEOF_ARG(t9)
+	REG_L	a5, 5*FFI_SIZEOF_ARG(t9)
+	REG_L	a6, 6*FFI_SIZEOF_ARG(t9)
+	REG_L	a7, 7*FFI_SIZEOF_ARG(t9)
+#else
 	and	t4, t6, ((1<<FFI_FLAG_BITS)-1)
 	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
 	beqz	t4, arg1_next
@@ -198,6 +208,7 @@ arg7_next:
 arg8_doublep:	
  	l.d	$f19, 7*FFI_SIZEOF_ARG(t9)	
 arg8_next:	
+#endif
 
 callit:		
 	# Load the function pointer
@@ -222,6 +233,7 @@ retint:
 	b	epilogue
 
 retfloat:
+#ifndef __mips_soft_float
 	bne     t6, FFI_TYPE_FLOAT, retdouble
 	jal	t9
 	REG_L	t4, 4*FFI_SIZEOF_ARG($fp)
@@ -280,6 +292,7 @@ retstruct_f_d:
 	s.s	$f0, 0(t4)
 	s.d	$f2, 8(t4)
 	b	epilogue
+#endif
 
 retstruct_d_soft:
 	bne	t6, FFI_TYPE_STRUCT_D_SOFT, retstruct_f_soft
@@ -483,6 +496,7 @@ $do_closure:
 	REG_S	a6, A6_OFF2($sp)
 	REG_S	a7, A7_OFF2($sp)
 
+#ifndef __mips_soft_float
 	# Store all possible float/double registers.
 	s.d	$f12, F12_OFF2($sp)
 	s.d	$f13, F13_OFF2($sp)
@@ -492,6 +506,7 @@ $do_closure:
 	s.d	$f17, F17_OFF2($sp)
 	s.d	$f18, F18_OFF2($sp)
 	s.d	$f19, F19_OFF2($sp)
+#endif
 
 	jalr	t9
 
@@ -506,6 +521,7 @@ cls_retint:
 	b	cls_epilogue
 
 cls_retfloat:
+#ifndef __mips_soft_float
 	bne     v0, FFI_TYPE_FLOAT, cls_retdouble
 	l.s	$f0, V0_OFF2($sp)
 	b	cls_epilogue
@@ -548,6 +564,7 @@ cls_retstruct_f_d:
 	l.s	$f0, V0_OFF2($sp)
 	l.d	$f2, V1_OFF2($sp)
 	b	cls_epilogue
+#endif
 	
 cls_retstruct_small2:	
 	REG_L	v0, V0_OFF2($sp)

--- a/src/mips/o32.S
+++ b/src/mips/o32.S
@@ -82,13 +82,16 @@ sixteen:
 		
 	ADDU	$sp, 4 * FFI_SIZEOF_ARG		# adjust $sp to new args
 
+#ifndef __mips_soft_float
 	bnez	t0, pass_d			# make it quick for int
+#endif
 	REG_L	a0, 0*FFI_SIZEOF_ARG($sp)	# just go ahead and load the
 	REG_L	a1, 1*FFI_SIZEOF_ARG($sp)	# four regs.
 	REG_L	a2, 2*FFI_SIZEOF_ARG($sp)
 	REG_L	a3, 3*FFI_SIZEOF_ARG($sp)
 	b	call_it
 
+#ifndef __mips_soft_float
 pass_d:
 	bne	t0, FFI_ARGS_D, pass_f
 	l.d	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
@@ -130,6 +133,7 @@ pass_f_d:
  #	bne	t0, FFI_ARGS_F_D, call_it
 	l.s	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
 	l.d	$f14, 2*FFI_SIZEOF_ARG($sp)	# passing double and float
+#endif
 
 call_it:	
 	# Load the static chain pointer
@@ -161,14 +165,23 @@ retfloat:
 	bne     t2, FFI_TYPE_FLOAT, retdouble
 	jalr	t9
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
+#ifndef __mips_soft_float
 	s.s	$f0, 0(t0)
+#else
+	REG_S	v0, 0(t0)
+#endif
 	b	epilogue
 
 retdouble:	
 	bne	t2, FFI_TYPE_DOUBLE, noretval
 	jalr	t9
 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
+#ifndef __mips_soft_float
 	s.d	$f0, 0(t0)
+#else
+	REG_S	v1, 4(t0)
+	REG_S	v0, 0(t0)
+#endif
 	b	epilogue
 	
 noretval:	
@@ -324,9 +337,11 @@ $LCFI22:
 	li	$13, 1		# FFI_O32
 	bne	$16, $13, 1f	# Skip fp save if FFI_O32_SOFT_FLOAT
 	
+#ifndef __mips_soft_float
 	# Store all possible float/double registers.
 	s.d	$f12, FA_0_0_OFF2($fp)
 	s.d	$f14, FA_1_0_OFF2($fp)
+#endif
 1:	
 	# prepare arguments for ffi_closure_mips_inner_O32
 	REG_L	a0, 20($12)	 # cif pointer follows tramp.
@@ -353,6 +368,7 @@ $do_closure:
 	li	$13, 1		# FFI_O32
 	bne	$16, $13, 1f	# Skip fp restore if FFI_O32_SOFT_FLOAT
 
+#ifndef __mips_soft_float
 	li	$9, FFI_TYPE_FLOAT
 	l.s	$f0, V0_OFF2($fp)
 	beq	$8, $9, closure_done
@@ -360,6 +376,7 @@ $do_closure:
 	li	$9, FFI_TYPE_DOUBLE
 	l.d	$f0, V0_OFF2($fp)
 	beq	$8, $9, closure_done
+#endif
 1:	
 	REG_L	$3, V1_OFF2($fp)
 	REG_L	$2, V0_OFF2($fp)


### PR DESCRIPTION
This was only lightly tested with python ctypes

```
from ctypes import *
libc = CDLL('libc.so.6')
libm = CDLL('libm.so.6')
libm_sin = libm.sin
libm_sin.restype = c_double
v = libm_sin(c_double(0.5))
print v
```