### PR TITLE
build: fix subst toolexecdir, toolexeclibdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,11 +353,11 @@ AC_ARG_ENABLE(multi-os-directory,
 if test "x$GCC" = "xyes"; then
   if test -n "$with_cross_host" &&
      test x"$with_cross_host" != x"no"; then
-    toolexecdir="${exec_prefix}"/'$(target_alias)'
-    toolexeclibdir="${toolexecdir}"/lib
+    toolexecdir='${exec_prefix}'/'$(target_alias)'
+    toolexeclibdir='${toolexecdir}'/lib
   else
-    toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
-    toolexeclibdir="${libdir}"
+    toolexecdir='${libdir}'/gcc-lib/'$(target_alias)'
+    toolexeclibdir='${libdir}'
   fi
   if test x"$enable_multi_os_directory" != x"no"; then
     multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
@@ -368,7 +368,7 @@ if test "x$GCC" = "xyes"; then
   fi
   AC_SUBST(toolexecdir)
 else
-  toolexeclibdir="${libdir}"
+  toolexeclibdir='${libdir}'
 fi
 AC_SUBST(toolexeclibdir)
 


### PR DESCRIPTION
On CentOS 7.4, configure script generated by autogen.sh will output the
following values when compiling GCC source code

    toolexecdir='NONE/$(target_alias)'
    toolexeclibdir='NONE/$(target_alias)/lib'

and cause build error

    ... -o libffi.la -rpath NONE/riscv64-bs-linux-gnu/lib ...
    checking for shl_load in -ldld... libtool: link: only absolute run-paths are allowed