### PR TITLE
Update FFI_HIDDEN() to use .private_extern on Apple platforms and use the macro where appropriate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,11 @@ AM_CONDITIONAL(BUILD_DOCS, [test x$enable_docs = xyes])
 AH_BOTTOM([
 #ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
 #ifdef LIBFFI_ASM
+#ifdef __APPLE__
+#define FFI_HIDDEN(name) .private_extern name
+#else
 #define FFI_HIDDEN(name) .hidden name
+#endif
 #else
 #define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
 #endif

--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -85,7 +85,6 @@
 
 #define ARM_FUNC_START(name)		\
 	.globl CNAME(name);		\
-	.private_extern CNAME(name);	\
 	FFI_HIDDEN(CNAME(name));	\
 	ARM_FUNC_START_LOCAL(name)
 

--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -794,7 +794,7 @@ ENDF(C(ffi_closure_raw_THISCALL))
 # define COMDAT(X)							\
         .section __TEXT,__text,coalesced,pure_instructions;		\
         .weak_definition X;						\
-        .private_extern X
+        FFI_HIDDEN(X)
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
 # define COMDAT(X)							\
 	.section .text.X,"axG",@progbits,X,comdat;			\


### PR DESCRIPTION
Fix issue #439