### PR TITLE
Cleanup symbol exports on darwin and add architecture preprocessor checks to assist in building fat binaries (eg: i386+x86_64 on macOS or arm+aarch64 on iOS)

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -283,11 +283,13 @@ FFI_API size_t ffi_raw_size (ffi_cif *cif);
    packing, even on 64-bit machines.  I.e. on 64-bit machines longs
    and doubles are followed by an empty 64-bit word.  */
 
+#if !FFI_NATIVE_RAW_API
 FFI_API
 void ffi_java_raw_call (ffi_cif *cif,
 			void (*fn)(void),
 			void *rvalue,
 			ffi_java_raw *avalue);
+#endif
 
 FFI_API
 void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw);
@@ -414,6 +416,7 @@ ffi_prep_raw_closure_loc (ffi_raw_closure*,
 			  void *user_data,
 			  void *codeloc);
 
+#if !FFI_NATIVE_RAW_API
 FFI_API ffi_status
 ffi_prep_java_raw_closure (ffi_java_raw_closure*,
 		           ffi_cif *cif,
@@ -426,6 +429,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 			       void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
 			       void *user_data,
 			       void *codeloc);
+#endif
 
 #endif /* FFI_CLOSURES */
 

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -19,6 +19,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#ifdef __arm64__
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -939,3 +940,5 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 
   return flags;
 }
+
+#endif /* __arm64__ */

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -454,7 +454,7 @@ allocate_int_to_reg_or_stack (struct call_context *context,
   return allocate_to_stack (state, stack, size, size);
 }
 
