### PR TITLE
Don't use FFI_TYPE_LONGDOUBLE in the jump table in win64*.S

### DIFF
--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -30,7 +30,7 @@
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
 # define E(BASE, X)	.balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + X * 8
+# define E(BASE, X)	.balign 8; .org BASE + (X) * 8
 #endif
 
 	.text
@@ -108,7 +108,8 @@ E(0b, FFI_TYPE_FLOAT)
 E(0b, FFI_TYPE_DOUBLE)
 	movsd	%xmm0, (%r8)
 	epilogue
-E(0b, FFI_TYPE_LONGDOUBLE)
+// FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
+E(0b, FFI_TYPE_DOUBLE + 1)
 	call	PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
 	movzbl	%al, %eax

--- a/src/x86/win64_intel.S
+++ b/src/x86/win64_intel.S
@@ -29,7 +29,7 @@
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
 # define E(BASE, X)	ALIGN 8
 #else
-# define E(BASE, X)	ALIGN 8; ORG BASE + X * 8
+# define E(BASE, X)	ALIGN 8; ORG BASE + (X) * 8
 #endif
 
 	.CODE
@@ -107,7 +107,8 @@ E(0b, FFI_TYPE_FLOAT)
 E(0b, FFI_TYPE_DOUBLE)
 	movsd qword ptr[r8], xmm0; movsd	%xmm0, (%r8)
 	epilogue
-E(0b, FFI_TYPE_LONGDOUBLE)
+// FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
+E(0b, FFI_TYPE_DOUBLE + 1)
 	call	PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
 	movzx eax, al ;movzbl	%al, %eax


### PR DESCRIPTION
It may have the same value as FFI_TYPE_DOUBLE per ffi.h, which
possibly can make things go wrong with .org/ORG.

For instance, GCC complains about "Error: attempt to move .org
backwards"