### PR TITLE
testsuite: fix compiler vendor detection on dash as /bin/sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ fi
 cat > local.exp <<EOF
 set CC_FOR_TARGET "$CC"
 set CXX_FOR_TARGET "$CXX"
+set compiler_vendor "$ax_cv_c_compiler_vendor"
 EOF
 
 AM_MAINTAINER_MODE

--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -292,9 +292,6 @@ proc libffi-init { args } {
     verbose "libffi $blddirffi"
 
     # Which compiler are we building with?
-    set tmp [grep "$blddirffi/config.log" "^ax_cv_c_compiler_vendor.*$"]
-    regexp -- {^[^=]*=(.*)$} $tmp nil compiler_vendor
-
     if { [string match $compiler_vendor "gnu"] } {
         set gccdir [lookfor_file $tool_root_dir gcc/libgcc.a]
         if {$gccdir != ""} {


### PR DESCRIPTION
In https://bugs.gentoo.org/753299 Paolo Pedroni reported
a single test failure out of all libffi. Here is the minimal
reproducer:

```
$ ./autogen
$ CONFIG_SHELL=/bin/dash ./configure --host=x86_64-pc-linux-gnu
$ make check RUNTESTFLAGS='complex.exp'
...
FAIL: libffi.complex/cls_align_complex_float.c (test for excess errors)
```

This happens because under 'dash' shell autoconf generates slightly
different style of string quotation in `config.log`:

- on bash: `ax_cv_c_compiler_vendor=gnu`
- on dash: `ax_cv_c_compiler_vendor='gnu'`

To avoid shell quotation parsing the change just embeds
`compiler_vendor` into `local.exp` at configure time.

Reported-by: Paolo Pedroni
Bug: https://bugs.gentoo.org/753299