### PR TITLE
Prefix ALIGN macros with FFI_

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -74,7 +74,7 @@ void ffi_type_test(ffi_type *a, char *file, int line);
 #define FFI_ASSERT_VALID_TYPE(x)
 #endif
 
-#define ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
+#define FFI_ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
 #define ALIGN_DOWN(v, a) (((size_t) (v)) & -a)
 
 /* Perform machine dependent cif processing */

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -280,7 +280,7 @@ allocate_to_stack (struct arg_state *state, void *stack,
     alignment = 8;
 #endif
     
-  nsaa = ALIGN (nsaa, alignment);
+  nsaa = FFI_ALIGN (nsaa, alignment);
   state->nsaa = nsaa + size;
 
   return (char *)stack + nsaa;
@@ -528,7 +528,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
       }
 
   /* Round the stack up to a multiple of the stack alignment requirement. */
-  cif->bytes = ALIGN(bytes, 16);
+  cif->bytes = FFI_ALIGN(bytes, 16);
   cif->flags = flags;
 #if defined (__APPLE__)
   cif->aarch64_nfixedargs = 0;

--- a/src/alpha/ffi.c
+++ b/src/alpha/ffi.c
@@ -98,7 +98,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	case FFI_TYPE_VOID:
 	case FFI_TYPE_STRUCT:
 	  /* Passed by value in N slots.  */
-	  bytes += ALIGN(itype->size, FFI_SIZEOF_ARG);
+	  bytes += FFI_ALIGN(itype->size, FFI_SIZEOF_ARG);
 	  break;
 
 	case FFI_TYPE_COMPLEX:
@@ -285,7 +285,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	case FFI_TYPE_STRUCT:
 	  size = ty->size;
 	  memcpy(argp + argn, valp, size);
-	  argn += ALIGN(size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	  argn += FFI_ALIGN(size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
 	  break;
 
 	case FFI_TYPE_COMPLEX:
@@ -421,7 +421,7 @@ ffi_closure_osf_inner (ffi_cif *cif,
 	case FFI_TYPE_VOID:
 	case FFI_TYPE_STRUCT:
 	  size = ty->size;
-	  argn += ALIGN(size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	  argn += FFI_ALIGN(size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
 	  break;
 
 	case FFI_TYPE_FLOAT:

--- a/src/arc/ffi.c
+++ b/src/arc/ffi.c
@@ -71,7 +71,7 @@ ffi_prep_args (char *stack, extended_cif * ecif)
 
       /* Align if necessary.  */
       if ((alignment - 1) & (unsigned) argp)
-	argp = (char *) ALIGN (argp, alignment);
+	argp = (char *) FFI_ALIGN (argp, alignment);
 
       z = (*p_arg)->size;
       if (z < sizeof (int))
@@ -223,7 +223,7 @@ ffi_closure_inner_ARCompact (ffi_closure * closure, void *rvalue,
 
       /* Align if necessary.  */
       if ((alignment - 1) & (unsigned) argp)
-	argp = (char *) ALIGN (argp, alignment);
+	argp = (char *) FFI_ALIGN (argp, alignment);
 
       z = (*p_argt)->size;
       *p_argv = (void *) argp;

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -60,7 +60,7 @@ ffi_align (ffi_type *ty, void *p)
   if (alignment < 4)
     alignment = 4;
 #endif
-  return (void *) ALIGN (p, alignment);
+  return (void *) FFI_ALIGN (p, alignment);
 }
 
 static size_t
@@ -106,7 +106,7 @@ ffi_put_arg (ffi_type *ty, void *src, void *dst)
       abort();
     }
 
-  return ALIGN (z, 4);
+  return FFI_ALIGN (z, 4);
 }
 
 /* ffi_prep_args is called once stack space has been allocated
@@ -287,7 +287,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
   /* Round the stack up to a multiple of 8 bytes.  This isn't needed
      everywhere, but it is on some platforms, and it doesn't harm anything
      when it isn't needed.  */
-  bytes = ALIGN (bytes, 8);
+  bytes = FFI_ALIGN (bytes, 8);
 
   /* Minimum stack space is the 4 register arguments that we pop.  */
   if (bytes < 4*4)

--- a/src/cris/ffi.c
+++ b/src/cris/ffi.c
@@ -29,7 +29,7 @@
 #include <ffi.h>
 #include <ffi_common.h>
 
-#define STACK_ARG_SIZE(x) ALIGN(x, FFI_SIZEOF_ARG)
+#define STACK_ARG_SIZE(x) FFI_ALIGN(x, FFI_SIZEOF_ARG)
 
 static ffi_status
 initialize_aggregate_packed_struct (ffi_type * arg)
@@ -190,7 +190,7 @@ ffi_prep_cif_core (ffi_cif * cif,
       FFI_ASSERT_VALID_TYPE (*ptr);
 
       if (((*ptr)->alignment - 1) & bytes)
-	bytes = ALIGN (bytes, (*ptr)->alignment);
+	bytes = FFI_ALIGN (bytes, (*ptr)->alignment);
       if ((*ptr)->type == FFI_TYPE_STRUCT)
 	{
 	  if ((*ptr)->size > 8)

--- a/src/frv/ffi.c
+++ b/src/frv/ffi.c
@@ -118,7 +118,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
   else
     cif->flags = cif->rtype->size;
 
-  cif->bytes = ALIGN (cif->bytes, 8);
+  cif->bytes = FFI_ALIGN (cif->bytes, 8);
 
   return FFI_OK;
 }

--- a/src/java_raw_api.c
+++ b/src/java_raw_api.c
@@ -114,7 +114,7 @@ ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args)
 	default:
 	  *args = raw;
 	  raw +=
-	    ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
+	    FFI_ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
 	}
     }
 
@@ -142,7 +142,7 @@ ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args)
 #else /* FFI_SIZEOF_JAVA_RAW != 8 */
 	*args = (void*) raw;
 	raw +=
