### PR TITLE
Fix variadic arguments on arm64 darwin ABI

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -646,12 +646,13 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 		state.ngrn = N_X_ARG_REG;
 		/* Note that the default abi extends each argument
 		   to a full 64-bit slot, while the iOS abi allocates
-		   only enough space. */
+		   only enough space, except for variadic arguments. */
 #ifdef __APPLE__
-		memcpy(d, a, s);
-#else
-		*(ffi_arg *)d = ext;
+		if (!state.allocating_variadic)
+		  memcpy(d, a, s);
+		else
 #endif
+		  *(ffi_arg *)d = ext;
 	      }
 	  }
 	  break;


### PR DESCRIPTION
Normal arguments that spill on the stack are packed, but not variadic
arguments. This is handled correctly for their placement already, but
code generated on the callee side with va_list expects word-size
sign-extension, so we need to fill the entire word.