### PR TITLE
docs: fix simple typo, paramters -> parameters

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -353,7 +353,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	  size_t align = FFI_SIZEOF_ARG;
 
 	  /* Issue 434: For thiscall and fastcall, if the paramter passed
-	     as 64-bit integer or struct, all following integer paramters
+	     as 64-bit integer or struct, all following integer parameters
 	     will be passed on stack.  */
 	  if ((cabi == FFI_THISCALL || cabi == FFI_FASTCALL)
 	      && (t == FFI_TYPE_SINT64
@@ -492,7 +492,7 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
 	    align = 16;
 
 	  /* Issue 434: For thiscall and fastcall, if the paramter passed
-	     as 64-bit integer or struct, all following integer paramters
+	     as 64-bit integer or struct, all following integer parameters
 	     will be passed on stack.  */
 	  if ((cabi == FFI_THISCALL || cabi == FFI_FASTCALL)
 	      && (t == FFI_TYPE_SINT64


### PR DESCRIPTION
There is a small typo in src/x86/ffi.c.

Should read `parameters` rather than `paramters`.

