### PR TITLE
Various MIPS Fixes

### DIFF
--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -322,9 +322,10 @@ calc_n32_return_struct_flags(int soft_float, ffi_type *arg)
 #endif
 
 /* Perform machine dependent cif processing */
-ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
+static ffi_status ffi_prep_cif_machdep_int(ffi_cif *cif, unsigned nfixedargs)
 {
   cif->flags = 0;
+  cif->mips_nfixedargs = nfixedargs;
 
 #ifdef FFI_MIPS_O32
   /* Set the flags necessary for O32 processing.  FFI_O32_SOFT_FLOAT
@@ -333,7 +334,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 
   if (cif->rtype->type != FFI_TYPE_STRUCT && cif->abi == FFI_O32)
     {
-      if (cif->nargs > 0)
+      if (cif->nargs > 0 && cif->nargs == nfixedargs)
 	{
 	  switch ((cif->arg_types)[0]->type)
 	    {
@@ -450,7 +451,9 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
     while (count-- > 0 && arg_reg < 8)
       {
 	type = (cif->arg_types)[index]->type;
-	if (soft_float)
+
+	// Pass variadic arguments in integer registers even if they're floats
+	if (soft_float || index >= nfixedargs)
 	  {
 	    switch (type)
 	      {
@@ -476,7 +479,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
             /* Align it.  */
             arg_reg = FFI_ALIGN(arg_reg, 2);
             /* Treat it as two adjacent doubles.  */
-	    if (soft_float) 
+	    if (soft_float || index >= nfixedargs)
 	      {
 		arg_reg += 2;
 	      }
@@ -493,7 +496,7 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 
 	  case FFI_TYPE_STRUCT:
             loc = arg_reg * FFI_SIZEOF_ARG;
-	    cif->flags += calc_n32_struct_flags(soft_float,
+	    cif->flags += calc_n32_struct_flags(soft_float || index >= nfixedargs,
 						(cif->arg_types)[index],
 						&loc, &arg_reg);
 	    break;
@@ -576,6 +579,18 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 #endif
   
   return FFI_OK;
+}
+
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
+{
+    return ffi_prep_cif_machdep_int(cif, cif->nargs);
+}
+
+ffi_status ffi_prep_cif_machdep_var(ffi_cif *cif,
+                                    unsigned nfixedargs,
+                                    unsigned ntotalargs MAYBE_UNUSED)
+{
+    return ffi_prep_cif_machdep_int(cif, nfixedargs);
 }
 
 /* Low level routine for calling O32 functions */
@@ -801,7 +816,7 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
   avalue = alloca (cif->nargs * sizeof (ffi_arg));
   avaluep = alloca (cif->nargs * sizeof (ffi_arg));
 
-  seen_int = (cif->abi == FFI_O32_SOFT_FLOAT);
+  seen_int = (cif->abi == FFI_O32_SOFT_FLOAT) || (cif->mips_nfixedargs != cif->nargs);
   argn = 0;
 
   if ((cif->flags >> (FFI_FLAG_BITS * 2)) == FFI_TYPE_STRUCT)
@@ -981,7 +996,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
 	  || arg_types[i]->type == FFI_TYPE_DOUBLE
 	  || arg_types[i]->type == FFI_TYPE_LONGDOUBLE)
         {
-          argp = (argn >= 8 || soft_float) ? ar + argn : fpr + argn;
+          argp = (argn >= 8 || i >= cif->mips_nfixedargs || soft_float) ? ar + argn : fpr + argn;
           if ((arg_types[i]->type == FFI_TYPE_LONGDOUBLE) && ((unsigned)argp & (arg_types[i]->alignment-1)))
             {
               argp=(ffi_arg*)FFI_ALIGN(argp,arg_types[i]->alignment);
@@ -1050,7 +1065,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
                      it was passed in registers.  */
                   avaluep[i] = alloca(arg_types[i]->size);
                   copy_struct_N32(avaluep[i], 0, cif->abi, arg_types[i],
-                                  argn, 0, ar, fpr, soft_float);
+                                  argn, 0, ar, fpr, i >= cif->mips_nfixedargs || soft_float);
 
                   break;
                 }

