### PR TITLE
Fix Win32 stdcall closure

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -177,7 +177,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       bytes = FFI_ALIGN (bytes, t->alignment);
       bytes += FFI_ALIGN (t->size, FFI_SIZEOF_ARG);
     }
-  cif->bytes = FFI_ALIGN (bytes, 16);
+  cif->bytes = FFI_ALIGN (bytes, FFI_SIZEOF_ARG);
 
   return FFI_OK;
 }

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -101,7 +101,7 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
   n += (flags == FFI_TYPE_STRUCT);
   if (n < 4)
     n = 4;
-  cif->bytes = n * 8;
+  cif->bytes = n * FFI_SIZEOF_ARG;
 
   return FFI_OK;
 }


### PR DESCRIPTION
The stack pointer has been incorrectly restored after a closure call.

The issue came up at ruby-ffi: https://github.com/ffi/ffi/issues/649

Patch by Alexander Mitin: https://github.com/libffi/libffi/issues/215#issuecomment-363731005

Fixes #215