### PR TITLE
Only include FFI_TYPE_LONGDOUBLE case in win64*.S when it differs from FFI_TYPE_DOUBLE

### DIFF
--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -108,8 +108,10 @@ E(0b, FFI_TYPE_FLOAT)
 E(0b, FFI_TYPE_DOUBLE)
 	movsd	%xmm0, (%r8)
 	epilogue
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 E(0b, FFI_TYPE_LONGDOUBLE)
 	call	PLT(C(abort))
+#endif
 E(0b, FFI_TYPE_UINT8)
 	movzbl	%al, %eax
 	movq	%rax, (%r8)

--- a/src/x86/win64_intel.S
+++ b/src/x86/win64_intel.S
@@ -107,8 +107,10 @@ E(0b, FFI_TYPE_FLOAT)
 E(0b, FFI_TYPE_DOUBLE)
 	movsd qword ptr[r8], xmm0; movsd	%xmm0, (%r8)
 	epilogue
+#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 E(0b, FFI_TYPE_LONGDOUBLE)
 	call	PLT(C(abort))
+#endif
 E(0b, FFI_TYPE_UINT8)
 	movzx eax, al ;movzbl	%al, %eax
 	mov qword ptr[r8], rax; movq	%rax, (%r8)


### PR DESCRIPTION
Otherwise, GCC can complain about "Error: attempt to move .org backwards"