### PR TITLE
Fix installation location of libffi

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ MAKEOVERRIDES=
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libffi.pc
 
-toolexeclib_LTLIBRARIES = libffi.la
+lib_LTLIBRARIES = libffi.la
 noinst_LTLIBRARIES = libffi_convenience.la
 
 libffi_la_SOURCES = src/prep_cif.c src/types.c \


### PR DESCRIPTION
The libffi is currently declared as toolexeclib_LTLIBRARIES. In many
cases, toolexeclib libraries will be installed in /usr/lib, so it
doesn't make any difference.

However, with multilib toolchains, they get installed in a
subdirectory of /usr/lib/. For example, with a Sourcery CodeBench
PowerPC toolchain, if the e500mc multilib variant is used, the libffi
library gets installed in /usr/lib/te500mc/. This is due to the
following code in the configure script:

  multi_os_directory=`$CC -print-multi-os-directory`
  case $multi_os_directory in
    .) ;; # Avoid trailing /.
    *) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
  esac

Once the library is installed in /usr/lib/te500mc/, nothing works
because this installation location is inconsistent with the
installation location declared in libffi.pc.

So, instead of using this bizarre toolexeclib_LTLIBRARIES, simply use
the more standard lib_LTLIBRARIES, which ensures that the libffi
library is always installed in /usr/lib.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[unfuzz for 3.2.1]
Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
[Patch retrieved from:
https://git.buildroot.net/buildroot/tree/package/libffi/0001-Fix-installation-location-of-libffi.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>