### PR TITLE
x86/win64: disable runtime stack frame checks with msvc around built assembly

### DIFF
--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -97,6 +97,14 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
   return FFI_OK;
 }
 
+/* we perform some black magic here to use some of the parent's
+ * stack frame in ff_call_win64() that breaks with the msvc compiler
+ * with the /RTCs or /GZ flags.  Disable the 'Stack frame run time
+ * error checking' for this function so we don't hit weird exceptions
+ * in debug builds */
+#if defined(_MSVC_VER)
+#pragma runtime_checks("s", off)
+#endif
 static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      void **avalue, void *closure)
@@ -161,6 +169,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 
   ffi_call_win64 (stack, frame, closure);
 }
+#if defined(_MSVC_VER)
+#pragma runtime_checks("s", restore)
+#endif
 
 void
 EFI64(ffi_call)(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)


### PR DESCRIPTION
MSVC can add runtime code that checks if a stack frame is mismanaged
however our custom assembly deliberately accesses and modifies the parent
stack frame.  Fortunately we can disable that specific check for the
function call so do that.