-	  ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
+	  FFI_ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
 #endif /* FFI_SIZEOF_JAVA_RAW == 8 */
     }
 
@@ -234,7 +234,7 @@ ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw)
 #else
 	  memcpy ((void*) raw->data, (void*)*args, (*tp)->size);
 	  raw +=
-	    ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
+	    FFI_ALIGN ((*tp)->size, sizeof(ffi_java_raw)) / sizeof(ffi_java_raw);
 #endif
 	}
     }

--- a/src/m32r/ffi.c
+++ b/src/m32r/ffi.c
@@ -61,7 +61,7 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
 
       /* Align if necessary.  */
       if (((*p_arg)->alignment - 1) & (unsigned) argp)
-	argp = (char *) ALIGN (argp, (*p_arg)->alignment);
+	argp = (char *) FFI_ALIGN (argp, (*p_arg)->alignment);
 
       if (avn != 0) 
 	{

--- a/src/m68k/ffi.c
+++ b/src/m68k/ffi.c
@@ -105,7 +105,7 @@ ffi_prep_args (void *stack, extended_cif *ecif)
 
 	  /* Align if necessary.  */
 	  if ((sizeof(int) - 1) & z)
-	    z = ALIGN(z, sizeof(int));
+	    z = FFI_ALIGN(z, sizeof(int));
 	}
 
       p_argv++;
@@ -297,7 +297,7 @@ ffi_prep_incoming_args_SYSV (char *stack, void **avalue, ffi_cif *cif)
 
 	  /* Align if necessary */
 	  if ((sizeof(int) - 1) & z)
-	    z = ALIGN(z, sizeof(int));
+	    z = FFI_ALIGN(z, sizeof(int));
 	}
 
       p_argv++;

--- a/src/m88k/ffi.c
+++ b/src/m88k/ffi.c
@@ -134,7 +134,7 @@ ffi_prep_args (void *stack, extended_cif *ecif)
       /* Enforce proper stack alignment of 64-bit types */
       if (argp == stackp && a > sizeof (int))
 	{
-	  stackp = (char *) ALIGN(stackp, a);
+	  stackp = (char *) FFI_ALIGN(stackp, a);
 	  argp = stackp;
 	}
 
@@ -177,7 +177,7 @@ ffi_prep_args (void *stack, extended_cif *ecif)
 
       /* Align if necessary.  */
       if ((sizeof (int) - 1) & z)
-	z = ALIGN(z, sizeof (int));
+	z = FFI_ALIGN(z, sizeof (int));
 
       p_argv++;
 
@@ -320,7 +320,7 @@ ffi_prep_closure_args_OBSD (ffi_cif *cif, void **avalue, unsigned int *regp,
       /* Enforce proper stack alignment of 64-bit types */
       if (argp == stackp && a > sizeof (int))
 	{
-	  stackp = (char *) ALIGN(stackp, a);
+	  stackp = (char *) FFI_ALIGN(stackp, a);
 	  argp = stackp;
 	}
 
@@ -331,7 +331,7 @@ ffi_prep_closure_args_OBSD (ffi_cif *cif, void **avalue, unsigned int *regp,
 
       /* Align if necessary */
       if ((sizeof (int) - 1) & z)
-	z = ALIGN(z, sizeof (int));
+	z = FFI_ALIGN(z, sizeof (int));
 
       p_argv++;
 

--- a/src/metag/ffi.c
+++ b/src/metag/ffi.c
@@ -93,7 +93,7 @@ unsigned int ffi_prep_args(char *stack, extended_cif *ecif)
 
 	/* return the size of the arguments to be passed in registers,
 	   padded to an 8 byte boundary to preserve stack alignment */
-	return ALIGN(MIN(stack - argp, 6*4), 8);
+	return FFI_ALIGN(MIN(stack - argp, 6*4), 8);
 }
 
 /* Perform machine dependent cif processing */
@@ -112,20 +112,20 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 
 		/* Add any padding if necessary */
 		if (((*ptr)->alignment - 1) & bytes)
-			bytes = ALIGN(bytes, (*ptr)->alignment);
+			bytes = FFI_ALIGN(bytes, (*ptr)->alignment);
 
-		bytes += ALIGN((*ptr)->size, 4);
+		bytes += FFI_ALIGN((*ptr)->size, 4);
 	}
 
 	/* Ensure arg space is aligned to an 8-byte boundary */
