### PR TITLE
Remove libtool-ldflags file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ include/ffitarget.h
 install-sh
 libffi.pc
 libtool
-libtool-ldflags
 ltmain.sh
 m4/libtool.m4
 m4/lt*.m4


### PR DESCRIPTION
The file `libtool-ldflags` seems to be used by the build system although [history suggests it may have been removed and re-added at some point](https://github.com/libffi/libffi/commit/2f44952c95765c1486fad66f57235f8d459a9748).

* Does automake create this?  If so, can it be removed entirely?  I assume not, since 2f44952c95765c1486fad66f57235f8d459a9748 suggests it's needed.
* If it can't be removed, I believe it should NOT be in the `.gitignore`.

Downstream, some odd stuff happens with line-endings for files in `.gitignore`.  It's hard to explain, so I'll quote the conversation:

```diff
- /cygdrive/c/Users/Owner/jna/native/libffi/libtool-ldflags: line 2: $'\r': command not found
```

> It's a file that `libffi/libffi` upstream explicitly has in the `.gitignore` but ships anyway.  It appears `git` ignores the `.gitattributes` for files listed in the `.gitignore`.  I assume it's an actual git bug, but it's so edge-case, I can't find any mentions of it.  Commenting this out in 95750d2 unintuitively fixes the `\r` errors which `libtool-ldflags` creates.
> 
> **Edit:** Just an FYI incase you don't know this, but `.gitignore` [only works for untracked files](https://stackoverflow.com/q/1274057), so it IS in the repository, hence the edge-case `.gitattributes` behavior.

... so with this in `.gitignore`, we can't manage this downstream.  `dos2unix` is a viable workaround, but we're [trying to remove that from our tutorials](https://github.com/java-native-access/jna/pull/1273).
