### PR TITLE
Removing unnecessary instruction from ffi_call_unix64

### DIFF
--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -84,7 +84,6 @@ L(UW1):
 
 	movq	%rdi, %r10		/* Save a copy of the register area. */
 	movq	%r8, %r11		/* Save a copy of the target fn.  */
-	movl	%r9d, %eax		/* Set number of SSE registers.  */
 
 	/* Load up all argument registers.  */
 	movq	(%r10), %rdi
@@ -93,7 +92,7 @@ L(UW1):
 	movq	0x18(%r10), %rcx
 	movq	0x20(%r10), %r8
 	movq	0x28(%r10), %r9
-	movl	0xb0(%r10), %eax
+	movl	0xb0(%r10), %eax	/* Set number of SSE registers.  */
 	testl	%eax, %eax
 	jnz	L(load_sse)
 L(ret_from_load_sse):


### PR DESCRIPTION
`unix64.S`'s `ffi_call_unix64` looks like it used to take six parameters,
where the sixth said the number of SSE register arguments. However,
currently the function only takes five parameters, and the number of SSE
register arguments is encoded in the `struct register_args *` passed as
the first parameter to `ffi_call_unix64`. This change removes an
instruction that tries to use this missing sixth parameter as the number
of SSE arguments.

This fix should not change any behavior, nor fix any bugs, because a few
instructions later the value moved from `%r9d` into `%eax` is overwritten by
the correct value anyway. This change merely makes the code a tad less
confusing, because currently the assembly moves from a register (`r9`)
whose value is never set.

I ran `make check` and got:
```
Test run by snp on Mon Oct  5 00:37:01 2020
Native configuration is x86_64-pc-linux-gnu

		=== libffi tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
Using ../../testsuite/config/default.exp as tool-and-target-specific interface file.
Running ../../testsuite/libffi.bhaible/bhaible.exp ...
Running ../../testsuite/libffi.call/call.exp ...
Running ../../testsuite/libffi.closures/closure.exp ...
Running ../../testsuite/libffi.complex/complex.exp ...
Running ../../testsuite/libffi.go/go.exp ...

		=== libffi Summary ===

# of expected passes		2272
# of expected failures		12
```