### PR TITLE
ffi_powerpc.h: fix build failure with powerpc7

### DIFF
--- a/src/powerpc/ffi_powerpc.h
+++ b/src/powerpc/ffi_powerpc.h
@@ -57,7 +57,7 @@ typedef union
   double d;
 } ffi_dblfl;
 
-#if defined(__FLOAT128_TYPE__)
+#if defined(__FLOAT128_TYPE__) && defined(__HAVE_FLOAT128)
 typedef _Float128 float128;
 #elif defined(__FLOAT128__)
 typedef __float128 float128;


### PR DESCRIPTION
This is a patch pulled down from the following:
https://github.com/buildroot/buildroot/blob/78926f610b1411b03464152472fd430012deb9ac/package/libffi/0004-ffi_powerpc.h-fix-build-failure-with-powerpc7.patch

This issue is being hit on OpenBMC code when pulling the latest
libffi tag and building on a P8 ppc64le machine. I verified this
patch fixes the issue we are seeing.

Below is the original commit message:

Sicne commit 73dd43afc8a447ba98ea02e9aad4c6898dc77fb0, build on powerpc7
fails on:

In file included from ../src/powerpc/ffi.c:33:0:
../src/powerpc/ffi_powerpc.h:61:9: error: '_Float128' is not supported on this target
 typedef _Float128 float128;
         ^~~~~~~~~

Fix this build failure by checking for __HAVE_FLOAT128 before using
_Float128, as _Float128 is enabled only on specific conditions, see
output/host/powerpc64-buildroot-linux-gnu/sysroot/usr/include/bits/floatn.h:

 /* Defined to 1 if the current compiler invocation provides a
    floating-point type with the IEEE 754 binary128 format, and this glibc
    includes corresponding *f128 interfaces for it.  */
 #if defined _ARCH_PWR8 && defined __LITTLE_ENDIAN__ && (_CALL_ELF == 2) \
     && defined __FLOAT128__ && !defined __NO_LONG_DOUBLE_MATH
 # define __HAVE_FLOAT128 1
 #else
 # define __HAVE_FLOAT128 0
 #endif

Fixes:
 - http://autobuild.buildroot.org/results/5c9dd8fb3b6a128882b6250f197c80232d8a3b53

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>