### PR TITLE
aarch64: Flush code mapping in addition to data mapping

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -99,6 +99,10 @@ ffi_status ffi_prep_cif_core(ffi_cif *cif,
 			     ffi_type *rtype,
 			     ffi_type **atypes);
 
+/* Translate a data pointer to a code pointer.  Needed for closures on
+   some targets.  */
+void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
+
 /* Extended cif, used in callback from assembly routine */
 typedef struct
 {

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -773,6 +773,10 @@ ffi_prep_closure_loc (ffi_closure *closure,
   *(UINT64 *)(tramp + 16) = (uintptr_t)start;
 
   ffi_clear_cache(tramp, tramp + FFI_TRAMPOLINE_SIZE);
+
+  /* Also flush the cache for code mapping.  */
+  unsigned char *tramp_code = ffi_data_to_code_pointer (tramp);
+  ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
 #endif
 
   closure->cif = cif;

--- a/src/closures.c
+++ b/src/closures.c
@@ -921,6 +921,13 @@ ffi_closure_alloc (size_t size, void **code)
   return ptr;
 }
 
+void *
+ffi_data_to_code_pointer (void *data)
+{
+  msegmentptr seg = segment_holding (gm, data);
+  return add_segment_exec_offset (data, seg);
+}
+
 /* Release a chunk of memory allocated with ffi_closure_alloc.  If
    FFI_CLOSURE_FREE_CODE is nonzero, the given address can be the
    writable or the executable address given.  Otherwise, only the
@@ -958,6 +965,12 @@ void
 ffi_closure_free (void *ptr)
 {
   free (ptr);
+}
+
+void *
+ffi_data_to_code_pointer (void *data)
+{
+  return data;
 }
 
 # endif /* ! FFI_MMAP_EXEC_WRIT */


### PR DESCRIPTION
This needs a new function, ffi_data_to_code_pointer, to translate
from data pointers to code pointers.

Fixes issue #470.