### PR TITLE
Makefile.am: add 'src/s390/internal.h' to source tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,7 @@ noinst_HEADERS = \
 	src/or1k/ffitarget.h						\
 	src/pa/ffitarget.h						\
 	src/powerpc/ffitarget.h src/powerpc/asm.h src/powerpc/ffi_powerpc.h \
-	src/s390/ffitarget.h						\
+	src/s390/ffitarget.h src/s390/internal.h			\
 	src/sh/ffitarget.h						\
 	src/sh64/ffitarget.h						\
 	src/sparc/ffitarget.h src/sparc/internal.h			\


### PR DESCRIPTION
commit 2f530de168e0253ac06e044c832132c496e8788b
("s390: Reorganize assembly") introduced new header
(similar to other arches) but did not add it to source
tarball.

As a result build from 'make dist' tarballs failed as:

```
../src/s390/ffi.c:34:10: fatal error: internal.h: No such file or directory
 #include "internal.h"
          ^~~~~~~~~~~~
```

To fix it the change adds file to 'Makefile.am'.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>