### PR TITLE
arm: fix a level of indirection issue

### DIFF
--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -31,6 +31,7 @@
 #include <fficonfig.h>
 #include <ffi.h>
 #include <ffi_common.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include "internal.h"
 
@@ -422,7 +423,7 @@ ffi_prep_incoming_args_SYSV (ffi_cif *cif, void *rvalue,
   else
     {
       if (cif->rtype->size && cif->rtype->size < 4)
-	**(int32_t **) rvalue = 0;
+        *(uint32_t *) rvalue = 0;
     }
 
   for (i = 0, n = cif->nargs; i < n; i++)


### PR DESCRIPTION
Rather than relying on the stack being 0'ed out always, do it manually.
The stack generally happened to be zero, and because the compiler
realizes that the tests are dealing with chars truncates the read value.
However, the top 3 nibbles of the value are undefined and may be
non-zero.  The indirection level caused a null-pointer dereference.

Explicitly scribbling on the stack during the allocation causes test
failures without the original zexting behaviour.