### PR TITLE
arm: zext return value parameters

### DIFF
--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -419,6 +419,11 @@ ffi_prep_incoming_args_SYSV (ffi_cif *cif, void *rvalue,
       rvalue = *(void **) argp;
       argp += 4;
     }
+  else
+    {
+      if (cif->rtype->size && cif->rtype->size < 4)
+	**(int32_t **) rvalue = 0;
+    }
 
   for (i = 0, n = cif->nargs; i < n; i++)
     {


### PR DESCRIPTION
The closure function (invoked as closure->fun in ffi_closure_XXX_inner)
will only populate the actual number of bytes for the true return type,
which may be a character.  This leaves garbage on the stack when the
assembly closure function (i.e. ffi_closure_XXX) reads the return value
off of the stack into r0 as a 4-byte value.  ffi_closure_XXX always
leaves room for at least 4 bytes here, so we can safely set them to 0.
Otherwise, if there is garbage in any of these bytes, these end up in r0
and in the returned value as well.