### PR TITLE
arm: avoid a null pointer dereference

### DIFF
--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -31,6 +31,7 @@
 #include <fficonfig.h>
 #include <ffi.h>
 #include <ffi_common.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include "internal.h"
 
@@ -421,8 +422,10 @@ ffi_prep_incoming_args_SYSV (ffi_cif *cif, void *rvalue,
     }
   else
     {
+      uint32_t *p;
       if (cif->rtype->size && cif->rtype->size < 4)
-	**(int32_t **) rvalue = 0;
+	if ((p = *(uint32_t **) rvalue))
+	  *p = 0;
     }
 
   for (i = 0, n = cif->nargs; i < n; i++)


### PR DESCRIPTION
When zexting, ensure that we have a location to write to.