### PR TITLE
x86: Fix ffi_prep_closure_loc

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -566,7 +566,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
 
   /* jmp dest */
   tramp[9] = 0xe9;
-  *(unsigned *)(tramp + 10) = (unsigned)dest - ((unsigned)codeloc + 10);
+  *(unsigned *)(tramp + 10) = (unsigned)dest - ((unsigned)codeloc + 14);
 
   closure->cif = cif;
   closure->fun = fun;


### PR DESCRIPTION
Since FFI_TRAMPOLINE_SIZE is increased by 4 bytes to add ENDBR32, adjust
jump displacement by 4 bytes.