### PR TITLE
Fix error path so mutex is unlocked before returning

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -211,6 +211,7 @@ ffi_closure_alloc (size_t size, void **code)
       table = ffi_trampoline_table_alloc ();
       if (table == NULL)
 	{
+	  pthread_mutex_unlock (&ffi_trampoline_lock);
 	  free (closure);
 	  return NULL;
 	}


### PR DESCRIPTION
In the unusual case where ffi_trampoline_table_alloc() fails.