### PR TITLE
Adding oss-fuzz to libffi

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,12 @@ if FFI_DEBUG
 libffi_la_SOURCES += src/debug.c
 endif
 
+if FFI_FUZZING
+bin_PROGRAMS = ffi_strlen_fuzzer ffi_strlen2_fuzzer
+ffi_strlen_fuzzer_SOURCES = src/fuzz/ffi_strlen_fuzzer.cpp
+ffi_strlen2_fuzzer_SOURCES = src/fuzz/ffi_strlen2_fuzzer.cpp
+endif
+
 noinst_HEADERS = \
 	src/aarch64/ffitarget.h src/aarch64/internal.h			\
 	src/alpha/ffitarget.h src/alpha/internal.h			\

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,13 @@ AX_ENABLE_BUILDDIR
 
 AM_INIT_AUTOMAKE
 
+dnl If CXX is Clang, add these flags to avoid compilation error.
+if test "$CXX" = "clang++"; then
+  AC_MSG_CHECKING([whether clang works])
+  CFLAGS=-Qunused-arguments
+  CXXFLAGS=-Qunused-arguments
+fi
+
 # The same as in boehm-gc and libstdc++. Have to borrow it from there.
 # We must force CC to /not/ be precious variables; otherwise
 # the wrong, non-multilib-adjusted value will be used in multilibs.
@@ -328,6 +335,16 @@ AC_ARG_ENABLE(debug,
     AC_DEFINE(FFI_DEBUG, 1, [Define this if you want extra debugging.])
   fi)
 AM_CONDITIONAL(FFI_DEBUG, test "$enable_debug" = "yes")
+
+AC_ARG_ENABLE(fuzzing,
+[  --enable-fuzzing          fuzzing],
+  if test "$enable_fuzzing" = "yes"; then
+    AC_DEFINE(FFI_FUZZING, 1, [Define this if you want fuzzing.])
+    dnl Switch to a clang++ compiler and add fuzzing related flags.
+    CFLAGS="$CFLAGS -fno-strict-aliasing"
+    CXXFLAGS="$CXXFLAGS -fno-strict-aliasing -std=c++14 -g -fsanitize=fuzzer"
+  fi)
+AM_CONDITIONAL(FFI_FUZZING, test "$enable_fuzzing" = "yes")
 
 AC_ARG_ENABLE(structs,
 [  --disable-structs       omit code for struct support],

--- a/src/fuzz/ffi_strlen2_fuzzer.cpp
+++ b/src/fuzz/ffi_strlen2_fuzzer.cpp
@@ -1,0 +1,51 @@
+/* Area:        ffi_call
+   Purpose:     Check strlen function call with additional arguments.
+   Limitations: none.
+   PR:          none.
+   Originator:  From the original ffitest.c  */
+
+/* { dg-do run } */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cstdint>
+
+#include <ffi.h>
+
+#define MAX_ARGS 256
+#define CHECK(x) (void)(!(x) ? (abort(), 1) : 0)
+
+#ifndef ABI_NUM
+#define ABI_NUM FFI_DEFAULT_ABI
+#define ABI_ATTR
+#endif
+
+static size_t ABI_ATTR my_f(char *s, float a)
+{
+    return (size_t) ((int) strlen(s) + (int) a);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size) {
+
+    ffi_cif cif;
+    ffi_type *args[MAX_ARGS];
+    void *values[MAX_ARGS];
+    ffi_arg rint;
+    const char *s;
+    float v2;
+    args[0] = &ffi_type_pointer;
+    args[1] = &ffi_type_float;
+    values[0] = (void*) &s;
+    values[1] = (void*) &v2;
+
+    /* Initialize the cif */
+    CHECK(ffi_prep_cif(&cif, ABI_NUM, 2,
+                       &ffi_type_sint, args) == FFI_OK);
+
+    s = (char *)data;
+    v2 = (float)size;
+    ffi_call(&cif, FFI_FN(my_f), &rint, values);
+
+    return 0;
+}

--- a/src/fuzz/ffi_strlen_fuzzer.cpp
+++ b/src/fuzz/ffi_strlen_fuzzer.cpp
@@ -1,0 +1,48 @@
+/* Area:	ffi_call
+   Purpose:	Check strlen function call.
+   Limitations:	none.
+   PR:		none.
+   Originator:	From the original ffitest.c  */
+
+/* { dg-do run } */
+
+#include <cstdint>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ffi.h>
+
+#define MAX_ARGS 256
+#define CHECK(x) (void)(!(x) ? (abort(), 1) : 0)
+
+#ifndef ABI_NUM
+#define ABI_NUM FFI_DEFAULT_ABI
+#define ABI_ATTR
+#endif
+
+static size_t ABI_ATTR my_strlen(char *s)
+{
+  return (strlen(s));
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, std::size_t Size) {
+  ffi_cif cif;
+  ffi_type *args[MAX_ARGS];
+  void *values[MAX_ARGS];
+  ffi_arg rint;
+  char *s;
+
+  args[0] = &ffi_type_pointer;
+  values[0] = (void*) &s;
+  
+  /* Initialize the cif */
+  CHECK(ffi_prep_cif(&cif, ABI_NUM, 1,
+		     &ffi_type_sint, args) == FFI_OK);
+  s = (char *)Data;
+  ffi_call(&cif, FFI_FN(my_strlen), &rint, values);
+  
+  return 0;
+}
+  


### PR DESCRIPTION
Adding initial changes to support oss-fuzz in libffi (Ref [#292 ](https://github.com/libffi/libffi/issues/292).

**Steps to enable fuzzing in libffi:**
git clone https://github.com/libffi/libffi.git
cd libffi
./autogen.sh
./configure CC=clang CXX=clang++ LD=clang++ --enable-fuzzing LDFLAGS=-lffi --prefix=/path/to/precompiled/libffi.so/
make 
./x86_64-pc-linux-gnu/ffi_strlen_fuzzer
or
./x86_64-pc-linux-gnu/ffi_strlen2_fuzzer

Build integration to osss-fuzz is in-progress. Please review & provide your feedback.