### PR TITLE
closures.c: Close the execfd in dlmmap to avoid FD leaks

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -734,6 +734,8 @@ dlmmap_locked (void *start, size_t length, int prot, int flags, off_t offset)
 
   execsize += length;
 
+  close(execfd);
+
   return start;
 }
 


### PR DESCRIPTION
In the current implementation, any use of dlmmap will result in a file
descriptor leak similar to the following visible in lsof output. This is
due to the FD not being closed following mmap operation.

  COMM PID root 6u REG 253,0 4096 51133553 /tmp/ffiEmToG6 (deleted)

This patch closes the execfd within dlmmap_locked codepath to avoid the
condition.

Signed-off-by: Kyle Walker <disneyworldguy@gmail.com>