-ffi_status
+ffi_status FFI_HIDDEN
 ffi_prep_cif_machdep (ffi_cif *cif)
 {
   ffi_type *rtype = cif->rtype;
@@ -539,9 +539,9 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 
 #if defined (__APPLE__)
 /* Perform Apple-specific cif processing for variadic calls */
-ffi_status ffi_prep_cif_machdep_var(ffi_cif *cif,
-				    unsigned int nfixedargs,
-				    unsigned int ntotalargs)
+ffi_status FFI_HIDDEN
+ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned int nfixedargs,
+			 unsigned int ntotalargs)
 {
   ffi_status status = ffi_prep_cif_machdep (cif);
   cif->aarch64_nfixedargs = nfixedargs;

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -19,6 +19,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#ifdef __arm64__
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
@@ -431,6 +432,7 @@ CNAME(ffi_go_closure_SYSV):
 	.size	CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */
+#endif /* __arm64__ */
 
 #if defined __ELF__ && defined __linux__
 	.section .note.GNU-stack,"",%progbits

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -199,9 +199,9 @@ CNAME(ffi_call_SYSV):
 	cfi_endproc
 
 	.globl	CNAME(ffi_call_SYSV)
+	FFI_HIDDEN(CNAME(ffi_call_SYSV))
 #ifdef __ELF__
 	.type	CNAME(ffi_call_SYSV), #function
-	.hidden	CNAME(ffi_call_SYSV)
 	.size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
 #endif
 
@@ -238,9 +238,9 @@ CNAME(ffi_closure_SYSV_V):
 	cfi_endproc
 
 	.globl	CNAME(ffi_closure_SYSV_V)
+	FFI_HIDDEN(CNAME(ffi_closure_SYSV_V))
 #ifdef __ELF__
 	.type	CNAME(ffi_closure_SYSV_V), #function
-	.hidden	CNAME(ffi_closure_SYSV_V)
 	.size	CNAME(ffi_closure_SYSV_V), . - CNAME(ffi_closure_SYSV_V)
 #endif
 
@@ -350,9 +350,9 @@ CNAME(ffi_closure_SYSV):
 	cfi_endproc
 
 	.globl	CNAME(ffi_closure_SYSV)
+	FFI_HIDDEN(CNAME(ffi_closure_SYSV))
 #ifdef __ELF__
 	.type	CNAME(ffi_closure_SYSV), #function
-	.hidden	CNAME(ffi_closure_SYSV)
 	.size	CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
 #endif
 
@@ -370,9 +370,9 @@ CNAME(ffi_closure_trampoline_table_page):
     .endr
 
     .globl CNAME(ffi_closure_trampoline_table_page)
+    FFI_HIDDEN(CNAME(ffi_closure_trampoline_table_page))
     #ifdef __ELF__
     	.type	CNAME(ffi_closure_trampoline_table_page), #function
-    	.hidden	CNAME(ffi_closure_trampoline_table_page)
     	.size	CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
     #endif
 #endif
@@ -397,9 +397,9 @@ CNAME(ffi_go_closure_SYSV_V):
 	cfi_endproc
 
 	.globl	CNAME(ffi_go_closure_SYSV_V)
+	FFI_HIDDEN(CNAME(ffi_go_closure_SYSV_V))
 #ifdef __ELF__
 	.type	CNAME(ffi_go_closure_SYSV_V), #function
-	.hidden	CNAME(ffi_go_closure_SYSV_V)
 	.size	CNAME(ffi_go_closure_SYSV_V), . - CNAME(ffi_go_closure_SYSV_V)
 #endif
 
@@ -426,9 +426,9 @@ CNAME(ffi_go_closure_SYSV):
 	cfi_endproc
 
 	.globl	CNAME(ffi_go_closure_SYSV)
+	FFI_HIDDEN(CNAME(ffi_go_closure_SYSV))
 #ifdef __ELF__
 	.type	CNAME(ffi_go_closure_SYSV), #function
-	.hidden	CNAME(ffi_go_closure_SYSV)
 	.size	CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -210,7 +210,7 @@ ffi_prep_args_VFP (ffi_cif *cif, int flags, void *rvalue,
 }
 
 /* Perform machine dependent cif processing */
-ffi_status
+ffi_status FFI_HIDDEN
 ffi_prep_cif_machdep (ffi_cif *cif)
 {
   int flags = 0, cabi = cif->abi;
@@ -301,7 +301,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 }
 
 /* Perform machine dependent cif processing for variadic calls */
-ffi_status
+ffi_status FFI_HIDDEN
 ffi_prep_cif_machdep_var (ffi_cif * cif,
 			  unsigned int nfixedargs, unsigned int ntotalargs)
 {

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -28,6 +28,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
+#ifdef __arm__
 #include <fficonfig.h>
 #include <ffi.h>
 #include <ffi_common.h>
@@ -817,3 +818,5 @@ layout_vfp_args (ffi_cif * cif)
 	break;
     }
 }
+
+#endif /* __arm__ */

--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -25,6 +25,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
+#ifdef __arm__
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
@@ -377,6 +378,7 @@ ARM_FUNC_START(ffi_arm_trampoline)
 ARM_FUNC_END(ffi_arm_trampoline)
 
 #endif /* FFI_EXEC_TRAMPOLINE_TABLE */
+#endif /* __arm__ */
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",%progbits

--- a/src/closures.c
+++ b/src/closures.c
@@ -172,7 +172,7 @@ struct ffi_trampoline_table
 
 struct ffi_trampoline_table_entry
 {
-  void *(*trampoline) ();
+  void *(*trampoline) (void);
   ffi_trampoline_table_entry *next;
 };
 

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -29,7 +29,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
-#ifndef __x86_64__
+#ifdef __i386__
 #include <ffi.h>
 #include <ffi_common.h>
 #include <stdint.h>
@@ -751,4 +751,4 @@ ffi_raw_call(ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *avalue)
   ffi_call_i386 (frame, stack);
 }
 #endif /* !FFI_NO_RAW_API */
-#endif /* !__x86_64__ */
+#endif /* __i386__ */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -282,7 +282,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 	    /* The X86_64_SSEUP_CLASS should be always preceded by
 	       X86_64_SSE_CLASS or X86_64_SSEUP_CLASS.  */
