### PR TITLE
feature: arm64 simd support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ os:
 compiler:
   - gcc
   - clang
+env:
+  - CONFIGURE_OPTIONS=--disable-shared
+  - CONFIGURE_OPTIONS=
 matrix:
   include:
     - os: linux
       compiler: gcc
       env: HOST=i386-pc-linux-gnu
-      env: CONFIGURE_OPTIONS=--disable-shared
 
 install:
   - ./.travis/install.sh

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AM_CONDITIONAL(TESTSUBDIR, test -d $srcdir/testsuite)
 
 TARGETDIR="unknown"
 HAVE_LONG_DOUBLE_VARIANT=0
+HAVE_EXT_VECTOR=0
 
 . ${srcdir}/configure.host
 
@@ -106,6 +107,7 @@ if test -z "$HAVE_LONG_DOUBLE"; then
 fi
 AC_SUBST(HAVE_LONG_DOUBLE)
 AC_SUBST(HAVE_LONG_DOUBLE_VARIANT)
+AC_SUBST(HAVE_EXT_VECTOR)
 
 AC_C_BIGENDIAN
 
@@ -191,7 +193,7 @@ fi
 
 FFI_EXEC_TRAMPOLINE_TABLE=0
 case "$target" in
-     *arm*-apple-* | aarch64-apple-*)
+     *arm*-apple-darwin* | aarch64-apple-darwin*)
        FFI_EXEC_TRAMPOLINE_TABLE=1
        AC_DEFINE(FFI_EXEC_TRAMPOLINE_TABLE, 1,
                  [Cannot use PROT_EXEC on this target, so, we revert to
@@ -202,6 +204,12 @@ case "$target" in
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])
      ;;
+esac
+
+
+case "$target" in
+     aarch64-apple-darwin*)
+       HAVE_EXT_VECTOR=1
 esac
 AM_CONDITIONAL(FFI_EXEC_TRAMPOLINE_TABLE, test x$FFI_EXEC_TRAMPOLINE_TABLE = x1)
 AC_SUBST(FFI_EXEC_TRAMPOLINE_TABLE)

--- a/configure.host
+++ b/configure.host
@@ -7,6 +7,7 @@
 # Most of the time we can define all the variables all at once...
 case "${host}" in
   aarch64*-*-*)
+  	HAVE_EXT_VECTOR=1
 	TARGET=AARCH64; TARGETDIR=aarch64
 	SOURCES="ffi.c sysv.S"
 	;;

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -40,7 +40,6 @@
 
    http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
    -------------------------------------------------------------------- */
-
 #ifndef LIBFFI_H
 #define LIBFFI_H
 
@@ -478,9 +477,18 @@ ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
 #define FFI_TYPE_STRUCT     13
 #define FFI_TYPE_POINTER    14
 #define FFI_TYPE_COMPLEX    15
+#if @HAVE_EXT_VECTOR@
+#define FFI_TYPE_EXT_VECTOR 16
+#else
+#define FFI_TYPE_EXT_VECTOR FFI_TYPE_STRUCT
+#endif
 
 /* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
+#if @HAVE_EXT_VECTOR@
+#define FFI_TYPE_LAST  FFI_TYPE_EXT_VECTOR
+#else
+#define FFI_TYPE_LAST  FFI_TYPE_COMPLEX
+#endif    
 
 #ifdef __cplusplus
 }

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -115,7 +115,7 @@ is_hfa0 (const ffi_type *ty)
 
 static size_t is_simd(const ffi_type *ty) // return 0 if no SIMD elements
 {
-    if (ty->type == FFI_TYPE_EXT_VECTOR || element_type == FFI_TYPE_COMPLEX) {
+    if (ty->type == FFI_TYPE_EXT_VECTOR || ty->type == FFI_TYPE_COMPLEX) {
         return ty->size;
     }
     ffi_type **elements = ty->elements;

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -81,6 +81,12 @@ ffi_clear_cache (void *start, void *end)
 
 #endif
 
+static int intlog2(int n) {
+  int targetlevel = 0;
+  while (n >>= 1) ++targetlevel;
+  return targetlevel;
+}
+
 /* A subroutine of is_vfp_type.  Given a structure type, return the type code
    of the first non-structure element.  Recurse for structure elements.
    Return -1 if the structure is in fact empty, i.e. no nested elements.  */
