### PR TITLE
Add support for powerpc64le-*-freebsd*.

### DIFF
--- a/configure.host
+++ b/configure.host
@@ -222,7 +222,7 @@ case "${host}" in
 	TARGET=POWERPC_FREEBSD; TARGETDIR=powerpc
 	CFLAGS="$CFLAGS -D__NO_FPRS__"
 	;;
-  powerpc64-*-freebsd*)
+  powerpc64-*-freebsd* | powerpc64le-*-freebsd*)
 	TARGET=POWERPC; TARGETDIR=powerpc
 	;;
   powerpc*-*-rtems*)


### PR DESCRIPTION
Tests pass with no additional changes needed, tested on hardware.

Fun fact: The tests were run on the first machine that has ever booted a FreeBSD PowerPC64LE kernel on hardware.

```
root@crow:~/devel/libffi # gmake check
MAKE crow.east.rtk0.net :        1 * check
gmake[1]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0'
Making check in include
gmake[2]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/include'
gmake[2]: Nothing to be done for 'check'.
gmake[2]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/include'
Making check in testsuite
gmake[2]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/testsuite'
gmake  check-DEJAGNU
gmake[3]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/testsuite'
srcdir='../../testsuite'; export srcdir; \
EXPECT=expect; export EXPECT; \
if /bin/sh -c "runtest --version" > /dev/null 2>&1; then \
  exit_status=0; l='libffi'; for tool in $l; do \
    if runtest --tool $tool --srcdir $srcdir  ; \
    then :; else exit_status=1; fi; \
  done; \
else echo "WARNING: could not find 'runtest'" 1>&2; :;\
fi; \
exit $exit_status
WARNING: Couldn't find the global config file.
Using ../../testsuite/lib/libffi.exp as tool init file.
Test run by root on Fri Aug 28 12:44:37 2020
Native configuration is powerpc64le-unknown-freebsd13.0

		=== libffi tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/local/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/local/share/dejagnu/config/unix.exp as generic interface file for target.
Using ../../testsuite/config/default.exp as tool-and-target-specific interface file.
Running ../../testsuite/libffi.bhaible/bhaible.exp ...
Running ../../testsuite/libffi.call/call.exp ...
Running ../../testsuite/libffi.closures/closure.exp ...
Running ../../testsuite/libffi.complex/complex.exp ...
Running ../../testsuite/libffi.go/go.exp ...

		=== libffi Summary ===

# of expected passes		544
# of unsupported tests		206
gmake[3]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/testsuite'
gmake[2]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/testsuite'
Making check in man
gmake[2]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/man'
gmake[2]: Nothing to be done for 'check'.
gmake[2]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/man'
Making check in doc
gmake[2]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/doc'
gmake[2]: Nothing to be done for 'check'.
gmake[2]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0/doc'
gmake[2]: Entering directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0'
gmake[2]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0'
gmake[1]: Leaving directory '/root/devel/libffi/powerpc64le-unknown-freebsd13.0'
```