### PR TITLE
Fix cfi checks for old compiler

### DIFF
--- a/m4/asmcfi.m4
+++ b/m4/asmcfi.m4
@@ -2,7 +2,7 @@ AC_DEFUN([GCC_AS_CFI_PSEUDO_OP],
 [AC_CACHE_CHECK([assembler .cfi pseudo-op support],
     gcc_cv_as_cfi_pseudo_op, [
     gcc_cv_as_cfi_pseudo_op=unknown
-    AC_TRY_COMPILE([asm (".cfi_startproc\n\t.cfi_endproc");],,
+    AC_TRY_COMPILE([asm (".cfi_sections\n\t.cfi_startproc\n\t.cfi_endproc");],,
 		   [gcc_cv_as_cfi_pseudo_op=yes],
 		   [gcc_cv_as_cfi_pseudo_op=no])
  ])


### PR DESCRIPTION
cfi_sections can be unsupported when cfi_startproc
and cfi_endproc are.