### PR TITLE
Use __builtin_ffs instead of ffs

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -2371,7 +2371,7 @@ static size_t traverse_and_check(mstate m);
 
 #else /* GNUC */
 #if  USE_BUILTIN_FFS
-#define compute_bit2idx(X, I) I = ffs(X)-1
+#define compute_bit2idx(X, I) I = __builtin_ffs(X)-1
 
 #else /* USE_BUILTIN_FFS */
 #define compute_bit2idx(X, I)\


### PR DESCRIPTION
USE_BUILTIN_FFS is defined to 1 within __GNUC__, and the __builtin_ffs
function is available since GCC 3.x at least, while the ffs function
only exists on some OSes.

This fixes compilation for non-x86 mingw platforms. For x86,
USE_BUILTIN_FFS is explicitly disabled for windows targets - but
if USE_BUILTIN_FFS is enabled based on __GNUC__, it should also use
the builtin which actually is available correspondingly, not dependent
on the target OS.

This might need some post-commit cleanups, to stop disabling USE_BUILTIN_FFS  for mingw targets in src/x86/ffitarget.h.