### PR TITLE
__attribute__ deprecated (msg) only since gcc 4.5

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -315,7 +315,12 @@ ffi_prep_closure (ffi_closure*,
 		  ffi_cif *,
 		  void (*fun)(ffi_cif*,void*,void**,void*),
 		  void *user_data)
-  __attribute__((deprecated ("use ffi_prep_closure_loc instead")));
+#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 405)
+  __attribute__((deprecated ("use ffi_prep_closure_loc instead")))
+#elif defined(__GNUC__) && __GNUC__ >= 3
+  __attribute__((deprecated))
+#endif
+  ;
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure*,


### PR DESCRIPTION
make it work with older compilers. (in my case old cross-compilers)