### PR TITLE
disable obsolete 32-bit targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ tested:
 | X86             | Interix          | GCC                     |
 | X86             | kFreeBSD         | GCC                     |
 | X86             | Linux            | GCC                     |
-| X86             | Mac OSX          | GCC                     |
 | X86             | OpenBSD          | GCC                     |
 | X86             | OS/2             | GCC                     |
 | X86             | Solaris          | GCC                     |

--- a/generate-darwin-source-and-headers.py
+++ b/generate-darwin-source-and-headers.py
@@ -143,7 +143,7 @@ def build_target(platform, platform_headers):
     mkdir_p(build_dir)
     env = dict(CC=xcrun_cmd('clang'),
                LD=xcrun_cmd('ld'),
-               CFLAGS='%s' % (platform.version_min))
+               CFLAGS='%s -fembed-bitcode' % (platform.version_min))
     working_dir = os.getcwd()
     try:
         os.chdir(build_dir)
@@ -173,7 +173,7 @@ def generate_source_and_headers(generate_osx=True, generate_ios=True):
         copy_src_platform_files(device_platform)
         copy_src_platform_files(device64_platform)
     if generate_osx:
-        copy_src_platform_files(desktop32_platform)
+#        copy_src_platform_files(desktop32_platform)
         copy_src_platform_files(desktop64_platform)
 
     platform_headers = collections.defaultdict(set)
@@ -184,7 +184,7 @@ def generate_source_and_headers(generate_osx=True, generate_ios=True):
         build_target(device_platform, platform_headers)
         build_target(device64_platform, platform_headers)
     if generate_osx:
-        build_target(desktop32_platform, platform_headers)
+#        build_target(desktop32_platform, platform_headers)
         build_target(desktop64_platform, platform_headers)
 
     mkdir_p('darwin_common/include')


### PR DESCRIPTION
Under Mojave it is not possible any more to compile for 386 architecture. In Cataline it won't be even possible to run 386 applications.
For this reason the 32-bit version of the iOS simulator and macOS library has been put into comments.