### PR TITLE
Fix two "return" issues in x86/ffi64.c

### DIFF
--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -678,7 +678,10 @@ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
 {
 #ifndef __ILP32__
   if (cif->abi == FFI_EFI64)
-    return ffi_call_efi64(cif, fn, rvalue, avalue);
+    {
+      ffi_call_efi64(cif, fn, rvalue, avalue);
+      return;
+    }
 #endif
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
@@ -695,7 +698,10 @@ ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
 {
 #ifndef __ILP32__
   if (cif->abi == FFI_EFI64)
-    ffi_call_go_efi64(cif, fn, rvalue, avalue, closure);
+    {
+      ffi_call_go_efi64(cif, fn, rvalue, avalue, closure);
+      return;
+    }
 #endif
   ffi_call_int (cif, fn, rvalue, avalue, closure);
 }


### PR DESCRIPTION
Issue #70 pointed out that at least one compiler didn't like:

    return ffi_call_efi64(cif, fn, rvalue, avalue);

... where the return type is "void".  This patch splits the statement
into two.

I also noticed that ffi_call_go here seems to do a double call.  I
suspect a "return" is missing here, so this patch adds it as well.