### PR TITLE
Update the ABI version to LIBFFI_BASE_8.0

### DIFF
--- a/libffi.map.in
+++ b/libffi.map.in
@@ -6,7 +6,7 @@
 /* These version numbers correspond to the libtool-version abi numbers,
    not to the libffi release numbers.  */
 
-LIBFFI_BASE_7.0 {
+LIBFFI_BASE_8.0 {
   global:
 	/* Exported data variables.  */
 	ffi_type_void;
@@ -38,27 +38,23 @@ LIBFFI_BASE_7.0 {
 	ffi_java_raw_to_ptrarray;
 	ffi_java_raw_size;
 
+	ffi_get_struct_offsets;
   local:
 	*;
 };
 
-LIBFFI_BASE_7.1 {
-  global:
-	ffi_get_struct_offsets;
-} LIBFFI_BASE_7.0;
-
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
-LIBFFI_COMPLEX_7.0 {
+LIBFFI_COMPLEX_8.0 {
   global:
 	/* Exported data variables.  */
 	ffi_type_complex_float;
 	ffi_type_complex_double;
 	ffi_type_complex_longdouble;
-} LIBFFI_BASE_7.0;
+} LIBFFI_BASE_8.0;
 #endif
 
 #if FFI_CLOSURES
-LIBFFI_CLOSURE_7.0 {
+LIBFFI_CLOSURE_8.0 {
   global:
 	ffi_closure_alloc;
 	ffi_closure_free;
@@ -68,13 +64,13 @@ LIBFFI_CLOSURE_7.0 {
 	ffi_prep_raw_closure_loc;
 	ffi_prep_java_raw_closure;
 	ffi_prep_java_raw_closure_loc;
-} LIBFFI_BASE_7.0;
+} LIBFFI_BASE_8.0;
 #endif
 
 #if FFI_GO_CLOSURES
-LIBFFI_GO_CLOSURE_7.0 {
+LIBFFI_GO_CLOSURE_8.0 {
   global:
 	ffi_call_go;
 	ffi_prep_go_closure;
-} LIBFFI_CLOSURE_7.0;
+} LIBFFI_CLOSURE_8.0;
 #endif


### PR DESCRIPTION
Since x86 and x86-64 FFI_TRAMPOLINE_SIZE have been increased, we must
bump the ABI version.  This fixes:

https://github.com/libffi/libffi/issues/543