### PR TITLE
Fix read-only .eh_frame section test when CFLAGS contains -flto.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,11 +260,13 @@ EOF
 fi
 
 if test "x$GCC" = "xyes"; then
+  AX_CHECK_COMPILE_FLAG(-fno-lto, libffi_cv_no_lto=-fno-lto)
+
   AC_CACHE_CHECK([whether .eh_frame section should be read-only],
       libffi_cv_ro_eh_frame, [
   	libffi_cv_ro_eh_frame=yes
   	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c
-  	if $CC $CFLAGS -c -fpic -fexceptions -o conftest.o conftest.c > /dev/null 2>&1; then
+  	if $CC $CFLAGS -c -fpic -fexceptions $libffi_cv_no_lto -o conftest.o conftest.c > /dev/null 2>&1; then
 	    if readelf -WS conftest.o | grep -q -n 'eh_frame .* WA'; then
 	        libffi_cv_ro_eh_frame=no
 	    fi


### PR DESCRIPTION
When `CFLAGS` contains `-flto`, the `readelf` test won't work because LTO object files don't contain ELF sections yet, so explicitly disable LTO when supported.