@@ -95,7 +101,7 @@ is_hfa0 (const ffi_type *ty)
     for (i = 0; elements[i]; ++i)
       {
         ret = elements[i]->type;
-        if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_COMPLEX)
+        if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_EXT_VECTOR || ret == FFI_TYPE_COMPLEX)
           {
             ret = is_hfa0 (elements[i]);
             if (ret < 0)
@@ -105,6 +111,34 @@ is_hfa0 (const ffi_type *ty)
       }
 
   return ret;
+}
+
+static size_t is_simd(const ffi_type *ty)//return 0 if no SIMD elements
+{
+    if (ty->type == FFI_TYPE_EXT_VECTOR) {
+        return ty->size;
+    }
+    ffi_type **elements = ty->elements;
+    int i, ret = -1;
+    size_t size = 0;
+    
+    if (elements != NULL)
+        for (i = 0; elements[i]; ++i)
+        {
+            ret = elements[i]->type;
+            if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_COMPLEX || ret == FFI_TYPE_EXT_VECTOR)
+            {
+                if (ret == FFI_TYPE_EXT_VECTOR)
+                {
+                    return elements[i]->size;
+                }
+                size = is_simd(elements[i]);
+            }
+            
+        }
+    
+    return size;
+    
 }
 
 /* A subroutine of is_vfp_type.  Given a structure type, return true if all
@@ -120,7 +154,7 @@ is_hfa1 (const ffi_type *ty, int candidate)
     for (i = 0; elements[i]; ++i)
       {
         int t = elements[i]->type;
-        if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX)
+        if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX || t == FFI_TYPE_EXT_VECTOR)
           {
             if (!is_hfa1 (elements[i], candidate))
               return 0;
@@ -145,7 +179,7 @@ is_vfp_type (const ffi_type *ty)
 {
   ffi_type **elements;
   int candidate, i;
-  size_t size, ele_count;
+  size_t size, ele_count, simd_size;
 
   /* Quickest tests first.  */
   candidate = ty->type;
@@ -170,6 +204,7 @@ is_vfp_type (const ffi_type *ty)
 	}
       return 0;
     case FFI_TYPE_STRUCT:
+    case FFI_TYPE_EXT_VECTOR:
       break;
     }
 
@@ -181,7 +216,9 @@ is_vfp_type (const ffi_type *ty)
   /* Find the type of the first non-structure member.  */
   elements = ty->elements;
   candidate = elements[0]->type;
-  if (candidate == FFI_TYPE_STRUCT || candidate == FFI_TYPE_COMPLEX)
+  /* Find the size of the SIMD member, if any */
+  simd_size = is_simd(ty);
+  if (candidate == FFI_TYPE_STRUCT || candidate == FFI_TYPE_COMPLEX || candidate == FFI_TYPE_EXT_VECTOR)
     {
       for (i = 0; ; ++i)
         {
@@ -213,14 +250,14 @@ is_vfp_type (const ffi_type *ty)
     default:
       return 0;
     }
-  if (ele_count > 4)
+  if ((ele_count > 4 && !simd_size) || (simd_size && ele_count > 16))
     return 0;
 
   /* Finally, make sure that all scalar elements are the same type.  */
   for (i = 0; elements[i]; ++i)
     {
       int t = elements[i]->type;
-      if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX)
+      if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX || t == FFI_TYPE_EXT_VECTOR)
         {
           if (!is_hfa1 (elements[i], candidate))
             return 0;
@@ -230,8 +267,19 @@ is_vfp_type (const ffi_type *ty)
     }
 
   /* All tests succeeded.  Encode the result.  */
