### PR TITLE
Improve read-write .eh_frame check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,17 +240,11 @@ fi
 if test "x$GCC" = "xyes"; then
   AC_CACHE_CHECK([whether .eh_frame section should be read-only],
       libffi_cv_ro_eh_frame, [
-  	libffi_cv_ro_eh_frame=no
+  	libffi_cv_ro_eh_frame=yes
   	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c
   	if $CC $CFLAGS -c -fpic -fexceptions -o conftest.o conftest.c > /dev/null 2>&1; then
-	    objdump -h conftest.o > conftest.dump 2>&1
-	    libffi_eh_frame_line=`grep -n eh_frame conftest.dump | cut -d: -f 1`
-	    if test "x$libffi_eh_frame_line" != "x"; then
-	        libffi_test_line=`expr $libffi_eh_frame_line + 1`p
-	        sed -n $libffi_test_line conftest.dump > conftest.line
-	        if grep READONLY conftest.line > /dev/null; then
-	            libffi_cv_ro_eh_frame=yes
-	        fi
+	    if readelf -WS conftest.o | grep -q -n 'eh_frame .* WA'; then
+	        libffi_cv_ro_eh_frame=no
 	    fi
   	fi
   	rm -f conftest.*


### PR DESCRIPTION
llvm-objdump -h does not print BFD `SEC_*` constants like "READONLY",
so the check will consider .eh_frame writable.
clang 11 (since https://reviews.llvm.org/D73999) will error for mismatching section flags.

Use readelf -S and check "WA" instead.

-----

```
% objdump -h a.o                                                                                                                      
 ...
  6 .eh_frame     00000038  0000000000000000  0000000000000000  00000160  2**3
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA

% llvm-objdump -h a.o
...
  9 .eh_frame        00000038 0000000000000000
```