### PR TITLE
Power10 libffi fixes

### DIFF
--- a/src/powerpc/linux64.S
+++ b/src/powerpc/linux64.S
@@ -36,8 +36,10 @@
 	.cfi_startproc
 # if _CALL_ELF == 2
 ffi_call_LINUX64:
+#  ifndef __PCREL__
 	addis	%r2, %r12, .TOC.-ffi_call_LINUX64@ha
 	addi	%r2, %r2, .TOC.-ffi_call_LINUX64@l
+#  endif
 	.localentry ffi_call_LINUX64, . - ffi_call_LINUX64
 # else
 	.section	".opd","aw"
@@ -89,9 +91,15 @@ ffi_call_LINUX64:
 	/* Call ffi_prep_args64.  */
 	mr	%r4, %r1
 # if defined _CALL_LINUX || _CALL_ELF == 2
+#  ifdef __PCREL__
+	bl	ffi_prep_args64@notoc
+#  else
 	bl	ffi_prep_args64
+	nop
+#  endif
 # else
 	bl	.ffi_prep_args64
+	nop
 # endif
 
 # if _CALL_ELF == 2

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -37,8 +37,10 @@
 	.cfi_startproc
 # if _CALL_ELF == 2
 ffi_closure_LINUX64:
+#  ifndef __PCREL__
 	addis	%r2, %r12, .TOC.-ffi_closure_LINUX64@ha
 	addi	%r2, %r2, .TOC.-ffi_closure_LINUX64@l
+#  endif
 	.localentry ffi_closure_LINUX64, . - ffi_closure_LINUX64
 # else
 	.section        ".opd","aw"
@@ -190,11 +192,19 @@ ffi_closure_LINUX64:
 
 	# make the call
 # if defined _CALL_LINUX || _CALL_ELF == 2
+#  ifdef __PCREL__
+	bl ffi_closure_helper_LINUX64@notoc
+.Lret:
+#  else
 	bl ffi_closure_helper_LINUX64
+.Lret:
+	nop
+#  endif
 # else
 	bl .ffi_closure_helper_LINUX64
-# endif
 .Lret:
+	nop
+# endif
 
 	# now r3 contains the return type
 	# so use it to look up in a table
@@ -460,8 +470,10 @@ ffi_closure_LINUX64:
 	.cfi_startproc
 # if _CALL_ELF == 2
 ffi_go_closure_linux64:
+#  ifndef __PCREL__
 	addis	%r2, %r12, .TOC.-ffi_go_closure_linux64@ha
 	addi	%r2, %r2, .TOC.-ffi_go_closure_linux64@l
+#  endif
 	.localentry ffi_go_closure_linux64, . - ffi_go_closure_linux64
 # else
 	.section        ".opd","aw"


### PR DESCRIPTION
Power10 pc-relative code doesn't use or preserve r2 as a TOC pointer.
That means calling between pc-relative and TOC using code can't be
done without intervening linker stubs, and a call from TOC code to
pc-relative code must have a nop after the bl in order to restore r2.

Now the PowerPC libffi assembly code doesn't use r2 except for the
implicit use when making calls back to C, ffi_closure_helper_LINUX64
and ffi_prep_args64.  So changing the assembly to interoperate with
pc-relative code without stubs is easily done.

	* src/powerpc/linux64.S (ffi_call_LINUX64): Don't emit global
	entry when __PCREL__.  Call using @notoc.  Add nops.
	* src/powerpc/linux64_closure.S (ffi_closure_LINUX64): Likewise.
	(ffi_go_closure_linux64): Likewise.