### PR TITLE
xtensa-linux: dhwbi and ihi are not always available

### DIFF
--- a/src/xtensa/sysv.S
+++ b/src/xtensa/sysv.S
@@ -169,8 +169,13 @@ ENTRY(ffi_cacheflush)
 
 	entry	a1, 16
 
-1:	dhwbi	a2, 0
+1:	
+#if XCHAL_DCACHE_SIZE
+	dhwbi	a2, 0
+#endif
+#if XCHAL_ICACHE_SIZE
 	ihi	a2, 0
+#endif
 	addi	a2, a2, 4
 	blt	a2, a3, 1b
 


### PR DESCRIPTION
For the esp32 xtensa processor, data cache and instruction cache options are not enabled. 
A test on XCHAL_DCACHE_SIZE and XCHAL_ICACHE_SIZE should fix the issue. 