-	    if (classes[i] == X86_64_SSEUP_CLASS
+	    if (i > 1 && classes[i] == X86_64_SSEUP_CLASS
 		&& classes[i - 1] != X86_64_SSE_CLASS
 		&& classes[i - 1] != X86_64_SSEUP_CLASS)
 	      {
@@ -293,7 +293,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 	    /*  If X86_64_X87UP_CLASS isn't preceded by X86_64_X87_CLASS,
 		everything should be passed in memory.  */
-	    if (classes[i] == X86_64_X87UP_CLASS
+	    if (i > 1 && classes[i] == X86_64_X87UP_CLASS
 		&& (classes[i - 1] != X86_64_X87_CLASS))
 	      {
 		/* The first one should never be X86_64_X87UP_CLASS.  */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -394,7 +394,7 @@ extern ffi_status
 ffi_prep_cif_machdep_efi64(ffi_cif *cif);
 #endif
 
-ffi_status
+ffi_status FFI_HIDDEN
 ffi_prep_cif_machdep (ffi_cif *cif)
 {
   int gprcount, ssecount, i, avn, ngpr, nsse;

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -25,6 +25,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
+#ifdef __x86_64__
 #include <ffi.h>
 #include <ffi_common.h>
 #include <stdlib.h>
@@ -306,3 +307,5 @@ ffi_closure_win64_inner(ffi_cif *cif,
   fun (cif, rvalue, avalue, user_data);
   return flags;
 }
+
+#endif /* __x86_64__ */

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -48,7 +48,7 @@ struct win64_call_frame
 extern void ffi_call_win64 (void *stack, struct win64_call_frame *,
 			    void *closure) FFI_HIDDEN;
 
-ffi_status
+ffi_status FFI_HIDDEN
 EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
 {
   int flags, n;

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -33,7 +33,7 @@
 #ifdef X86_WIN64
 #define EFI64(name) name
 #else
-#define EFI64(name) name##_efi64
+#define EFI64(name) FFI_HIDDEN name##_efi64
 #endif
 
 struct win64_call_frame

--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -26,7 +26,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
-#ifndef __x86_64__
+#ifdef __i386__
 #ifndef _MSC_VER
 
 #define LIBFFI_ASM	
@@ -1122,7 +1122,7 @@ L(EFDE9):
 #endif /* __APPLE__ */
 
 #endif /* ifndef _MSC_VER */
-#endif /* ifndef __x86_64__ */
+#endif /* ifdef __i386__ */
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",@progbits

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -42,6 +42,7 @@
 
 	.align	8
 	.globl	C(ffi_call_win64)
+	FFI_HIDDEN(C(ffi_call_win64))
 
 	SEH(.seh_proc ffi_call_win64)
 C(ffi_call_win64):
@@ -169,6 +170,7 @@ E(0b, FFI_TYPE_SMALL_STRUCT_4B)
 
 	.align	8
 	.globl	C(ffi_go_closure_win64)
+	FFI_HIDDEN(C(ffi_go_closure_win64))
 
 	SEH(.seh_proc ffi_go_closure_win64)
 C(ffi_go_closure_win64):
@@ -188,6 +190,7 @@ C(ffi_go_closure_win64):
 
 	.align	8
 	.globl	C(ffi_closure_win64)
+	FFI_HIDDEN(C(ffi_closure_win64))
 
 	SEH(.seh_proc ffi_closure_win64)
 C(ffi_closure_win64):

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -1,3 +1,4 @@
+#ifdef __x86_64__
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
@@ -229,6 +230,7 @@ C(ffi_closure_win64):
 
 	cfi_endproc
 	SEH(.seh_endproc)
+#endif /* __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",@progbits


### PR DESCRIPTION
These changes address some symbol visibility issues that I uncovered while comparing symbols exported from current libffi master to previous versions on macOS (i386 + x86_64) and iOS (arm + aarch64) as well as a couple other minor trivia fixes for warnings.