--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -831,6 +831,8 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
 
   while (i < avn)
     {
+      if (arg_types[i]->alignment == 8 && (argn & 0x1))
+        argn++;
       if (i < 2 && !seen_int &&
 	  (arg_types[i]->type == FFI_TYPE_FLOAT ||
 	   arg_types[i]->type == FFI_TYPE_DOUBLE ||
@@ -845,8 +847,6 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
 	}
       else
 	{
-	  if (arg_types[i]->alignment == 8 && (argn & 0x1))
-	    argn++;
 	  switch (arg_types[i]->type)
 	    {
 	      case FFI_TYPE_SINT8:

--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -823,6 +823,7 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
     {
       rvalue = (void *)(UINT32)ar[0];
       argn = 1;
+      seen_int = 1;
     }
 
   i = 0;

--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -29,6 +29,7 @@
 #include <ffi.h>
 #include <ffi_common.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef __GNUC__
@@ -821,7 +822,7 @@ ffi_closure_mips_inner_O32 (ffi_cif *cif,
 
   if ((cif->flags >> (FFI_FLAG_BITS * 2)) == FFI_TYPE_STRUCT)
     {
-      rvalue = (void *)(UINT32)ar[0];
+      rvalue = (void *)(uintptr_t)ar[0];
       argn = 1;
       seen_int = 1;
     }
@@ -998,7 +999,7 @@ ffi_closure_mips_inner_N32 (ffi_cif *cif,
 	  || arg_types[i]->type == FFI_TYPE_LONGDOUBLE)
         {
           argp = (argn >= 8 || i >= cif->mips_nfixedargs || soft_float) ? ar + argn : fpr + argn;
-          if ((arg_types[i]->type == FFI_TYPE_LONGDOUBLE) && ((unsigned)argp & (arg_types[i]->alignment-1)))
+          if ((arg_types[i]->type == FFI_TYPE_LONGDOUBLE) && ((uintptr_t)argp & (arg_types[i]->alignment-1)))
             {
               argp=(ffi_arg*)FFI_ALIGN(argp,arg_types[i]->alignment);
               argn++;

--- a/src/mips/ffitarget.h
+++ b/src/mips/ffitarget.h
@@ -229,21 +229,15 @@ typedef enum ffi_abi {
 
 /* ---- Definitions for closures ----------------------------------------- */
 
-#if defined(FFI_MIPS_O32)
 #define FFI_CLOSURES 1
 #define FFI_GO_CLOSURES 1
-#define FFI_TRAMPOLINE_SIZE 20
-#else
-/* N32/N64. */
-# define FFI_CLOSURES 1
-#define FFI_GO_CLOSURES 1
-#if _MIPS_SIM==_ABI64
-#define FFI_TRAMPOLINE_SIZE 56
-#else
-#define FFI_TRAMPOLINE_SIZE 20
-#endif
-#endif /* FFI_MIPS_O32 */
 #define FFI_NATIVE_RAW_API 0
+
+#if defined(FFI_MIPS_O32) || (_MIPS_SIM ==_ABIN32)
+# define FFI_TRAMPOLINE_SIZE 20
+#else
+# define FFI_TRAMPOLINE_SIZE 56
+#endif
 
 #endif
 

--- a/src/mips/ffitarget.h
+++ b/src/mips/ffitarget.h
@@ -224,7 +224,8 @@ typedef enum ffi_abi {
 #endif
 } ffi_abi;
 
-#define FFI_EXTRA_CIF_FIELDS unsigned rstruct_flag
+#define FFI_EXTRA_CIF_FIELDS unsigned rstruct_flag; unsigned mips_nfixedargs
+#define FFI_TARGET_SPECIFIC_VARIADIC
 #endif /* !LIBFFI_ASM */
 
 /* ---- Definitions for closures ----------------------------------------- */


### PR DESCRIPTION
This PR contains various fixes for MIPS architectures. The first commit simplifies some #defines in `ffitarget.h` and the rest fixes some testsuite failures. More details are in the commit messages.

Note that I needed to change `FFI_EXTRA_CIF_FIELDS` to fix some variadic test failures so this will break the ABI on mips. I see that libffi 3.3 is going to bump the ABI version anyway so hopefully this is ok.

Fixes #371