### PR TITLE
darwin powerpc: use go closures only if enabled

### DIFF
--- a/src/powerpc/ffi_darwin.c
+++ b/src/powerpc/ffi_darwin.c
@@ -33,7 +33,10 @@
 #include <stdlib.h>
 
 extern void ffi_closure_ASM (void);
+
+#if defined (FFI_GO_CLOSURES)
 extern void ffi_go_closure_ASM (void);
+#endif
 
 enum {
   /* The assembly depends on these exact flags.  
@@ -909,8 +912,10 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 extern void ffi_call_AIX(extended_cif *, long, unsigned, unsigned *,
 			 void (*fn)(void), void (*fn2)(void));
 
+#if defined (FFI_GO_CLOSURES)
 extern void ffi_call_go_AIX(extended_cif *, long, unsigned, unsigned *,
 			    void (*fn)(void), void (*fn2)(void), void *closure);
+#endif
 
 extern void ffi_call_DARWIN(extended_cif *, long, unsigned, unsigned *,
 			    void (*fn)(void), void (*fn2)(void), ffi_type*);
@@ -950,6 +955,7 @@ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
     }
 }
 
+#if defined (FFI_GO_CLOSURES)
 void
 ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
 	     void *closure)
@@ -981,6 +987,7 @@ ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
       break;
     }
 }
+#endif
 
 static void flush_icache(char *);
 static void flush_range(char *, int);
@@ -1110,6 +1117,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   return FFI_OK;
 }
 
+#if defined (FFI_GO_CLOSURES)
 ffi_status
 ffi_prep_go_closure (ffi_go_closure* closure,
 		     ffi_cif* cif,
@@ -1133,6 +1141,7 @@ ffi_prep_go_closure (ffi_go_closure* closure,
     }
   return FFI_OK;
 }
+#endif
 
 static void
 flush_icache(char *addr)
@@ -1168,9 +1177,11 @@ ffi_type *
 ffi_closure_helper_DARWIN (ffi_closure *, void *,
 			   unsigned long *, ffi_dblfl *);
 
+#if defined (FFI_GO_CLOSURES)
 ffi_type *
 ffi_go_closure_helper_DARWIN (ffi_go_closure*, void *,
 			      unsigned long *, ffi_dblfl *);
+#endif
 
 /* Basically the trampoline invokes ffi_closure_ASM, and on
    entry, r11 holds the address of the closure.
@@ -1430,6 +1441,7 @@ ffi_closure_helper_DARWIN (ffi_closure *closure, void *rvalue,
 				    closure->user_data, rvalue, pgr, pfr);
 }
 
+#if defined (FFI_GO_CLOSURES)
 ffi_type *
 ffi_go_closure_helper_DARWIN (ffi_go_closure *closure, void *rvalue,
 			      unsigned long *pgr, ffi_dblfl *pfr)
@@ -1437,4 +1449,4 @@ ffi_go_closure_helper_DARWIN (ffi_go_closure *closure, void *rvalue,
   return ffi_closure_helper_common (closure->cif, closure->fun,
 				    closure, rvalue, pgr, pfr);
 }
-
+#endif


### PR DESCRIPTION
SHA: 0ff9419f2e75652426469e256cb7d0748064ad58 added go closures for darwin powerpc AIX, but
these have not yet been implemented for non-AIX systems

use the go closures only if enabled