-	bytes = ALIGN(bytes, 8);
+	bytes = FFI_ALIGN(bytes, 8);
 
 	/* Make space for the return structure pointer */
 	if (cif->rtype->type == FFI_TYPE_STRUCT) {
 		bytes += sizeof(void*);
 
 		/* Ensure stack is aligned to an 8-byte boundary */
-		bytes = ALIGN(bytes, 8);
+		bytes = FFI_ALIGN(bytes, 8);
 	}
 
 	cif->bytes = bytes;
@@ -319,7 +319,7 @@ static void ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
 		if (alignment < 4)
 			alignment = 4;
 		if ((alignment - 1) & (unsigned)argp)
-			argp = (char *) ALIGN(argp, alignment);
+			argp = (char *) FFI_ALIGN(argp, alignment);
 
 		z = (*p_arg)->size;
 		*p_argv = (void*) argp;

--- a/src/microblaze/ffi.c
+++ b/src/microblaze/ffi.c
@@ -35,7 +35,7 @@ extern void ffi_closure_SYSV(void);
 
 #define WORD_SIZE			sizeof(unsigned int)
 #define ARGS_REGISTER_SIZE	(WORD_SIZE * 6)
-#define WORD_ALIGN(x)		ALIGN(x, WORD_SIZE)
+#define WORD_FFI_ALIGN(x)		FFI_ALIGN(x, WORD_SIZE)
 
 /* ffi_prep_args is called by the assembly routine once stack space
    has been allocated for the function's arguments */
@@ -74,7 +74,7 @@ void ffi_prep_args(void* stack, extended_cif* ecif)
 		int type = (*p_arg)->type;
 		void* value = p_argv[i];
 		char* addr = stack_args_p;
-		int aligned_size = WORD_ALIGN(size);
+		int aligned_size = WORD_FFI_ALIGN(size);
 
 		/* force word alignment on the stack */
 		stack_args_p += aligned_size;
@@ -259,7 +259,7 @@ void ffi_closure_call_SYSV(void* register_args, void* stack_args,
 				avalue[i] = ptr;
 				break;
 		}
-		ptr += WORD_ALIGN(arg_types[i]->size);
+		ptr += WORD_FFI_ALIGN(arg_types[i]->size);
 	}
 
 	/* set the return type info passed back to the wrapper */

