### PR TITLE
Add AC_CONFIG_AUX_DIR to the configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ dnl Process this with autoconf to create configure
 AC_PREREQ(2.68)
 
 AC_INIT([libffi], [3.99999], [http://github.com/libffi/libffi/issues])
+AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_HEADERS([fficonfig.h])
 
 AC_CANONICAL_SYSTEM


### PR DESCRIPTION
Autoconf has this weird default:
> "The default is srcdir or srcdir/.. or srcdir/../.., whichever is the first that contains install-sh." (https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Input.html)
which means, running `autoreconf` on libffi, in a subfolder of another project, results in `depcomp`, `missing`, and other scripts to be installed outside of the libffi tree.