### PR TITLE
Makefile: increase compatibility with bmake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -145,7 +145,7 @@ libffi_version_info = -version-info `grep -v '^\#' $(srcdir)/libtool-version`
 
 libffi.map: $(top_srcdir)/libffi.map.in
 	$(COMPILE) -D$(TARGET) -DGENERATE_LIBFFI_MAP \
-	 -E -x assembler-with-cpp -o $@ $<
+	 -E -x assembler-with-cpp -o $@ $(top_srcdir)/libffi.map.in
 
 libffi_la_LDFLAGS = -no-undefined $(libffi_version_info) $(libffi_version_script) $(LTLDFLAGS) $(AM_LTLDFLAGS)
 libffi_la_DEPENDENCIES = $(libffi_la_LIBADD) $(libffi_version_dep)


### PR DESCRIPTION
Using [bmake-20200212](http://www.crufty.net/help/sjg/bmake.html), building because apparently bmake can't read `$<`, here's the log from my end: https://termbin.com/2ol4

Using this patch, `libffi` can be built with bmake-20200212. Log: https://termbin.com/9qb3g