--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -116,7 +116,7 @@ static void ffi_prep_args(char *stack,
       
       if ((a - 1) & (unsigned long) argp)
 	{
-	  argp = (char *) ALIGN(argp, a);
+	  argp = (char *) FFI_ALIGN(argp, a);
 	  FIX_ARGP;
 	}
 
@@ -247,7 +247,7 @@ calc_n32_struct_flags(int soft_float, ffi_type *arg,
   while ((e = arg->elements[index]))
     {
       /* Align this object.  */
-      *loc = ALIGN(*loc, e->alignment);
+      *loc = FFI_ALIGN(*loc, e->alignment);
       if (e->type == FFI_TYPE_DOUBLE)
 	{
           /* Already aligned to FFI_SIZEOF_ARG.  */
@@ -262,7 +262,7 @@ calc_n32_struct_flags(int soft_float, ffi_type *arg,
       index++;
     }
   /* Next Argument register at alignment of FFI_SIZEOF_ARG.  */
-  *arg_reg = ALIGN(*loc, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+  *arg_reg = FFI_ALIGN(*loc, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
 
   return flags;
 }
@@ -474,7 +474,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 	    break;
           case FFI_TYPE_LONGDOUBLE:
             /* Align it.  */
-            arg_reg = ALIGN(arg_reg, 2);
+            arg_reg = FFI_ALIGN(arg_reg, 2);
             /* Treat it as two adjacent doubles.  */
 	    if (soft_float) 
 	      {
@@ -852,7 +852,7 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
 	    }
 	  seen_int = 1;
 	}
-      argn += ALIGN(arg_types[i]->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+      argn += FFI_ALIGN(arg_types[i]->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
       i++;
     }
 
@@ -893,7 +893,7 @@ copy_struct_N32(char *target, unsigned offset, ffi_abi abi, ffi_type *type,
       char *argp;
       char *fpp;
 
-      o = ALIGN(offset, elt_type->alignment);
+      o = FFI_ALIGN(offset, elt_type->alignment);
       arg_offset += o - offset;
       offset = o;
       argn += arg_offset / sizeof(ffi_arg);
@@ -976,7 +976,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
           argp = (argn >= 8 || soft_float) ? ar + argn : fpr + argn;
           if ((arg_types[i]->type == FFI_TYPE_LONGDOUBLE) && ((unsigned)argp & (arg_types[i]->alignment-1)))
             {
-              argp=(ffi_arg*)ALIGN(argp,arg_types[i]->alignment);
+              argp=(ffi_arg*)FFI_ALIGN(argp,arg_types[i]->alignment);
               argn++;
             }
 #if defined(__MIPSEB__) || defined(_MIPSEB)
@@ -991,7 +991,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
           unsigned type = arg_types[i]->type;
 
           if (arg_types[i]->alignment > sizeof(ffi_arg))
-            argn = ALIGN(argn, arg_types[i]->alignment / sizeof(ffi_arg));
+            argn = FFI_ALIGN(argn, arg_types[i]->alignment / sizeof(ffi_arg));
 
           argp = ar + argn;
 
@@ -1052,7 +1052,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
               break;
             }
         }
-      argn += ALIGN(arg_types[i]->size, sizeof(ffi_arg)) / sizeof(ffi_arg);
+      argn += FFI_ALIGN(arg_types[i]->size, sizeof(ffi_arg)) / sizeof(ffi_arg);
       i++;
     }
 

--- a/src/moxie/ffi.c
+++ b/src/moxie/ffi.c
@@ -111,7 +111,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
   else
     cif->flags = cif->rtype->size;
 
-  cif->bytes = ALIGN (cif->bytes, 8);
+  cif->bytes = FFI_ALIGN (cif->bytes, 8);
 
   return FFI_OK;
 }

--- a/src/nios2/ffi.c
+++ b/src/nios2/ffi.c
@@ -101,7 +101,7 @@ void ffi_prep_args (char *stack, extended_cif *ecif)
 
       /* Align argp as appropriate for the argument type.  */
       if ((alignment - 1) & (unsigned) argp)
-	argp = (char *) ALIGN (argp, alignment);
+	argp = (char *) FFI_ALIGN (argp, alignment);
 
       /* Copy the argument, promoting integral types smaller than a
 	 word to word size.  */
@@ -230,7 +230,7 @@ ffi_closure_helper (unsigned char *args,
 
       /* Align argp as appropriate for the argument type.  */
       if ((alignment - 1) & (unsigned) argp)
-	argp = (char *) ALIGN (argp, alignment);
+	argp = (char *) FFI_ALIGN (argp, alignment);
 
       /* Arguments smaller than an int are promoted to int.  */
       if (size < sizeof (int))

--- a/src/powerpc/asm.h
+++ b/src/powerpc/asm.h
@@ -93,7 +93,7 @@
 /* EALIGN is like ENTRY, but does alignment to 'words'*4 bytes
    past a 2^align boundary.  */
 #ifdef PROF
-#define EALIGN(name, alignt, words)					      \
+#define EFFI_ALIGN(name, alignt, words)					      \
   ASM_GLOBAL_DIRECTIVE C_SYMBOL_NAME(name);				      \
   ASM_TYPE_DIRECTIVE (C_SYMBOL_NAME(name),@function)			      \
   .align ALIGNARG(2);							      \
@@ -104,7 +104,7 @@
   EALIGN_W_##words;							      \
   0:
 #else /* PROF */
-#define EALIGN(name, alignt, words)					      \
+#define EFFI_ALIGN(name, alignt, words)					      \
   ASM_GLOBAL_DIRECTIVE C_SYMBOL_NAME(name);				      \
   ASM_TYPE_DIRECTIVE (C_SYMBOL_NAME(name),@function)			      \
   .align ALIGNARG(alignt);						      \

--- a/src/powerpc/ffi_darwin.c
+++ b/src/powerpc/ffi_darwin.c
@@ -255,7 +255,7 @@ ffi_prep_args (extended_cif *ecif, unsigned long *const stack)
 	case FFI_TYPE_STRUCT:
 	  size_al = (*ptr)->size;
 #if defined(POWERPC_DARWIN64)
-	  next_arg = (unsigned long *)ALIGN((char *)next_arg, (*ptr)->alignment);
+	  next_arg = (unsigned long *)FFI_ALIGN((char *)next_arg, (*ptr)->alignment);
 	  darwin64_pass_struct_by_value (*ptr, (char *) *p_argv, 
 					 (unsigned) size_al,
 					 (unsigned int *) &fparg_count,
@@ -266,7 +266,7 @@ ffi_prep_args (extended_cif *ecif, unsigned long *const stack)
 	  /* If the first member of the struct is a double, then include enough
 	     padding in the struct size to align it to double-word.  */
 	  if ((*ptr)->elements[0]->type == FFI_TYPE_DOUBLE)
-	    size_al = ALIGN((*ptr)->size, 8);
+	    size_al = FFI_ALIGN((*ptr)->size, 8);
 
 #  if defined(POWERPC64) 
 	  FFI_ASSERT (abi != FFI_DARWIN);
@@ -352,7 +352,7 @@ darwin64_struct_size_exceeds_gprs_p (ffi_type *s, char *src, unsigned *nfpr)
       ffi_type *p = s->elements[i];
       /* Find the start of this item (0 for the first one).  */
       if (i > 0)
-        struct_offset = ALIGN(struct_offset, p->alignment);
+        struct_offset = FFI_ALIGN(struct_offset, p->alignment);
 
       item_base = src + struct_offset;
 
@@ -436,7 +436,7 @@ darwin64_pass_struct_floats (ffi_type *s, char *src,
       ffi_type *p = s->elements[i];
       /* Find the start of this item (0 for the first one).  */
       if (i > 0)
-        struct_offset = ALIGN(struct_offset, p->alignment);
+        struct_offset = FFI_ALIGN(struct_offset, p->alignment);
       item_base = src + struct_offset;
 
       switch (p->type)
@@ -527,7 +527,7 @@ darwin64_struct_floats_to_mem (ffi_type *s, char *dest, double *fprs, unsigned *
       ffi_type *p = s->elements[i];
       /* Find the start of this item (0 for the first one).  */
       if (i > 0)
-        struct_offset = ALIGN(struct_offset, p->alignment);
+        struct_offset = FFI_ALIGN(struct_offset, p->alignment);
       item_base = dest + struct_offset;
 
       switch (p->type)
@@ -604,10 +604,10 @@ darwin_adjust_aggregate_sizes (ffi_type *s)
 	align = 4;
 #endif
       /* Pad, if necessary, before adding the current item.  */
-      s->size = ALIGN(s->size, align) + p->size;
+      s->size = FFI_ALIGN(s->size, align) + p->size;
     }
   
-  s->size = ALIGN(s->size, s->alignment);
+  s->size = FFI_ALIGN(s->size, s->alignment);
   
   /* This should not be necessary on m64, but harmless.  */
   if (s->elements[0]->type == FFI_TYPE_UINT64
@@ -640,10 +640,10 @@ aix_adjust_aggregate_sizes (ffi_type *s)
       align = p->alignment;
       if (i != 0 && p->type == FFI_TYPE_DOUBLE)
 	align = 4;
-      s->size = ALIGN(s->size, align) + p->size;
+      s->size = FFI_ALIGN(s->size, align) + p->size;
     }
   
-  s->size = ALIGN(s->size, s->alignment);
+  s->size = FFI_ALIGN(s->size, s->alignment);
   
   if (s->elements[0]->type == FFI_TYPE_UINT64
       || s->elements[0]->type == FFI_TYPE_SINT64
@@ -809,9 +809,9 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 	     16-byte-aligned.  */
 	  if (fparg_count >= NUM_FPR_ARG_REGISTERS)
 #if defined (POWERPC64)
-	    intarg_count = ALIGN(intarg_count, 2);
+	    intarg_count = FFI_ALIGN(intarg_count, 2);
 #else
-	    intarg_count = ALIGN(intarg_count, 4);
+	    intarg_count = FFI_ALIGN(intarg_count, 4);
 #endif
 	  break;
 #endif
@@ -838,7 +838,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 #if defined(POWERPC_DARWIN64)
 	  align_words = (*ptr)->alignment >> 3;
 	  if (align_words)
-	    intarg_count = ALIGN(intarg_count, align_words);
+	    intarg_count = FFI_ALIGN(intarg_count, align_words);
 	  /* Base size of the struct.  */
 	  intarg_count += (size_al + 7) / 8;
 	  /* If 16 bytes then don't worry about floats.  */
@@ -848,11 +848,11 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 #else
 	  align_words = (*ptr)->alignment >> 2;
 	  if (align_words)
-	    intarg_count = ALIGN(intarg_count, align_words);
+	    intarg_count = FFI_ALIGN(intarg_count, align_words);
 	  /* If the first member of the struct is a double, then align
 	     the struct to double-word. 
 	  if ((*ptr)->elements[0]->type == FFI_TYPE_DOUBLE)
-	    size_al = ALIGN((*ptr)->size, 8); */
+	    size_al = FFI_ALIGN((*ptr)->size, 8); */
 #  ifdef POWERPC64
 	  intarg_count += (size_al + 7) / 8;
 #  else
@@ -897,7 +897,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
     bytes += NUM_GPR_ARG_REGISTERS * sizeof(long);
 
   /* The stack space allocated needs to be a multiple of 16 bytes.  */
-  bytes = ALIGN(bytes, 16) ;
+  bytes = FFI_ALIGN(bytes, 16) ;
 
   cif->flags = flags;
   cif->bytes = bytes;
@@ -1208,7 +1208,7 @@ ffi_closure_helper_DARWIN (ffi_closure *closure, void *rvalue,
 	case FFI_TYPE_STRUCT:
 	  size_al = arg_types[i]->size;
 #if defined(POWERPC_DARWIN64)
-	  pgr = (unsigned long *)ALIGN((char *)pgr, arg_types[i]->alignment);
+	  pgr = (unsigned long *)FFI_ALIGN((char *)pgr, arg_types[i]->alignment);
 	  if (size_al < 3 || size_al == 4)
 	    {
 	      avalue[i] = ((char *)pgr)+8-size_al;
@@ -1233,7 +1233,7 @@ ffi_closure_helper_DARWIN (ffi_closure *closure, void *rvalue,
 	  /* If the first member of the struct is a double, then align
 	     the struct to double-word.  */
 	  if (arg_types[i]->elements[0]->type == FFI_TYPE_DOUBLE)
-	    size_al = ALIGN(arg_types[i]->size, 8);
+	    size_al = FFI_ALIGN(arg_types[i]->size, 8);
 #  if defined(POWERPC64)
 	  FFI_ASSERT (cif->abi != FFI_DARWIN);
 	  avalue[i] = pgr;

--- a/src/powerpc/ffi_linux64.c
+++ b/src/powerpc/ffi_linux64.c
@@ -219,7 +219,7 @@ ffi_prep_cif_linux64_core (ffi_cif *cif)
 		align = 16;
 	      align = align / 8;
 	      if (align > 1)
-		intarg_count = ALIGN (intarg_count, align);
+		intarg_count = FFI_ALIGN (intarg_count, align);
 	    }
 	  intarg_count += ((*ptr)->size + 7) / 8;
 #if _CALL_ELF == 2
@@ -536,7 +536,7 @@ ffi_prep_args64 (extended_cif *ecif, unsigned long *const stack)
 	      if (align > 16)
 		align = 16;
 	      if (align > 1)
-		next_arg.p = ALIGN (next_arg.p, align);
+		next_arg.p = FFI_ALIGN (next_arg.p, align);
 	    }
 #if _CALL_ELF == 2
 	  elt = discover_homogeneous_aggregate (*ptr, &elnum);
@@ -794,7 +794,7 @@ ffi_closure_helper_LINUX64 (ffi_cif *cif,
 	      if (align > 16)
 		align = 16;
 	      if (align > 1)
-		pst = (unsigned long *) ALIGN ((size_t) pst, align);
+		pst = (unsigned long *) FFI_ALIGN ((size_t) pst, align);
 	    }
 	  elt = 0;
 #if _CALL_ELF == 2

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -29,7 +29,7 @@
 
 /* Round up to FFI_SIZEOF_ARG. */
 
-#define STACK_ARG_SIZE(x) ALIGN(x, FFI_SIZEOF_ARG)
+#define STACK_ARG_SIZE(x) FFI_ALIGN(x, FFI_SIZEOF_ARG)
 
 /* Perform machine independent initialization of aggregate type
    specifications. */
@@ -58,7 +58,7 @@ static ffi_status initialize_aggregate(ffi_type *arg, size_t *offsets)
       /* Perform a sanity check on the argument type */
       FFI_ASSERT_VALID_TYPE(*ptr);
 
-      arg->size = ALIGN(arg->size, (*ptr)->alignment);
+      arg->size = FFI_ALIGN(arg->size, (*ptr)->alignment);
       if (offsets)
 	*offsets++ = arg->size;
       arg->size += (*ptr)->size;
@@ -76,7 +76,7 @@ static ffi_status initialize_aggregate(ffi_type *arg, size_t *offsets)
      struct A { long a; char b; }; struct B { struct A x; char y; };
      should find y at an offset of 2*sizeof(long) and result in a
      total size of 3*sizeof(long).  */
-  arg->size = ALIGN (arg->size, arg->alignment);
+  arg->size = FFI_ALIGN (arg->size, arg->alignment);
 
   /* On some targets, the ABI defines that structures have an additional
      alignment beyond the "natural" one based on their elements.  */
@@ -183,7 +183,7 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
 	{
 	  /* Add any padding if necessary */
 	  if (((*ptr)->alignment - 1) & bytes)
-	    bytes = (unsigned)ALIGN(bytes, (*ptr)->alignment);
+	    bytes = (unsigned)FFI_ALIGN(bytes, (*ptr)->alignment);
 
 #ifdef TILE
 	  if (bytes < 10 * FFI_SIZEOF_ARG &&

--- a/src/raw_api.c
+++ b/src/raw_api.c
@@ -43,10 +43,10 @@ ffi_raw_size (ffi_cif *cif)
     {
 #if !FFI_NO_STRUCTS
       if ((*at)->type == FFI_TYPE_STRUCT)
-	result += ALIGN (sizeof (void*), FFI_SIZEOF_ARG);
+	result += FFI_ALIGN (sizeof (void*), FFI_SIZEOF_ARG);
       else
 #endif
-	result += ALIGN ((*at)->size, FFI_SIZEOF_ARG);
+	result += FFI_ALIGN ((*at)->size, FFI_SIZEOF_ARG);
     }
 
   return result;
@@ -98,7 +98,7 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
 	  
 	default:
 	  *args = raw;
-	  raw += ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	  raw += FFI_ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
 	}
     }
 
@@ -123,7 +123,7 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
       else
 	{
 	  *args = (void*) raw;
-	  raw += ALIGN ((*tp)->size, sizeof (void*)) / sizeof (void*);
+	  raw += FFI_ALIGN ((*tp)->size, sizeof (void*)) / sizeof (void*);
 	}
     }
 
@@ -186,7 +186,7 @@ ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw)
 
 	default:
 	  memcpy ((void*) raw->data, (void*)*args, (*tp)->size);
-	  raw += ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	  raw += FFI_ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
 	}
     }
 }

--- a/src/sparc/ffi.c
+++ b/src/sparc/ffi.c
@@ -153,7 +153,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	  /* FALLTHRU */
 
 	default:
-	  z = ALIGN(z, 4);
+	  z = FFI_ALIGN(z, 4);
 	}
       bytes += z;
     }