- done:
-  return candidate * 4 + (4 - (int)ele_count);
+    if (simd_size) {
+        size_t regSize = simd_size;
+        if (candidate == elements[0]->type) {
+            regSize = ty->size;
+        }
+        
+        int num_registers = (int) size / regSize + (size % regSize ? 1 : 0);
+        int first_level_element_type = FFI_TYPE_FLOAT + intlog2((int)regSize) - 2;
+        return (int) (first_level_element_type * 4 + (4 - num_registers));
+    }
+   
+  done:
+    return candidate * 4 + (4 - (int)ele_count);
 }
 
 /* Representation of the procedure call argument marshalling
@@ -518,6 +566,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
     case FFI_TYPE_DOUBLE:
     case FFI_TYPE_LONGDOUBLE:
     case FFI_TYPE_STRUCT:
+    case FFI_TYPE_EXT_VECTOR:
     case FFI_TYPE_COMPLEX:
       flags = is_vfp_type (rtype);
       if (flags == 0)
@@ -665,6 +714,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 	case FFI_TYPE_DOUBLE:
 	case FFI_TYPE_LONGDOUBLE:
 	case FFI_TYPE_STRUCT:
+    case FFI_TYPE_EXT_VECTOR:
 	case FFI_TYPE_COMPLEX:
 	  {
 	    h = is_vfp_type (ty);
@@ -759,6 +809,241 @@ ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
 
 extern void ffi_closure_SYSV (void) FFI_HIDDEN;
 extern void ffi_closure_SYSV_V (void) FFI_HIDDEN;
+
+#if FFI_EXEC_TRAMPOLINE_TABLE
+
+#include <mach/mach.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *ffi_closure_trampoline_table_page;
+
+typedef struct ffi_trampoline_table ffi_trampoline_table;
+typedef struct ffi_trampoline_table_entry ffi_trampoline_table_entry;
+
+struct ffi_trampoline_table
+{
+  /* contiguous writable and executable pages */
+  vm_address_t config_page;
+  vm_address_t trampoline_page;
+
+  /* free list tracking */
+  uint16_t free_count;
+  ffi_trampoline_table_entry *free_list;
+  ffi_trampoline_table_entry *free_list_pool;
+
+  ffi_trampoline_table *prev;
+  ffi_trampoline_table *next;
+};
+
+struct ffi_trampoline_table_entry
+{
+  void *(*trampoline) ();
+  ffi_trampoline_table_entry *next;
+};
+
+/* The trampoline configuration is placed a page prior to the trampoline's entry point */
+#define FFI_TRAMPOLINE_CODELOC_CONFIG(codeloc) ((void **) (((uint8_t *) codeloc) - PAGE_SIZE));
+
+/* Total number of trampolines that fit in one trampoline table */
+#define FFI_TRAMPOLINE_COUNT (PAGE_SIZE / FFI_TRAMPOLINE_SIZE)
+
+static pthread_mutex_t ffi_trampoline_lock = PTHREAD_MUTEX_INITIALIZER;
+static ffi_trampoline_table *ffi_trampoline_tables = NULL;
+
+static ffi_trampoline_table *
+ffi_trampoline_table_alloc ()
+{
+  ffi_trampoline_table *table = NULL;
+
+  /* Loop until we can allocate two contiguous pages */
+  while (table == NULL)
+    {
+      vm_address_t config_page = 0x0;
+      kern_return_t kt;
+
+      /* Try to allocate two pages */
+      kt =
+  vm_allocate (mach_task_self (), &config_page, PAGE_SIZE * 2,
+         VM_FLAGS_ANYWHERE);
+      if (kt != KERN_SUCCESS)
+  {
+    fprintf (stderr, "vm_allocate() failure: %d at %s:%d\n", kt,
+       __FILE__, __LINE__);
+    break;
+  }
+
+      /* Now drop the second half of the allocation to make room for the trampoline table */
+      vm_address_t trampoline_page = config_page + PAGE_SIZE;
+      kt = vm_deallocate (mach_task_self (), trampoline_page, PAGE_SIZE);
+      if (kt != KERN_SUCCESS)
+  {
+    fprintf (stderr, "vm_deallocate() failure: %d at %s:%d\n", kt,
+       __FILE__, __LINE__);
+    break;
+  }
+
+      /* Remap the trampoline table to directly follow the config page */
+      vm_prot_t cur_prot;
+      vm_prot_t max_prot;
+
+      kt =
+  vm_remap (mach_task_self (), &trampoline_page, PAGE_SIZE, 0x0, FALSE,
+      mach_task_self (),
+      (vm_address_t) & ffi_closure_trampoline_table_page, FALSE,
+      &cur_prot, &max_prot, VM_INHERIT_SHARE);
+
+      /* If we lost access to the destination trampoline page, drop our config allocation mapping and retry */
+      if (kt != KERN_SUCCESS)
+  {
+    /* Log unexpected failures */
+    if (kt != KERN_NO_SPACE)
+      {
+        fprintf (stderr, "vm_remap() failure: %d at %s:%d\n", kt,
+           __FILE__, __LINE__);
+      }
+
+    vm_deallocate (mach_task_self (), config_page, PAGE_SIZE);
+    continue;
+  }
+
+      /* We have valid trampoline and config pages */
+      table = calloc (1, sizeof (ffi_trampoline_table));
+      table->free_count = FFI_TRAMPOLINE_COUNT;
+      table->config_page = config_page;
+      table->trampoline_page = trampoline_page;
+
+      /* Create and initialize the free list */
+      table->free_list_pool =
+  calloc (FFI_TRAMPOLINE_COUNT, sizeof (ffi_trampoline_table_entry));
+
+      uint16_t i;
+      for (i = 0; i < table->free_count; i++)
+  {
+    ffi_trampoline_table_entry *entry = &table->free_list_pool[i];
+    entry->trampoline =
+      (void *) (table->trampoline_page + (i * FFI_TRAMPOLINE_SIZE));
+
+    if (i < table->free_count - 1)
+      entry->next = &table->free_list_pool[i + 1];
+  }
+
+      table->free_list = table->free_list_pool;
+    }
+
+  return table;
+}
+
+void *
+ffi_closure_alloc (size_t size, void **code)
+{
+  /* Create the closure */
+  ffi_closure *closure = malloc (size);
+  if (closure == NULL)
+    return NULL;
+
+  pthread_mutex_lock (&ffi_trampoline_lock);
+
+  /* Check for an active trampoline table with available entries. */
+  ffi_trampoline_table *table = ffi_trampoline_tables;
+  if (table == NULL || table->free_list == NULL)
+    {
+      table = ffi_trampoline_table_alloc ();
+      if (table == NULL)
+  {
+    free (closure);
+    return NULL;
+  }
+
+      /* Insert the new table at the top of the list */
+      table->next = ffi_trampoline_tables;
+      if (table->next != NULL)
+  table->next->prev = table;
+
+      ffi_trampoline_tables = table;
+    }
+
+  /* Claim the free entry */
+  ffi_trampoline_table_entry *entry = ffi_trampoline_tables->free_list;
+  ffi_trampoline_tables->free_list = entry->next;
+  ffi_trampoline_tables->free_count--;
+  entry->next = NULL;
+
+  pthread_mutex_unlock (&ffi_trampoline_lock);
+
+  /* Initialize the return values */
+  *code = entry->trampoline;
+  closure->trampoline_table = table;
+  closure->trampoline_table_entry = entry;
+
+  return closure;
+}
+
+void
+ffi_closure_free (void *ptr)
+{
+  ffi_closure *closure = ptr;
+
+  pthread_mutex_lock (&ffi_trampoline_lock);
+
+  /* Fetch the table and entry references */
+  ffi_trampoline_table *table = closure->trampoline_table;
+  ffi_trampoline_table_entry *entry = closure->trampoline_table_entry;
+
+  /* Return the entry to the free list */
+  entry->next = table->free_list;
+  table->free_list = entry;
+  table->free_count++;
+
+  /* If all trampolines within this table are free, and at least one other table exists, deallocate
+   * the table */
+  if (table->free_count == FFI_TRAMPOLINE_COUNT
+      && ffi_trampoline_tables != table)
+    {
+      /* Remove from the list */
+      if (table->prev != NULL)
+  table->prev->next = table->next;
+
+      if (table->next != NULL)
+  table->next->prev = table->prev;
+
+      /* Deallocate pages */
+      kern_return_t kt;
+      kt = vm_deallocate (mach_task_self (), table->config_page, PAGE_SIZE);
+      if (kt != KERN_SUCCESS)
+  fprintf (stderr, "vm_deallocate() failure: %d at %s:%d\n", kt,
+     __FILE__, __LINE__);
+
+      kt =
+  vm_deallocate (mach_task_self (), table->trampoline_page, PAGE_SIZE);
+      if (kt != KERN_SUCCESS)
+  fprintf (stderr, "vm_deallocate() failure: %d at %s:%d\n", kt,
+     __FILE__, __LINE__);
+
+      /* Deallocate free list */
+      free (table->free_list_pool);
+      free (table);
+    }
+  else if (ffi_trampoline_tables != table)
+    {
+      /* Otherwise, bump this table to the top of the list */
+      table->prev = NULL;
+      table->next = ffi_trampoline_tables;
+      if (ffi_trampoline_tables != NULL)
+  ffi_trampoline_tables->prev = table;
+
+      ffi_trampoline_tables = table;
+    }
+
+  pthread_mutex_unlock (&ffi_trampoline_lock);
+
+  /* Free the closure */
+  free (closure);
+}
+
+#endif
+
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure *closure,
@@ -889,6 +1174,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 	case FFI_TYPE_DOUBLE:
 	case FFI_TYPE_LONGDOUBLE:
 	case FFI_TYPE_STRUCT:
