### PR TITLE
Add `configure.host` and `libtool-version` to the `EXTRA_DIST` files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST = LICENSE ChangeLog.v1 ChangeLog.libgcj			\
 	 m4/ltversion.m4 src/debug.c msvcc.sh				\
 	generate-darwin-source-and-headers.py				\
 	libffi.xcodeproj/project.pbxproj				\
-	libtool-ldflags
+	libtool-ldflags configure.host
 
 
 ## ################################################################


### PR DESCRIPTION
When running `make dist`, `configure.host` would not result in the distribution tarball, however `configure` would try to read it, and as such the tarball would not be buildable.