### PR TITLE
mips/n32.S: disable .set mips4 on mips r6

### DIFF
--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -47,7 +47,9 @@
 #ifdef __GNUC__
 	.abicalls
 #endif
+#if !defined(__mips_isa_rev) || (__mips_isa_rev<6)
 	.set mips4
+#endif
 	.text
 	.align	2
 	.globl	ffi_call_N32


### PR DESCRIPTION
MIPS release changed encodes of some instructions, include ll/sc etc.

if .set mips4 on mips r6, as will generate some wrong encode of some instructions.