### PR TITLE
hppa: avoid TEXTREL in .eh_frame section

### DIFF
--- a/src/pa/linux.S
+++ b/src/pa/linux.S
@@ -297,10 +297,18 @@ ffi_closure_pa32:
 .LSCIE1:
 	.word   0x0     ;# CIE Identifier Tag
 	.byte   0x1     ;# CIE Version
+#ifdef __PIC__
+	.ascii  "zR\0"  ;# CIE Augmentation: 'z' - data, 'R' - DW_EH_PE_... data
+#else
 	.ascii "\0"     ;# CIE Augmentation
+#endif
 	.uleb128 0x1    ;# CIE Code Alignment Factor
 	.sleb128 4      ;# CIE Data Alignment Factor
 	.byte   0x2     ;# CIE RA Column
+#ifdef __PIC__
+	.uleb128 0x1    ;# Augmentation size
+	.byte	0x1b    ;# FDE Encoding (DW_EH_PE_pcrel|DW_EH_PE_sdata4)
+#endif
 	.byte   0xc     ;# DW_CFA_def_cfa
 	.uleb128 0x1e
 	.uleb128 0x0
@@ -310,9 +318,15 @@ ffi_closure_pa32:
 	.word   .LEFDE1-.LASFDE1        ;# FDE Length
 .LASFDE1:
 	.word   .LASFDE1-.Lframe1       ;# FDE CIE offset
-	.word   .LFB1   ;# FDE initial location
+#ifdef __PIC__
+	.word	.LFB1-. ;# FDE initial location
+#else
+	.word	.LFB1   ;# FDE initial location
+#endif
 	.word   .LFE1-.LFB1     ;# FDE address range
-
+#ifdef __PIC__
+	.uleb128 0x0	;# Augmentation size: no data
+#endif
 	.byte   0x4     ;# DW_CFA_advance_loc4
 	.word   .LCFI11-.LFB1
 	.byte	0x83	;# DW_CFA_offset, column 0x3
@@ -338,8 +352,15 @@ ffi_closure_pa32:
 	.word   .LEFDE2-.LASFDE2        ;# FDE Length
 .LASFDE2:
 	.word   .LASFDE2-.Lframe1       ;# FDE CIE offset
+#ifdef __PIC__
+	.word   .LFB2-. ;# FDE initial location
+#else
 	.word   .LFB2   ;# FDE initial location
+#endif
 	.word   .LFE2-.LFB2     ;# FDE address range
+#ifdef __PIC__
+	.uleb128 0x0	;# Augmentation size: no data
+#endif
 	.byte   0x4     ;# DW_CFA_advance_loc4
 	.word   .LCFI21-.LFB2
 	.byte   0x83    ;# DW_CFA_offset, column 0x3


### PR DESCRIPTION
Before the change hand-crafted .eh_frame section contained
ABS relocation and caused TEXTREL tag to be emitted:

```
$ ./configure --host=hppa2.0-unknown-linux-gnu LDFLAGS=-Wl,-z,text
$ make
...
/usr/libexec/gcc/hppa2.0-unknown-linux-gnu/ld:
    read-only segment has dynamic relocations.
```

Link failure is caused by absolute address of FDEs
encoded into .eh_frame entries.

Fixed TEXTREL by using pcrel (instead of ABS) encoding
for absolute addresses (__PIC__ code) by adding augmentation
information ("zR" CIE type).

All tests still pass on hppa2.0. The specific tests that still pass
and exercise this code path:
    testsuite/libffi.call/unwindtest.cc
    testsuite/libffi.call/unwindtest_ffi_call.cc

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>