+    case FFI_TYPE_EXT_VECTOR:
 	case FFI_TYPE_COMPLEX:
 	  h = is_vfp_type (ty);
 	  if (h)

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -113,31 +113,27 @@ is_hfa0 (const ffi_type *ty)
   return ret;
 }
 
-static size_t is_simd(const ffi_type *ty)//return 0 if no SIMD elements
+static size_t is_simd(const ffi_type *ty) // return 0 if no SIMD elements
 {
-    if (ty->type == FFI_TYPE_EXT_VECTOR) {
+    if (ty->type == FFI_TYPE_EXT_VECTOR || element_type == FFI_TYPE_COMPLEX) {
         return ty->size;
     }
     ffi_type **elements = ty->elements;
-    int i, ret = -1;
-    size_t size = 0;
+    int i;
     
     if (elements != NULL)
+    {
         for (i = 0; elements[i]; ++i)
         {
-            ret = elements[i]->type;
-            if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_COMPLEX || ret == FFI_TYPE_EXT_VECTOR)
+            int element_type = elements[i]->type;
+            if (element_type == FFI_TYPE_STRUCT || element_type == FFI_TYPE_COMPLEX || element_type == FFI_TYPE_EXT_VECTOR)
             {
-                if (ret == FFI_TYPE_EXT_VECTOR)
-                {
-                    return elements[i]->size;
-                }
-                size = is_simd(elements[i]);
+                return is_simd(elements[i]);
             }
-            
         }
+    }
     
-    return size;
+    return 0;
     
 }
 

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -265,9 +265,6 @@ is_vfp_type (const ffi_type *ty)
   /* All tests succeeded.  Encode the result.  */
     if (simd_size) {
         size_t regSize = simd_size;
-        if (candidate == elements[0]->type) {
-            regSize = ty->size;
-        }
         
         int num_registers = (int) size / regSize + (size % regSize ? 1 : 0);
         int first_level_element_type = FFI_TYPE_FLOAT + intlog2((int)regSize) - 2;

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -149,7 +149,7 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   /* x86, x86-64 and s390 stack space allocation is handled in prep_machdep. */
 #if !defined FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION
   /* Make space for the return structure pointer */
-  if (cif->rtype->type == FFI_TYPE_STRUCT
+  if ((cif->rtype->type == FFI_TYPE_STRUCT || cif->rtype->type == FFI_TYPE_EXT_VECTOR)
 #ifdef TILE
       && (cif->rtype->size > 10 * FFI_SIZEOF_ARG)
 #endif
@@ -250,7 +250,7 @@ ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type, size_t *offsets)
 {
   if (! (abi > FFI_FIRST_ABI && abi < FFI_LAST_ABI))
     return FFI_BAD_ABI;
-  if (struct_type->type != FFI_TYPE_STRUCT)
+  if (struct_type->type != FFI_TYPE_STRUCT || struct_type->type != FFI_TYPE_EXT_VECTOR)
     return FFI_BAD_TYPEDEF;
 
 #if HAVE_LONG_DOUBLE_VARIANT

--- a/src/raw_api.c
+++ b/src/raw_api.c
@@ -42,7 +42,7 @@ ffi_raw_size (ffi_cif *cif)
   for (i = cif->nargs-1; i >= 0; i--, at++)
     {
 #if !FFI_NO_STRUCTS
-      if ((*at)->type == FFI_TYPE_STRUCT)
+      if ((*at)->type == FFI_TYPE_STRUCT || (*at)->type == FFI_TYPE_EXT_VECTOR)
 	result += FFI_ALIGN (sizeof (void*), FFI_SIZEOF_ARG);
       else
 #endif
@@ -84,6 +84,7 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
 	
 #if !FFI_NO_STRUCTS  
 	case FFI_TYPE_STRUCT:
+    case FFI_TYPE_EXT_VECTOR:
 	  *args = (raw++)->ptr;
 	  break;
 #endif
@@ -110,7 +111,7 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
   for (i = 0; i < cif->nargs; i++, tp++, args++)
     {	  
 #if !FFI_NO_STRUCTS
-      if ((*tp)->type == FFI_TYPE_STRUCT)
+      if ((*tp)->type == FFI_TYPE_STRUCT || (*tp)->type == FFI_TYPE_EXT_VECTOR)
 	{
 	  *args = (raw++)->ptr;
 	}


### PR DESCRIPTION
Current implementation of libffi doesn't handle ext_vector values properly on Aarch64. New ffi type = FFI_TYPE_EXT_VECTOR is introduced in order for ffi_call function to be able to distinguish between standard collection types (marked as FFI_TYPE_STRUCT) and ext_vector ones as ext_vector values are not being stored in general-purpose registers.