@@ -167,7 +167,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
   bytes += 4;
 
   /* The stack must be 2 word aligned, so round bytes up appropriately. */
-  bytes = ALIGN(bytes, 2 * 4);
+  bytes = FFI_ALIGN(bytes, 2 * 4);
 
   /* Include the call frame to prep_args.  */
   bytes += 4*16 + 4*8;
@@ -293,7 +293,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
      got to pass the return value to the callee.  Otherwise ignore it.  */
   if (rvalue == NULL
       && (cif->flags & SPARC_FLAG_RET_MASK) == SPARC_RET_STRUCT)
-    bytes += ALIGN (cif->rtype->size, 8);
+    bytes += FFI_ALIGN (cif->rtype->size, 8);
 
   ffi_call_v8(cif, fn, rvalue, avalue, -bytes, closure);
 }

--- a/src/sparc/ffi64.c
+++ b/src/sparc/ffi64.c
@@ -75,7 +75,7 @@ ffi_struct_float_mask (ffi_type *outer_type, int size_mask)
       size_t z = t->size;
       int o, m, tt;
 
-      size_mask = ALIGN(size_mask, t->alignment);
+      size_mask = FFI_ALIGN(size_mask, t->alignment);
       switch (t->type)
 	{
 	case FFI_TYPE_STRUCT:
@@ -99,7 +99,7 @@ ffi_struct_float_mask (ffi_type *outer_type, int size_mask)
       size_mask += z;
     }
 
