### PR TITLE
Upstream local FreeBSD patches

### DIFF
--- a/configure.host
+++ b/configure.host
@@ -218,6 +218,10 @@ case "${host}" in
 	TARGET=POWERPC_FREEBSD; TARGETDIR=powerpc
 	HAVE_LONG_DOUBLE_VARIANT=1
 	;;
+  powerpcspe-*-freebsd*)
+	TARGET=POWERPC_FREEBSD; TARGETDIR=powerpc
+	CFLAGS="$CFLAGS -D__NO_FPRS__"
+	;;
   powerpc64-*-freebsd*)
 	TARGET=POWERPC; TARGETDIR=powerpc
 	;;

--- a/configure.host
+++ b/configure.host
@@ -179,7 +179,7 @@ case "${host}" in
   mips-sgi-irix5.* | mips-sgi-irix6.* | mips*-*-rtems*)
 	TARGET=MIPS; TARGETDIR=mips
 	;;
-  mips*-*linux* | mips*-*-openbsd*)
+  mips*-*linux* | mips*-*-openbsd* | mips*-*-freebsd*)
 	# Support 128-bit long double for NewABI.
 	HAVE_LONG_DOUBLE='defined(__mips64)'
 	TARGET=MIPS; TARGETDIR=mips

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -55,6 +55,11 @@ extern unsigned int ffi_arm_trampoline[3] FFI_HIDDEN;
 #endif
 #endif
 
+#if defined(__FreeBSD__) && defined(__arm__)
+#include <sys/types.h>
+#include <machine/sysarch.h>
+#endif
+
 /* Forward declares. */
 static int vfp_type_p (const ffi_type *);
 static void layout_vfp_args (ffi_cif *);
@@ -568,6 +573,16 @@ void ffi_go_closure_SYSV (void) FFI_HIDDEN;
 void ffi_go_closure_VFP (void) FFI_HIDDEN;
 
 /* the cif must already be prep'ed */
+
+#if defined(__FreeBSD__) && defined(__arm__)
+#define __clear_cache(start, end) do { \
+		struct arm_sync_icache_args ua; 		\
+								\
+		ua.addr = (uintptr_t)(start);			\
+		ua.len = (char *)(end) - (char *)start;		\
+		sysarch(ARM_SYNC_ICACHE, &ua);			\
+	} while (0);
+#endif
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure * closure,

--- a/src/mips/ffi.c
+++ b/src/mips/ffi.c
@@ -39,7 +39,9 @@
 #endif
 
 #ifndef USE__BUILTIN___CLEAR_CACHE
-#  if defined(__OpenBSD__)
+#  if defined(__FreeBSD__)
+#    include <machine/sysarch.h>
+#  elif defined(__OpenBSD__)
 #    include <mips64/sysarch.h>
 #  else
 #    include <sys/cachectl.h>
@@ -777,11 +779,13 @@ ffi_prep_closure_loc (ffi_closure *closure,
   closure->fun = fun;
   closure->user_data = user_data;
 
+#if !defined(__FreeBSD__)
 #ifdef USE__BUILTIN___CLEAR_CACHE
   __builtin___clear_cache(clear_location, clear_location + FFI_TRAMPOLINE_SIZE);
 #else
   cacheflush (clear_location, FFI_TRAMPOLINE_SIZE, ICACHE);
 #endif
+#endif /* ! __FreeBSD__ */
   return FFI_OK;
 }
 

--- a/src/mips/ffitarget.h
+++ b/src/mips/ffitarget.h
@@ -41,7 +41,7 @@
 #define _MIPS_SIM_ABI32		1
 #define _MIPS_SIM_NABI32	2
 #define _MIPS_SIM_ABI64		3
-#elif !defined(__OpenBSD__)
+#elif !defined(__OpenBSD__) && !defined(__FreeBSD__)
 # include <sgidefs.h>
 #endif
 


### PR DESCRIPTION
Hi!
Here is a set of patches that for some reason or another never were up streamed from the FreeBSD ports tree. Most of them has been in FreeBSD for quite some years.
Short summary:
* Add support for FreeBSD mips
* Add support for FreeBSD powerpcsp
* Fix abort() on arm related to __clear_cache()