### PR TITLE
Mark sysv.S as SafeSEH compatible

### DIFF
--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -1035,6 +1035,15 @@ L(SFDE9):
 L(EFDE9):
 #endif /* !FFI_NO_RAW_API */
 
+#ifdef _WIN32
+	.def	 @feat.00;
+	.scl	3;
+	.type	0;
+	.endef
+	.globl	@feat.00
+@feat.00 = 1
+#endif
+
 #endif /* ifndef _MSC_VER */
 #endif /* ifndef __x86_64__ */
 


### PR DESCRIPTION
It contains no exception handler, so we can just emit the special
@feat.00 symbol to indicate that it's trivially SafeSEH compatible.
SafeSEH only applies to x86 and not x86-64, hence its inclusion in the
x86-specific block. See [1] for details.

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/ms680547(v=vs.85).aspx#the_.sxdata_section_