-  size_mask = ALIGN(size_mask, outer_type->alignment);
+  size_mask = FFI_ALIGN(size_mask, outer_type->alignment);
   FFI_ASSERT ((size_mask & 0xff) == outer_type->size);
 
   return size_mask;
@@ -284,8 +284,8 @@ ffi_prep_cif_machdep_core(ffi_cif *cif)
 	  flags |= SPARC_FLAG_FP_ARGS;
 	  break;
 	}
-      bytes = ALIGN(bytes, a);
-      bytes += ALIGN(z, 8);
+      bytes = FFI_ALIGN(bytes, a);
+      bytes += FFI_ALIGN(z, 8);
     }
 
   /* Sparc call frames require that space is allocated for 6 args,
@@ -294,7 +294,7 @@ ffi_prep_cif_machdep_core(ffi_cif *cif)
     bytes = 6 * 8;
 
   /* The stack must be 2 word aligned, so round bytes up appropriately. */
-  bytes = ALIGN(bytes, 16);
+  bytes = FFI_ALIGN(bytes, 16);
 
   /* Include the call frame to prep_args.  */
   bytes += 8*16 + 8*8;
@@ -405,7 +405,7 @@ ffi_prep_args_v9(ffi_cif *cif, unsigned long *argp, void *rvalue, void **avalue)
 	  if (((unsigned long)argp & 15) && ty->alignment > 8)
 	    argp++;
 	  memcpy(argp, a, z);
