### PR TITLE
powerpc: fix build failure on power7 and older

### DIFF
--- a/src/powerpc/ffi_powerpc.h
+++ b/src/powerpc/ffi_powerpc.h
@@ -62,7 +62,7 @@ typedef _Float128 float128;
 #elif defined(__FLOAT128__)
 typedef __float128 float128;
 #else
-typedef __int128 float128;
+typedef char float128[16] __attribute__((aligned(16)));
 #endif
 
 void FFI_HIDDEN ffi_closure_SYSV (void);


### PR DESCRIPTION
Build failure looks as:
```
libtool: compile:  powerpc-unknown-linux-gnu-gcc \
    -O2 -mcpu=powerpc -mtune=powerpc -pipe ... -c src/powerpc/ffi.c ...
In file included from src/powerpc/ffi.c:33:
src/powerpc/ffi_powerpc.h:65:9: error: '__int128' is not supported on this target
   65 | typedef __int128 float128;
      |         ^~~~~~~~
```

The fix avoids using __int128 in favour of aligned char[16].

Closes: https://github.com/libffi/libffi/issues/531
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>