### PR TITLE
Allow to build with mingw-clang

### DIFF
--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -56,8 +56,8 @@
 
 /* Handle win32 fastcall name mangling.  */
 #ifdef X86_WIN32
-# define ffi_call_i386		@ffi_call_i386@8
-# define ffi_closure_inner	@ffi_closure_inner@8
+# define ffi_call_i386		"@ffi_call_i386@8"
+# define ffi_closure_inner	"@ffi_closure_inner@8"
 #else
 # define ffi_call_i386		C(ffi_call_i386)
 # define ffi_closure_inner	C(ffi_closure_inner)


### PR DESCRIPTION
For some reason, compiling sysv.S with mingw-clang fails with:
```
error: invalid variant 'ffi_closure_inner@8'
```

This can be fixed (worked around?) by quoting the symbol. This works
fine with mingw-gcc too.