### PR TITLE
Add src/x86/asmnames.h to noinst_HEADERS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -113,7 +113,7 @@ noinst_HEADERS = \
 	src/sparc/ffitarget.h src/sparc/internal.h			\
 	src/tile/ffitarget.h						\
 	src/vax/ffitarget.h						\
-	src/x86/ffitarget.h src/x86/internal.h src/x86/internal64.h	\
+	src/x86/ffitarget.h src/x86/internal.h src/x86/internal64.h src/x86/asmnames.h \
 	src/xtensa/ffitarget.h						\
 	src/dlmalloc.c
 


### PR DESCRIPTION
In eaa59755fcbb692a8cb763c7f9f24a350aadbd30, macros from `unix64.S` were extracted into `asmnames.h` to be used with `win64.S` as well. As such these are required by `unix64.S`, which fails to build without them.