### PR TITLE
powerpc64le: Add nop's in order to recover the TOC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,23 @@ case "$TARGET" in
 		  [Define if the compiler uses zarch features.])
     fi
     ;;
+
+  POWERPC*)
+    AC_CACHE_CHECK([assembler supports pc related relocs],
+	libffi_cv_as_ppc_pcrel, [
+	libffi_cv_as_ppc_pcrel=no
+	echo '.text; foo: bl bar@notoc; .data; .long foo-.; .text' > conftest.s
+	if $CC $CFLAGS -c conftest.s > /dev/null 2>&1; then
+	    libffi_cv_as_ppc_pcrel=yes
+	fi
+	])
+    if test "x$libffi_cv_as_ppc_pcrel" = xyes; then
+	AC_DEFINE(HAVE_AS_PPC_PCREL, 1,
+		  [Define if your assembler supports PC relative relocs.])
+    fi
+    ;;
+
+
 esac
 
 AC_CACHE_CHECK([whether compiler supports pointer authentication],

--- a/src/powerpc/asm.h
+++ b/src/powerpc/asm.h
@@ -123,3 +123,9 @@
 
 /* Local labels stripped out by the linker.  */
 #define L(x) .L##x
+
+#ifdef HAVE_AS_PPC_PCREL
+# define NOTOC(X) X@notoc
+#else
+# define NOTOC(X) X
+#endif

--- a/src/powerpc/linux64.S
+++ b/src/powerpc/linux64.S
@@ -28,6 +28,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include <powerpc/asm.h>
 
 #ifdef POWERPC64
 	.hidden	ffi_call_LINUX64
@@ -89,7 +90,7 @@ ffi_call_LINUX64:
 	/* Call ffi_prep_args64.  */
 	mr	%r4, %r1
 # if defined _CALL_LINUX || _CALL_ELF == 2
-	bl	ffi_prep_args64
+	bl	NOTOC(ffi_prep_args64)
 # else
 	bl	.ffi_prep_args64
 # endif

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -27,6 +27,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include <powerpc/asm.h>
 
 	.file	"linux64_closure.S"
 
@@ -190,7 +191,7 @@ ffi_closure_LINUX64:
 
 	# make the call
 # if defined _CALL_LINUX || _CALL_ELF == 2
-	bl ffi_closure_helper_LINUX64
+	bl NOTOC(ffi_closure_helper_LINUX64)
 # else
 	bl .ffi_closure_helper_LINUX64
 # endif


### PR DESCRIPTION
The POWER ELFv2 ABI requires a caller that uses the TOC pointer to
provide a nop immediately after calls to functions in other compilation
units.
However, if the caller doesn't use the TOC pointer a R_PPC64_REL24_NOTOC
relocation can be used instead.