### PR TITLE
Ensure libffi.map is generated

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,6 @@ test -d src/$TARGETDIR || mkdir src/$TARGETDIR
 
 AC_CONFIG_LINKS(include/ffitarget.h:src/$TARGETDIR/ffitarget.h)
 
-AC_CONFIG_FILES(include/Makefile include/ffi.h Makefile testsuite/Makefile man/Makefile doc/Makefile libffi.pc)
+AC_CONFIG_FILES(include/Makefile include/ffi.h Makefile testsuite/Makefile man/Makefile doc/Makefile libffi.pc libffi.map)
 
 AC_OUTPUT


### PR DESCRIPTION
This file is necessary on Linux it seems.