### PR TITLE
aarch64: Deal with non-heap closures in ffi_prep_closure_loc (#498)

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -809,7 +809,8 @@ ffi_prep_closure_loc (ffi_closure *closure,
 
   /* Also flush the cache for code mapping.  */
   unsigned char *tramp_code = ffi_data_to_code_pointer (tramp);
-  ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
+  if (tramp_code != NULL)
+    ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
 #endif
 
   closure->cif = cif;

--- a/src/closures.c
+++ b/src/closures.c
@@ -925,6 +925,8 @@ void *
 ffi_data_to_code_pointer (void *data)
 {
   msegmentptr seg = segment_holding (gm, data);
+  if (seg == NULL)
+    return NULL;
   return add_segment_exec_offset (data, seg);
 }
 


### PR DESCRIPTION
ffi_prep_closure_loc can be called with pointers not allocated using
ffi_closure_alloc.  In this case, we cannot find the code alias
mapping, and the code cache cannot be flushed.

Fixes issue #498.