### PR TITLE
libffi/x86: Always check __x86_64__ for x32 hosts (#601)

### DIFF
--- a/configure.host
+++ b/configure.host
@@ -115,22 +115,14 @@ case "${host}" in
   i?86-*-* | x86_64-*-* | amd64-*)
 	TARGETDIR=x86
 	if test $ac_cv_sizeof_size_t = 4; then
-	  case "$host" in
-	    x86_64-*x32|x86_64-x32-*)
-	      TARGET_X32=yes
-	      TARGET=X86_64
-	      ;;
-	    *)
-	      echo 'int foo (void) { return __x86_64__; }' > conftest.c
-	      if $CC $CFLAGS -Werror -S conftest.c -o conftest.s > /dev/null 2>&1; then
-		TARGET_X32=yes
-		TARGET=X86_64
-	      else
-		TARGET=X86;
-	      fi
-	      rm -f conftest.*
-	      ;;
-          esac
+	  echo 'int foo (void) { return __x86_64__; }' > conftest.c
+	  if $CC $CFLAGS -Werror -S conftest.c -o conftest.s > /dev/null 2>&1; then
+	    TARGET_X32=yes
+	    TARGET=X86_64
+	  else
+	    TARGET=X86;
+	  fi
+	  rm -f conftest.*
 	else
 	  TARGET=X86_64;
 	fi


### PR DESCRIPTION
Since for x86_64-*x32 and x86_64-x32-* hosts, -m32 generates ia32 codes.
We should always check __x86_64__ for x32 hosts.