### PR TITLE
Linker error "recompile with -fPIC" for x86_64

### DIFF
--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -274,7 +274,7 @@ L(do_closure):
 	leaq	ffi_closure_OFS_RVALUE(%rsp), %rcx	/* Load rvalue */
 	movq	%rsp, %r8				/* Load reg_args */
 	leaq	ffi_closure_FS+8(%rsp), %r9		/* Load argp */
-	call	C(ffi_closure_unix64_inner)
+	call	PLT(C(ffi_closure_unix64_inner))
 
 	/* Deallocate stack frame early; return value is now in redzone.  */
 	addq	$ffi_closure_FS, %rsp

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -214,7 +214,7 @@ C(ffi_closure_win64):
 	movsd	%xmm3, ffi_clo_OFF_X+24(%rsp)
 
 	leaq	ffi_clo_OFF_R(%rsp), %r9
-	call	C(ffi_closure_win64_inner)
+	call	PLT(C(ffi_closure_win64_inner))
 
 	/* Load the result into both possible result registers.  */
 	movq    ffi_clo_OFF_R(%rsp), %rax


### PR DESCRIPTION
Updating calls to ffi_closure_unix64_inner and ffi_closure_win64_inner to use PLT.  Without this fix, statically linking libffi causes the linker error:

'requires dynamic R_X86_64_PC32 reloc against ffi_closure_unix64_inner which may overflow at runtime; recompile with -fPIC)'
'requires dynamic R_X86_64_PC32 reloc against 'ffi_closure_win64_inner' which may overflow at runtime; recompile with -fPIC'

Changing the calls to use PLT fixes the linker errors.