### PR TITLE
Install public headers in the standard path

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -6,5 +6,4 @@ DISTCLEANFILES=ffitarget.h
 noinst_HEADERS=ffi_common.h ffi_cfi.h
 EXTRA_DIST=ffi.h.in
 
-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
-nodist_includes_HEADERS = ffi.h ffitarget.h
+nodist_include_HEADERS = ffi.h ffitarget.h

--- a/libffi.pc.in
+++ b/libffi.pc.in
@@ -2,7 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 toolexeclibdir=@toolexeclibdir@
-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: Library supporting Foreign Function Interfaces


### PR DESCRIPTION
As title, install ```ffi.h``` and ```ffitarget.h``` to the standard path ```$PREFIX/include``` instead of mysterious ```$PREFIX/lib/libffi-x.y.z/include```