### PR TITLE
Prefix ALIGN_DOWN macro with FFI_

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -77,7 +77,7 @@ void ffi_type_test(ffi_type *a, char *file, int line);
 /* v cast to size_t and aligned up to a multiple of a */
 #define FFI_ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
 /* v cast to size_t and aligned down to a multiple of a */
-#define ALIGN_DOWN(v, a) (((size_t) (v)) & -a)
+#define FFI_ALIGN_DOWN(v, a) (((size_t) (v)) & -a)
 
 /* Perform machine dependent cif processing */
 ffi_status ffi_prep_cif_machdep(ffi_cif *cif);

--- a/src/frv/ffi.c
+++ b/src/frv/ffi.c
@@ -107,7 +107,7 @@ void *ffi_prep_args(char *stack, extended_cif *ecif)
       count += z;
     }
 
-  return (stack + ((count > 24) ? 24 : ALIGN_DOWN(count, 8)));
+  return (stack + ((count > 24) ? 24 : FFI_ALIGN_DOWN(count, 8)));
 }
 
 /* Perform machine dependent cif processing */

--- a/src/metag/ffi.c
+++ b/src/metag/ffi.c
@@ -61,7 +61,7 @@ unsigned int ffi_prep_args(char *stack, extended_cif *ecif)
 		argp -= z;
 
 		/* Align if necessary */
-		argp = (char *) ALIGN_DOWN(ALIGN_DOWN(argp, (*p_arg)->alignment), 4);
+		argp = (char *) FFI_ALIGN_DOWN(FFI_ALIGN_DOWN(argp, (*p_arg)->alignment), 4);
 
 		if (z < sizeof(int)) {
 			z = sizeof(int);

--- a/src/moxie/ffi.c
+++ b/src/moxie/ffi.c
@@ -100,7 +100,7 @@ void *ffi_prep_args(char *stack, extended_cif *ecif)
       count += z;
     }
 
-  return (stack + ((count > 24) ? 24 : ALIGN_DOWN(count, 8)));
+  return (stack + ((count > 24) ? 24 : FFI_ALIGN_DOWN(count, 8)));
 }
 
 /* Perform machine dependent cif processing */


### PR DESCRIPTION
A while ago, a PR of mine that changes `ALIGN()` macro to `FFI_ALIGN()` got merged
```
commit c0cc9f1df9fd4c5e758470f05d0e48123f0638ae
Merge: b841ae7 bd72848
Author: Tom Tromey <tom@tromey.com>
Date:   Mon May 8 15:20:39 2017 -0600

    Merge pull request #302 from gpakosz/align-macros

    Prefix ALIGN macros with FFI_

commit bd72848c7af9302df50a7a11652c77166d17caa8
Author: Gregory Pakosz <gregory.pakosz@gmail.com>
Date:   Thu Apr 27 13:20:36 2017 +0200

    Prefix ALIGN macros with FFI_

diff --git a/include/ffi_common.h b/include/ffi_common.h
index 00eae1b..d1d9fd8 100644
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -74,7 +74,7 @@ void ffi_type_test(ffi_type *a, char *file, int line);
 #define FFI_ASSERT_VALID_TYPE(x)
 #endif

-#define ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
+#define FFI_ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)

...
```

For some reason, when I submitted it, I forgot to commit the equivalent change for the `ALIGN_DOWN()` macro. I'm sorry for that.

For the sake of regularity, here's a new PR.