-	  argp += ALIGN(z, 8) / 8;
+	  argp += FFI_ALIGN(z, 8) / 8;
 	  break;
 
 	default:
@@ -425,7 +425,7 @@ ffi_call_int(ffi_cif *cif, void (*fn)(void), void *rvalue,
   FFI_ASSERT (cif->abi == FFI_V9);
 
   if (rvalue == NULL && (cif->flags & SPARC_FLAG_RET_IN_MEM))
-    bytes += ALIGN (cif->rtype->size, 16);
+    bytes += FFI_ALIGN (cif->rtype->size, 16);
 
   ffi_call_v9(cif, fn, rvalue, avalue, -bytes, closure);
 }
@@ -547,7 +547,7 @@ ffi_closure_sparc_inner_v9(ffi_cif *cif,
 	    a = *(void **)a;
 	  else
 	    {
-	      argx = argn + ALIGN (z, 8) / 8;
+	      argx = argn + FFI_ALIGN (z, 8) / 8;
 	      if (named && argn < 16)
 		{
 		  int size_mask = ffi_struct_float_mask (ty, 0);
@@ -561,7 +561,7 @@ ffi_closure_sparc_inner_v9(ffi_cif *cif,
 	  break;
 
 	case FFI_TYPE_LONGDOUBLE:
-	  argn = ALIGN (argn, 2);
+	  argn = FFI_ALIGN (argn, 2);
 	  a = (named && argn < 16 ? fpr : gpr) + argn;
 	  argx = argn + 2;
 	  break;

--- a/src/vax/ffi.c
+++ b/src/vax/ffi.c
@@ -108,7 +108,7 @@ ffi_prep_args (extended_cif *ecif, void *stack)
 
 	  /* Align if necessary.  */
 	  if ((sizeof(int) - 1) & z)
-	    z = ALIGN(z, sizeof(int));
+	    z = FFI_ALIGN(z, sizeof(int));
 	}
 
       p_argv++;
@@ -215,7 +215,7 @@ ffi_prep_closure_elfbsd (ffi_cif *cif, void **avalue, char *stackp)
 
       /* Align if necessary */
       if ((sizeof (int) - 1) & z)
-	z = ALIGN(z, sizeof (int));
+	z = FFI_ALIGN(z, sizeof (int));
 
       p_argv++;
       stackp += z;

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -135,7 +135,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
 	      break;
 	    }
 	  /* Allocate space for return value pointer.  */
-	  bytes += ALIGN (sizeof(void*), FFI_SIZEOF_ARG);
+	  bytes += FFI_ALIGN (sizeof(void*), FFI_SIZEOF_ARG);
 	}
       break;
     case FFI_TYPE_COMPLEX:
@@ -173,10 +173,10 @@ ffi_prep_cif_machdep(ffi_cif *cif)
     {
       ffi_type *t = cif->arg_types[i];
 
-      bytes = ALIGN (bytes, t->alignment);
-      bytes += ALIGN (t->size, FFI_SIZEOF_ARG);
+      bytes = FFI_ALIGN (bytes, t->alignment);
+      bytes += FFI_ALIGN (t->size, FFI_SIZEOF_ARG);
     }
-  cif->bytes = ALIGN (bytes, 16);
+  cif->bytes = FFI_ALIGN (bytes, 16);
 
   return FFI_OK;
 }
