### PR TITLE
arm: Fix the clang specific version of the assembly

### DIFF
--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -129,11 +129,11 @@ ARM_FUNC_START(ffi_call_VFP)
 
 	cmp	r3, #3			@ load only d0 if possible
 #ifdef __clang__
-	vldrle d0, [sp]
-	vldmgt sp, {d0-d7}
+	vldrle d0, [r0]
+	vldmgt r0, {d0-d7}
 #else
-	ldcle	p11, cr0, [r0]		@ vldrle d0, [sp]
-	ldcgt	p11, cr0, [r0], {16}	@ vldmgt sp, {d0-d7}
+	ldcle	p11, cr0, [r0]		@ vldrle d0, [r0]
+	ldcgt	p11, cr0, [r0], {16}	@ vldmgt r0, {d0-d7}
 #endif
 	add	r0, r0, #64		@ discard the vfp register args
 	/* FALLTHRU */


### PR DESCRIPTION
Also fix the same error in the comment for the non-clang case.
That typo there seems to have existed since the code was written
in that form, in e7f15f60e86 - and when the clang specific codepath
was added in e3d2812ce43, the typo in the comment made it into the
actual code.