### PR TITLE
testsuite: Add a missing include of <inttypes.h> to fix build failure…

### DIFF
--- a/testsuite/libffi.closures/huge_struct.c
+++ b/testsuite/libffi.closures/huge_struct.c
@@ -9,6 +9,8 @@
 /* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
 /* { dg-options -Wformat=0 { target moxie*-*-elf or1k-*-* } } */
 
+#include <inttypes.h>
+
 #include "ffitest.h"
 
 typedef	struct BigStruct{


### PR DESCRIPTION
This is a build fix for the testsuite from Apple's libffi-27