@@ -341,7 +341,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	}
       else
 	{
-	  size_t za = ALIGN (z, FFI_SIZEOF_ARG);
+	  size_t za = FFI_ALIGN (z, FFI_SIZEOF_ARG);
 	  size_t align = FFI_SIZEOF_ARG;
 
 	  /* Alignment rules for arguments are quite complex.  Vectors and
@@ -363,7 +363,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	    }
 	  else
 	    {
-	      argp = (char *)ALIGN (argp, align);
+	      argp = (char *)FFI_ALIGN (argp, align);
 	      memcpy (argp, valp, z);
 	      argp += za;
 	    }
@@ -467,7 +467,7 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
 	}
       else
 	{
-	  size_t za = ALIGN (z, FFI_SIZEOF_ARG);
+	  size_t za = FFI_ALIGN (z, FFI_SIZEOF_ARG);
 	  size_t align = FFI_SIZEOF_ARG;
 
 	  /* See the comment in ffi_call_int.  */
@@ -483,7 +483,7 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
 	    }
 	  else
 	    {
-	      argp = (char *)ALIGN (argp, align);
+	      argp = (char *)FFI_ALIGN (argp, align);
 	      valp = argp;
 	      argp += za;
 	    }
@@ -718,7 +718,7 @@ ffi_raw_call(ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *avalue)
       else
 	{
 	  memcpy (argp, avalue, z);
-	  z = ALIGN (z, FFI_SIZEOF_ARG);
+	  z = FFI_ALIGN (z, FFI_SIZEOF_ARG);
 	  argp += z;
 	}
       avalue += z;

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -243,7 +243,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 	  {
 	    size_t num;
 
-	    byte_offset = ALIGN (byte_offset, (*ptr)->alignment);
+	    byte_offset = FFI_ALIGN (byte_offset, (*ptr)->alignment);
 
 	    num = classify_argument (*ptr, subclasses, byte_offset % 8);
 	    if (num == 0)
@@ -529,7 +529,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 	  if (align < 8)
 	    align = 8;
 
-	  bytes = ALIGN (bytes, align);
+	  bytes = FFI_ALIGN (bytes, align);
 	  bytes += cif->arg_types[i]->size;
 	}
       else
@@ -542,7 +542,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
     flags |= UNIX64_FLAG_XMM_ARGS;
 
   cif->flags = flags;
-  cif->bytes = ALIGN (bytes, 8);
+  cif->bytes = FFI_ALIGN (bytes, 8);
 
   return FFI_OK;
 }
@@ -604,7 +604,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	    align = 8;
 
 	  /* Pass this argument in memory.  */
-	  argp = (void *) ALIGN (argp, align);
+	  argp = (void *) FFI_ALIGN (argp, align);
 	  memcpy (argp, avalue[i], size);
 	  argp += size;
 	}
@@ -783,7 +783,7 @@ ffi_closure_unix64_inner(ffi_cif *cif,
 	    align = 8;
 
 	  /* Pass this argument in memory.  */
-	  argp = (void *) ALIGN (argp, align);
+	  argp = (void *) FFI_ALIGN (argp, align);
 	  avalue[i] = argp;
 	  argp += arg_types[i]->size;
 	}

--- a/src/xtensa/ffi.c
+++ b/src/xtensa/ffi.c
@@ -89,7 +89,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
   /* Round the stack up to a full 4 register frame, just in case
      (we use this size in movsp). This way, it's also a  multiple of
      8 bytes for 64-bit arguments.  */
-  cif->bytes = ALIGN(cif->bytes, 16);
+  cif->bytes = FFI_ALIGN(cif->bytes, 16);
 
   return FFI_OK;
 }
@@ -205,7 +205,7 @@ void ffi_call(ffi_cif* cif, void(*fn)(void), void *rvalue, void **avalue)
 
   if (flags == FFI_TYPE_STRUCT && (rsize <= 16 || rvalue == NULL))
   {
-    alloc = alloca(ALIGN(rsize, 4));
+    alloc = alloca(FFI_ALIGN(rsize, 4));
     ecif.rvalue = alloc;
   }
   else


### PR DESCRIPTION
Faced a conflict on Android with Android NDK r10e:
```
[armeabi-v7a] Compile arm    : test <= prep_cif.c
In file included from ./src/test/ffi/closures.c:123:0:
/opt/android-ndk-r10e/platforms/android-3/arch-arm/usr/include/sys/param.h:38:0: error: "ALIGN" redefined [-Werror]
 #define ALIGN(p)    (((unsigned int)(p) + ALIGNBYTES) &~ ALIGNBYTES)
 ^
In file included from ./src/test/ffi/closures.c:39:0:
./test/include/ffi/ffi_common.h:77:0: note: this is the location of the previous definition
 #define ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
 ^
```