### PR TITLE
Static trampolines version 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,8 @@ toolexeclib_LTLIBRARIES = libffi.la
 noinst_LTLIBRARIES = libffi_convenience.la
 
 libffi_la_SOURCES = src/prep_cif.c src/types.c \
-		src/raw_api.c src/java_raw_api.c src/closures.c
+		src/raw_api.c src/java_raw_api.c src/closures.c \
+		src/tramp.c
 
 if FFI_DEBUG
 libffi_la_SOURCES += src/debug.c

--- a/configure.ac
+++ b/configure.ac
@@ -360,6 +360,13 @@ AC_ARG_ENABLE(raw-api,
     AC_DEFINE(FFI_NO_RAW_API, 1, [Define this if you do not want support for the raw API.])
   fi)
 
+AC_ARG_ENABLE(static-tramp,
+[  --enable-static-tramp        use statically defined trampolines],
+  if test "$enable_static_tramp" = "yes"; then
+    AC_DEFINE(FFI_EXEC_STATIC_TRAMP, 1,
+      [Define this if you want to use statically defined trampolines.])
+  fi)
+
 AC_ARG_ENABLE(purify-safety,
 [  --enable-purify-safety  purify-safe mode],
   if test "$enable_purify_safety" = "yes"; then

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -310,7 +310,10 @@ typedef struct {
   void *trampoline_table;
   void *trampoline_table_entry;
 #else
-  char tramp[FFI_TRAMPOLINE_SIZE];
+  union {
+    char tramp[FFI_TRAMPOLINE_SIZE];
+    void *ftramp;
+  };
 #endif
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
@@ -456,6 +459,14 @@ FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
 		  void **avalue, void *closure);
 
 #endif /* FFI_GO_CLOSURES */
+
+/* ---- Static Trampoline Definitions -------------------------------------- */
+
+FFI_API int ffi_tramp_is_supported(void);
+FFI_API void *ffi_tramp_alloc (int flags);
+FFI_API int ffi_tramp_set_parms (void *tramp, void *data, void *code);
+FFI_API void *ffi_tramp_get_addr (void *tramp);
+FFI_API void ffi_tramp_free (void *tramp);
 
 /* ---- Public interface definition -------------------------------------- */
 

--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -103,6 +103,10 @@ ffi_status ffi_prep_cif_core(ffi_cif *cif,
    some targets.  */
 void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
 
+/* The arch code calls this to set the code and data parameters for a
+   closure's static trampoline, if any. */
+int ffi_closure_tramp_set_parms (void *closure, void *code);
+
 /* Extended cif, used in callback from assembly routine */
 typedef struct
 {

--- a/libffi.map.in
+++ b/libffi.map.in
@@ -74,3 +74,14 @@ LIBFFI_GO_CLOSURE_8.0 {
 	ffi_prep_go_closure;
 } LIBFFI_CLOSURE_8.0;
 #endif
+
+#if FFI_EXEC_STATIC_TRAMP
+LIBFFI_STATIC_TRAMP_8.0 {
+  global:
+	ffi_tramp_is_supported;
+	ffi_tramp_alloc;
+	ffi_tramp_set_parms;
+	ffi_tramp_get_addr;
+	ffi_tramp_free;
+} LIBFFI_BASE_8.0;
+#endif

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -817,6 +817,9 @@ ffi_prep_closure_loc (ffi_closure *closure,
   };
   char *tramp = closure->tramp;
   
+  if (ffi_closure_tramp_set_parms (closure, start))
+    goto out;
+
   memcpy (tramp, trampoline, sizeof(trampoline));
   
   *(UINT64 *)(tramp + 16) = (uintptr_t)start;
@@ -832,6 +835,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
   unsigned char *tramp_code = ffi_data_to_code_pointer (tramp);
   #endif
   ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
+out:
 #endif
 
   closure->cif = cif;
@@ -1021,5 +1025,17 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 
   return flags;
 }
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+
+  *tramp_size = AARCH64_TRAMP_SIZE;
+  *map_size = AARCH64_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif
 
 #endif /* (__aarch64__) || defined(__arm64__)|| defined (_M_ARM64)*/

--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -66,3 +66,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define N_X_ARG_REG		8
 #define N_V_ARG_REG		8
 #define CALL_CONTEXT_SIZE	(N_V_ARG_REG * 16 + N_X_ARG_REG * 8)
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 16K is chosen to
+ * cover the base page sizes of 4K and 16K.
+ */
+#define AARCH64_TRAMP_MAP_SHIFT	14
+#define AARCH64_TRAMP_MAP_SIZE	(1 << AARCH64_TRAMP_MAP_SHIFT)
+#define AARCH64_TRAMP_SIZE	32
+#endif

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -232,6 +232,10 @@ CNAME(ffi_call_SYSV):
 	.align 4
 CNAME(ffi_closure_SYSV_V):
 	cfi_startproc
+#if defined(FFI_EXEC_STATIC_TRAMP)
+	ldr	x17, [sp, #8]
+	add	sp, sp, #16
+#endif
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -255,6 +259,10 @@ CNAME(ffi_closure_SYSV_V):
 	.align	4
 	cfi_startproc
 CNAME(ffi_closure_SYSV):
+#if defined(FFI_EXEC_STATIC_TRAMP)
+	ldr	x17, [sp, #8]
+	add	sp, sp, #16
+#endif
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -366,6 +374,44 @@ CNAME(ffi_closure_SYSV):
 	.type	CNAME(ffi_closure_SYSV), #function
 	.size	CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
 #endif
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * The trampoline uses register x17. It saves the original value of x17 on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of x17
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+	.align	AARCH64_TRAMP_MAP_SHIFT
+CNAME(trampoline_code_table):
+	.rept	AARCH64_TRAMP_MAP_SIZE / AARCH64_TRAMP_SIZE
+	sub	sp, sp, #16		/* Make space on the stack */
+	str	x17, [sp]		/* Save x17 on stack */
+	adr	x17, #16376		/* Get data address */
+	ldr	x17, [x17]		/* Copy data into x17 */
+	str	x17, [sp, #8]		/* Save data on stack */
+	adr	x17, #16372		/* Get code address */
+	ldr	x17, [x17]		/* Load code address into x17 */
+	br	x17			/* Jump to code */
+	.endr
+
+	.globl CNAME(trampoline_code_table)
+	FFI_HIDDEN(CNAME(trampoline_code_table))
+#ifdef __ELF__
+	.type	CNAME(trampoline_code_table), #function
+	.size	CNAME(trampoline_code_table), . - CNAME(trampoline_code_table)
+#endif
+	.align	AARCH64_TRAMP_MAP_SHIFT
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -612,6 +612,9 @@ ffi_prep_closure_loc (ffi_closure * closure,
   config[1] = closure_func;
 #else
 
+  if (ffi_closure_tramp_set_parms (closure, closure_func))
+    goto out;
+
 #ifndef _M_ARM
   memcpy(closure->tramp, ffi_arm_trampoline, 8);
 #else
@@ -633,6 +636,7 @@ ffi_prep_closure_loc (ffi_closure * closure,
 #else
   *(void (**)(void))(closure->tramp + 8) = closure_func;
 #endif
+out:
 #endif
 
   closure->cif = cif;
@@ -872,5 +876,17 @@ layout_vfp_args (ffi_cif * cif)
 	break;
     }
 }
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+
+  *tramp_size = ARM_TRAMP_SIZE;
+  *map_size = ARM_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif
 
 #endif /* __arm__ or _M_ARM */

--- a/src/arm/internal.h
+++ b/src/arm/internal.h
@@ -5,3 +5,13 @@
 #define ARM_TYPE_INT	4
 #define ARM_TYPE_VOID	5
 #define ARM_TYPE_STRUCT	6
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline table mapping, a mapping size of 4K (base page size)
+ * is chosen.
+ */
+#define ARM_TRAMP_MAP_SHIFT	12
+#define ARM_TRAMP_MAP_SIZE	(1 << ARM_TRAMP_MAP_SHIFT)
+#define ARM_TRAMP_SIZE		20
+#endif

--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -227,6 +227,10 @@ ARM_FUNC_END(ffi_go_closure_SYSV)
 ARM_FUNC_START(ffi_closure_SYSV)
 	UNWIND(.fnstart)
 	cfi_startproc
+#if defined(FFI_EXEC_STATIC_TRAMP)
+	ldr	ip, [sp, #4]
+	add	sp, sp, 8
+#endif
 	stmdb	sp!, {r0-r3}			@ save argument regs
 	cfi_adjust_cfa_offset(16)
 
@@ -274,6 +278,10 @@ ARM_FUNC_END(ffi_go_closure_VFP)
 ARM_FUNC_START(ffi_closure_VFP)
 	UNWIND(.fnstart)
 	cfi_startproc
+#if defined(FFI_EXEC_STATIC_TRAMP)
+	ldr	ip, [sp, #4]
+	add	sp, sp, 8
+#endif
 	stmdb	sp!, {r0-r3}			@ save argument regs
 	cfi_adjust_cfa_offset(16)
 
@@ -353,6 +361,35 @@ E(ARM_TYPE_STRUCT)
 	ldm	sp, {sp,pc}
 	cfi_endproc
 ARM_FUNC_END(ffi_closure_ret)
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * The trampoline uses register ip (r12). It saves the original value of ip
+ * on the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of ip
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+	.align	ARM_TRAMP_MAP_SHIFT
+ARM_FUNC_START(trampoline_code_table)
+	.rept	ARM_TRAMP_MAP_SIZE / ARM_TRAMP_SIZE
+	sub	sp, sp, #8		/* Make space on the stack */
+	str	ip, [sp]		/* Save ip on stack */
+	ldr	ip, [pc, #4080]		/* Copy data into ip */
+	str	ip, [sp, #4]		/* Save data on stack */
+	ldr	pc, [pc, #4076]		/* Copy code into PC */
+	.endr
+ARM_FUNC_END(trampoline_code_table)
+	.align	ARM_TRAMP_MAP_SHIFT
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 

--- a/src/closures.c
+++ b/src/closures.c
@@ -109,6 +109,12 @@ ffi_closure_free (void *ptr)
   munmap(dataseg, rounded_size);
   munmap(codeseg, rounded_size);
 }
+
+int
+ffi_closure_tramp_set_parms (void *ptr, void *code)
+{
+  return 0;
+}
 #else /* !NetBSD with PROT_MPROTECT */
 
 #if !FFI_MMAP_EXEC_WRIT && !FFI_EXEC_TRAMPOLINE_TABLE
@@ -843,6 +849,12 @@ dlmmap (void *start, size_t length, int prot,
 	  && flags == (MAP_PRIVATE | MAP_ANONYMOUS)
 	  && fd == -1 && offset == 0);
 
+  if (execfd == -1 && ffi_tramp_is_supported ())
+    {
+      ptr = mmap (start, length, prot & ~PROT_EXEC, flags, fd, offset);
+      return ptr;
+    }
+
   if (execfd == -1 && is_emutramp_enabled ())
     {
       ptr = mmap (start, length, prot & ~PROT_EXEC, flags, fd, offset);
@@ -922,7 +934,7 @@ segment_holding_code (mstate m, char* addr)
 void *
 ffi_closure_alloc (size_t size, void **code)
 {
-  void *ptr;
+  void *ptr, *ftramp;
 
   if (!code)
     return NULL;
@@ -934,6 +946,17 @@ ffi_closure_alloc (size_t size, void **code)
       msegmentptr seg = segment_holding (gm, ptr);
 
       *code = add_segment_exec_offset (ptr, seg);
+      if (!ffi_tramp_is_supported ())
+        return ptr;
+
+      ftramp = ffi_tramp_alloc (0);
+      if (ftramp == NULL)
+      {
+        dlfree (FFI_RESTORE_PTR (ptr));
+        return NULL;
+      }
+      *code = ffi_tramp_get_addr (ftramp);
+      ((ffi_closure *) ptr)->ftramp = ftramp;
     }
 
   return ptr;
@@ -943,12 +966,17 @@ void *
 ffi_data_to_code_pointer (void *data)
 {
   msegmentptr seg = segment_holding (gm, data);
+
   /* We expect closures to be allocated with ffi_closure_alloc(), in
      which case seg will be non-NULL.  However, some users take on the
      burden of managing this memory themselves, in which case this
      we'll just return data. */
   if (seg)
-    return add_segment_exec_offset (data, seg);
+    {
+      if (!ffi_tramp_is_supported ())
+        return add_segment_exec_offset (data, seg);
+      return ffi_tramp_get_addr (((ffi_closure *) data)->ftramp);
+    }
   else
     return data;
 }
@@ -966,8 +994,24 @@ ffi_closure_free (void *ptr)
   if (seg)
     ptr = sub_segment_exec_offset (ptr, seg);
 #endif
+  if (ffi_tramp_is_supported ())
+    ffi_tramp_free (((ffi_closure *) ptr)->ftramp);
 
   dlfree (FFI_RESTORE_PTR (ptr));
+}
+
+int
+ffi_closure_tramp_set_parms (void *ptr, void *code)
+{
+  void *ftramp;
+
+  msegmentptr seg = segment_holding (gm, ptr);
+  if (!seg || !ffi_tramp_is_supported())
+    return 0;
+
+  ftramp = ((ffi_closure *) ptr)->ftramp;
+  ffi_tramp_set_parms (ftramp, code, ptr);
+  return 1;
 }
 
 # else /* ! FFI_MMAP_EXEC_WRIT */
@@ -996,6 +1040,12 @@ void *
 ffi_data_to_code_pointer (void *data)
 {
   return data;
+}
+
+int
+ffi_closure_tramp_set_parms (void *ptr, void *code)
+{
+  return 0;
 }
 
 # endif /* ! FFI_MMAP_EXEC_WRIT */

--- a/src/tramp.c
+++ b/src/tramp.c
@@ -1,0 +1,563 @@
+/* -----------------------------------------------------------------------
+   tramp.c - Copyright (c) 2020 Madhavan T. Venkataraman
+
+   API and support functions for managing statically defined closure
+   trampolines.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <linux/limits.h>
+#include <linux/types.h>
+#include <fficonfig.h>
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+
+#if !defined(__linux__)
+#error "FFI_EXEC_STATIC_TRAMP is currently only supported on Linux"
+#endif
+
+#if !defined _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+/*
+ * Each architecture defines static code for a trampoline code table. The
+ * trampoline code table is mapped into the address space of a process.
+ *
+ * The following architecture specific function returns:
+ *
+ *	- the address of the trampoline code table in the text segment
+ *	- the size of each trampoline in the trampoline code table
+ *	- the size of the mapping for the whole trampoline code table
+ */
+void __attribute__((weak)) *ffi_tramp_arch (size_t *tramp_size,
+  size_t *map_size);
+
+/* ------------------------- Trampoline Data Structures --------------------*/
+
+static pthread_mutex_t tramp_lock = PTHREAD_MUTEX_INITIALIZER;
+
+struct tramp;
+
+/*
+ * Trampoline table. Manages one trampoline code table and one trampoline
+ * parameter table.
+ *
+ * prev, next	Links in the global trampoline table list.
+ * code_table	Trampoline code table mapping.
+ * parm_table	Trampoline parameter table mapping.
+ * array	Array of trampolines malloced.
+ * free		List of free trampolines.
+ * nfree	Number of free trampolines.
+ */
+struct tramp_table
+{
+  struct tramp_table *prev;
+  struct tramp_table *next;
+  void *code_table;
+  void *parm_table;
+  struct tramp *array;
+  struct tramp *free;
+  int nfree;
+};
+
+/*
+ * Parameters for each trampoline.
+ *
+ * data
+ *	Data for the target code that the trampoline jumps to.
+ * target
+ *	Target code that the trampoline jumps to.
+ */
+struct tramp_parm
+{
+  void *data;
+  void *target;
+};
+
+/*
+ * Trampoline structure for each trampoline.
+ *
+ * prev, next	Links in the trampoline free list of a trampoline table.
+ * table	Trampoline table to which this trampoline belongs.
+ * code		Address of this trampoline in the code table mapping.
+ * parm		Address of this trampoline's parameters in the parameter
+ *		table mapping.
+ */
+struct tramp
+{
+  struct tramp *prev;
+  struct tramp *next;
+  struct tramp_table *table;
+  void *code;
+  struct tramp_parm *parm;
+};
+
+/*
+ * Trampoline globals.
+ *
+ * fd
+ *	File descriptor of binary file that contains the trampoline code table.
+ * offset
+ *	Offset of the trampoline code table in that file.
+ * map_size
+ *	Size of the trampoline code table mapping.
+ * size
+ *	Size of one trampoline in the trampoline code table.
+ * ntramp
+ *	Total number of trampolines in the trampoline code table.
+ * tables
+ *	List of trampoline tables that contain free trampolines.
+ * ntables
+ *	Number of trampoline tables that contain free trampolines.
+ */
+struct tramp_global
+{
+  int fd;
+  off_t offset;
+  size_t map_size;
+  size_t size;
+  int ntramp;
+  struct tramp_table *tables;
+  int ntables;
+};
+
+static struct tramp_global gtramp = { -1 };
+
+/* ------------------------ Trampoline Initialization ----------------------*/
+
+static int ffi_tramp_get_fd_offset (void *tramp_text, off_t *offset);
+
+/*
+ * Initialize the static trampoline feature.
+ */
+static int
+ffi_tramp_init (void)
+{
+  if (ffi_tramp_arch == NULL)
+    return 0;
+
+  if (gtramp.fd == -1)
+    {
+      void *tramp_text;
+
+      gtramp.tables = NULL;
+      gtramp.ntables = 0;
+
+      /*
+       * Get trampoline code table information from the architecture.
+       */
+      tramp_text = ffi_tramp_arch (&gtramp.size, &gtramp.map_size);
+      gtramp.ntramp = gtramp.map_size / gtramp.size;
+
+      /*
+       * Get the binary file that contains the trampoline code table and also
+       * the offset of the table within the file. These are used to mmap()
+       * the trampoline code table.
+       */
+      gtramp.fd = ffi_tramp_get_fd_offset (tramp_text, &gtramp.offset);
+    }
+  return gtramp.fd != -1;
+}
+
+/*
+ * From the address of the trampoline code table in the text segment, find the
+ * binary file and offset of the trampoline code table from /proc/<pid>/maps.
+ */
+static int
+ffi_tramp_get_fd_offset (void *tramp_text, off_t *offset)
+{
+  FILE *fp;
+  char file[PATH_MAX], line[PATH_MAX+100], perm[10], dev[10];
+  unsigned long start, end, inode;
+  uintptr_t addr = (uintptr_t) tramp_text;
+  int nfields, found;
+
+  snprintf (file, PATH_MAX, "/proc/%d/maps", getpid());
+  fp = fopen (file, "r");
+  if (fp == NULL)
+    return -1;
+
+  found = 0;
+  while (feof (fp) == 0) {
+    if (fgets (line, sizeof (line), fp) == 0)
+      break;
+
+    nfields = sscanf (line, "%lx-%lx %s %lx %s %ld %s",
+      &start, &end, perm, offset, dev, &inode, file);
+    if (nfields != 7)
+      continue;
+
+    if (addr >= start && addr < end) {
+      *offset += (addr - start);
+      found = 1;
+      break;
+    }
+  }
+  fclose (fp);
+
+  if (!found)
+    return -1;
+
+  return open (file, O_RDONLY);
+}
+
+/* ---------------------- Trampoline Table functions ---------------------- */
+
+static int tramp_table_map (char **code_table, char **parm_table);
+static void tramp_add (struct tramp *tramp);
+
+/*
+ * Allocate and initialize a trampoline table.
+ */
+static int
+tramp_table_alloc (void)
+{
+  char *code_table, *parm_table;
+  struct tramp_table *table;
+  struct tramp *tramp_array, *tramp;
+  size_t size;
+  char *code, *parm;
+  int i;
+
+  /*
+   * If we already have tables with free trampolines, there is no need to
+   * allocate a new table.
+   */
+  if (gtramp.ntables > 0)
+    return 1;
+
+  /*
+   * Allocate a new trampoline table structure.
+   */
+  table = malloc (sizeof (*table));
+  if (table == NULL)
+    return 0;
+
+  /*
+   * Allocate new trampoline structures.
+   */
+  tramp_array = malloc (sizeof (*tramp) * gtramp.ntramp);
+  if (tramp_array == NULL)
+    goto free_table;
+
+  /*
+   * Map a code table and a parameter table into the caller's address space.
+   */
+  if (!tramp_table_map (&code_table, &parm_table))
+    goto free_tramp_array;
+
+  /*
+   * Initialize the trampoline table.
+   */
+  table->code_table = code_table;
+  table->parm_table = parm_table;
+  table->array = tramp_array;
+  table->free = NULL;
+  table->nfree = 0;
+
+  /*
+   * Populate the trampoline table free list. This will also add the trampoline
+   * table to the global list of trampoline tables.
+   */
+  size = gtramp.size;
+  code = code_table;
+  parm = parm_table;
+  for (i = 0; i < gtramp.ntramp; i++)
+    {
+      tramp = &tramp_array[i];
+      tramp->table = table;
+      tramp->code = code;
+      tramp->parm = (struct tramp_parm *) parm;
+      tramp_add (tramp);
+
+      code += size;
+      parm += size;
+    }
+  return 1;
+
+free_tramp_array:
+  free (tramp_array);
+free_table:
+  free (table);
+  return 0;
+}
+
+/*
+ * Create a trampoline code table mapping and a trampoline parameter table
+ * mapping. The two mappings must be adjacent to each other for PC-relative
+ * access.
+ *
+ * For each trampoline in the code table, there is a corresponding parameter
+ * block in the parameter table. The size of the parameter block is the same
+ * as the size of the trampoline. This means that the parameter block is at
+ * a fixed offset from its trampoline making it easy for a trampoline to find
+ * its parameters using PC-relative access.
+ *
+ * The parameter block will contain a struct tramp_parm. This means that
+ * sizeof (struct tramp_parm) cannot exceed the size of a parameter block.
+ */
+static int
+tramp_table_map (char **code_table, char **parm_table)
+{
+  char *addr;
+
+  /*
+   * Create an anonymous mapping twice the map size. The top half will be used
+   * for the code table. The bottom half will be used for the parameter table.
+   */
+  addr = mmap (NULL, gtramp.map_size * 2, PROT_READ | PROT_WRITE,
+    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (addr == MAP_FAILED)
+    return 0;
+
+  /*
+   * Replace the top half of the anonymous mapping with the code table mapping.
+   */
+  *code_table = mmap (addr, gtramp.map_size, PROT_READ | PROT_EXEC,
+    MAP_PRIVATE | MAP_FIXED, gtramp.fd, gtramp.offset);
+  if (*code_table == MAP_FAILED)
+    {
+      (void) munmap (addr, gtramp.map_size * 2);
+      return 0;
+    }
+  *parm_table = *code_table + gtramp.map_size;
+  return 1;
+}
+
+/*
+ * Free a trampoline table.
+ */
+static void
+tramp_table_free (struct tramp_table *table)
+{
+  (void) munmap (table->code_table, gtramp.map_size);
+  (void) munmap (table->parm_table, gtramp.map_size);
+  free (table->array);
+  free (table);
+}
+
+/*
+ * Add a new trampoline table to the global table list.
+ */
+static void
+tramp_table_add (struct tramp_table *table)
+{
+  table->next = gtramp.tables;
+  table->prev = NULL;
+  if (gtramp.tables != NULL)
+    gtramp.tables->prev = table;
+  gtramp.tables = table;
+  gtramp.ntables++;
+}
+
+/*
+ * Delete a trampoline table from the global table list.
+ */
+static void
+tramp_table_del (struct tramp_table *table)
+{
+  gtramp.ntables--;
+  if (table->prev != NULL)
+    table->prev->next = table->next;
+  if (table->next != NULL)
+    table->next->prev = table->prev;
+  if (gtramp.tables == table)
+    gtramp.tables = table->next;
+}
+
+/* ------------------------- Trampoline functions ------------------------- */
+
+/*
+ * Add a trampoline to its trampoline table.
+ */
+static void
+tramp_add (struct tramp *tramp)
+{
+  struct tramp_table *table = tramp->table;
+
+  tramp->next = table->free;
+  tramp->prev = NULL;
+  if (table->free != NULL)
+    table->free->prev = tramp;
+  table->free = tramp;
+  table->nfree++;
+
+  if (table->nfree == 1)
+    tramp_table_add (table);
+
+  /*
+   * We don't want to keep too many free trampoline tables lying around.
+   */
+  if (table->nfree == gtramp.ntramp && gtramp.ntables > 1)
+    {
+      tramp_table_del (table);
+      tramp_table_free (table);
+    }
+}
+
+/*
+ * Remove a trampoline from its trampoline table.
+ */
+static void
+tramp_del (struct tramp *tramp)
+{
+  struct tramp_table *table = tramp->table;
+
+  table->nfree--;
+  if (tramp->prev != NULL)
+    tramp->prev->next = tramp->next;
+  if (tramp->next != NULL)
+    tramp->next->prev = tramp->prev;
+  if (table->free == tramp)
+    table->free = tramp->next;
+
+  if (table->nfree == 0)
+    tramp_table_del (table);
+}
+
+/* ------------------------ Trampoline API functions ------------------------ */
+
+int
+ffi_tramp_is_supported(void)
+{
+  int ret;
+
+  pthread_mutex_lock (&tramp_lock);
+  ret = ffi_tramp_init ();
+  pthread_mutex_unlock (&tramp_lock);
+  return ret;
+}
+
+/*
+ * Allocate a trampoline and return its opaque address.
+ */
+void *
+ffi_tramp_alloc (int flags)
+{
+  struct tramp *tramp;
+
+  pthread_mutex_lock (&tramp_lock);
+
+  if (!ffi_tramp_init () || flags != 0)
+    {
+      pthread_mutex_unlock (&tramp_lock);
+      return NULL;
+    }
+
+  if (!tramp_table_alloc ())
+    {
+      pthread_mutex_unlock (&tramp_lock);
+      return NULL;
+    }
+
+  tramp = gtramp.tables->free;
+  tramp_del (tramp);
+
+  pthread_mutex_unlock (&tramp_lock);
+
+  return tramp;
+}
+
+/*
+ * Set the parameters for a trampoline.
+ */
+void
+ffi_tramp_set_parms (void *arg, void *target, void *data)
+{
+  struct tramp *tramp = arg;
+
+  pthread_mutex_lock (&tramp_lock);
+  tramp->parm->target = target;
+  tramp->parm->data = data;
+  pthread_mutex_unlock (&tramp_lock);
+}
+
+/*
+ * Get the invocation address of a trampoline.
+ */
+void *
+ffi_tramp_get_addr (void *arg)
+{
+  struct tramp *tramp = arg;
+  void *addr;
+
+  pthread_mutex_lock (&tramp_lock);
+  addr = tramp->code;
+  pthread_mutex_unlock (&tramp_lock);
+
+  return addr;
+}
+
+/*
+ * Free a trampoline.
+ */
+void
+ffi_tramp_free (void *arg)
+{
+  struct tramp *tramp = arg;
+
+  pthread_mutex_lock (&tramp_lock);
+  tramp_add (tramp);
+  pthread_mutex_unlock (&tramp_lock);
+}
+
+/* ------------------------------------------------------------------------- */
+
+#else /* !FFI_EXEC_STATIC_TRAMP */
+
+int
+ffi_tramp_is_supported(void)
+{
+  return 0;
+}
+
+void *
+ffi_tramp_alloc (int flags)
+{
+  return NULL;
+}
+
+void
+ffi_tramp_set_parms (void *arg, void *target, void *data)
+{
+}
+
+void *
+ffi_tramp_get_addr (void *arg)
+{
+  return NULL;
+}
+
+void
+ffi_tramp_free (void *arg)
+{
+}
+
+#endif /* FFI_EXEC_STATIC_TRAMP */

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -559,6 +559,9 @@ ffi_prep_closure_loc (ffi_closure* closure,
       return FFI_BAD_ABI;
     }
 
+  if (ffi_closure_tramp_set_parms (closure, dest))
+    goto out;
+
   /* endbr32.  */
   *(UINT32 *) tramp = 0xfb1e0ff3;
 
@@ -570,6 +573,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   tramp[9] = 0xe9;
   *(unsigned *)(tramp + 10) = (unsigned)dest - ((unsigned)codeloc + 14);
 
+out:
   closure->cif = cif;
   closure->fun = fun;
   closure->user_data = user_data;
@@ -767,4 +771,17 @@ ffi_raw_call(ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *avalue)
   ffi_call_i386 (frame, stack);
 }
 #endif /* !FFI_NO_RAW_API */
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+
+  *tramp_size = X86_TRAMP_SIZE;
+  *map_size = X86_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif
+
 #endif /* __i386__ */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -756,8 +756,11 @@ ffi_prep_closure_loc (ffi_closure* closure,
   else
     dest = ffi_closure_unix64;
 
-  memcpy (tramp, trampoline, sizeof(trampoline));
-  *(UINT64 *)(tramp + sizeof (trampoline)) = (uintptr_t)dest;
+  if (!ffi_closure_tramp_set_parms (closure, dest))
+    {
+      memcpy (tramp, trampoline, sizeof(trampoline));
+      *(UINT64 *)(tramp + sizeof (trampoline)) = (uintptr_t)dest;
+    }
 
   closure->cif = cif;
   closure->fun = fun;
@@ -891,5 +894,17 @@ ffi_prep_go_closure (ffi_go_closure* closure, ffi_cif* cif,
 }
 
 #endif /* FFI_GO_CLOSURES */
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+
+  *tramp_size = UNIX64_TRAMP_SIZE;
+  *map_size = UNIX64_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif
 
 #endif /* __x86_64__ */

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -185,7 +185,6 @@ EFI64(ffi_call_go)(ffi_cif *cif, void (*fn)(void), void *rvalue,
   ffi_call_int (cif, fn, rvalue, avalue, closure);
 }
 
-
 extern void ffi_closure_win64(void) FFI_HIDDEN;
 
 #ifdef FFI_GO_CLOSURES
@@ -220,8 +219,11 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
       return FFI_BAD_ABI;
     }
 
-  memcpy (tramp, trampoline, sizeof(trampoline));
-  *(UINT64 *)(tramp + sizeof (trampoline)) = (uintptr_t)ffi_closure_win64;
+  if (!ffi_closure_tramp_set_parms (closure, ffi_closure_win64))
+    {
+      memcpy (tramp, trampoline, sizeof(trampoline));
+      *(UINT64 *)(tramp + sizeof (trampoline)) = (uintptr_t)ffi_closure_win64;
+    }
 
   closure->cif = cif;
   closure->fun = fun;

--- a/src/x86/internal.h
+++ b/src/x86/internal.h
@@ -27,3 +27,13 @@
 #else
 # define HAVE_FASTCALL 1
 #endif
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 4K (base page size)
+ * is chosen.
+ */
+#define X86_TRAMP_MAP_SHIFT	12
+#define X86_TRAMP_MAP_SIZE	(1 << X86_TRAMP_MAP_SHIFT)
+#define X86_TRAMP_SIZE		44
+#endif

--- a/src/x86/internal64.h
+++ b/src/x86/internal64.h
@@ -20,3 +20,13 @@
 #define UNIX64_FLAG_RET_IN_MEM	(1 << 10)
 #define UNIX64_FLAG_XMM_ARGS	(1 << 11)
 #define UNIX64_SIZE_SHIFT	12
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 4K (base page size)
+ * is chosen.
+ */
+#define UNIX64_TRAMP_MAP_SHIFT	12
+#define UNIX64_TRAMP_MAP_SIZE	(1 << UNIX64_TRAMP_MAP_SHIFT)
+#define UNIX64_TRAMP_SIZE	40
+#endif

--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -344,6 +344,10 @@ C(ffi_closure_i386):
 L(UW12):
 	# cfi_startproc
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movl	4(%esp), %eax
+	add	$8, %esp
+#endif
 	subl	$closure_FS, %esp
 L(UW13):
 	# cfi_def_cfa_offset(closure_FS + 4)
@@ -454,6 +458,10 @@ L(UW24):
 	# cfi_def_cfa(%esp, 8)
 	# cfi_offset(%eip, -8)
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movl	(%esp), %eax
+	add	$4, %esp
+#endif
 	subl	$closure_FS-4, %esp
 L(UW25):
 	# cfi_def_cfa_offset(closure_FS + 4)
@@ -477,6 +485,10 @@ C(ffi_closure_STDCALL):
 L(UW27):
 	# cfi_startproc
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movl	4(%esp), %eax
+	add	$8, %esp
+#endif
 	subl	$closure_FS, %esp
 L(UW28):
 	# cfi_def_cfa_offset(closure_FS + 4)
@@ -572,6 +584,46 @@ E(L(load_table3), X86_RET_UNUSED15)
 L(UW31):
 	# cfi_endproc
 ENDF(C(ffi_closure_STDCALL))
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * The trampoline uses register eax.  It saves the original value of eax on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of eax
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+	.align	X86_TRAMP_MAP_SIZE
+	.globl	C(trampoline_code_table)
+	FFI_HIDDEN(C(trampoline_code_table))
+C(trampoline_code_table):
+	.rept	X86_TRAMP_MAP_SIZE / X86_TRAMP_SIZE
+	endbr32
+	sub	$8, %esp
+	movl	%eax, (%esp)		/* Save %eax on stack */
+	call	1f			/* Get next PC into %eax */
+	movl	4081(%eax), %eax	/* Copy data into %eax */
+	movl	%eax, 4(%esp)		/* Save data on stack */
+	call	1f			/* Get next PC into %eax */
+	movl	4070(%eax), %eax	/* Copy data into %eax */
+	jmp	*%eax			/* Jump to code */
+1:
+	mov	(%esp), %eax
+	ret
+	nop				/* Pad to 4 byte boundary */
+	nop
+	.endr
+ENDF(C(trampoline_code_table))
+	.align	X86_TRAMP_MAP_SIZE
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if !FFI_NO_RAW_API
 

--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -253,6 +253,10 @@ ENDF(C(ffi_call_unix64))
 C(ffi_closure_unix64_sse):
 L(UW5):
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movq	8(%rsp), %r10
+	addq	$16, %rsp
+#endif
 	subq	$ffi_closure_FS, %rsp
 L(UW6):
 	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
@@ -277,6 +281,10 @@ ENDF(C(ffi_closure_unix64_sse))
 C(ffi_closure_unix64):
 L(UW8):
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movq	8(%rsp), %r10
+	addq	$16, %rsp
+#endif
 	subq	$ffi_closure_FS, %rsp
 L(UW9):
 	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
@@ -455,6 +463,46 @@ L(sse_entry2):
 
 L(UW17):
 ENDF(C(ffi_go_closure_unix64))
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * The trampoline uses register r10. It saves the original value of r10 on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of r10
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+	.align	UNIX64_TRAMP_MAP_SIZE
+	.globl	trampoline_code_table
+	FFI_HIDDEN(C(trampoline_code_table))
+
+C(trampoline_code_table):
+	.rept	UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
+	endbr64
+	subq	$16, %rsp		/* Make space on the stack */
+	movq	%r10, (%rsp)		/* Save %r10 on stack */
+	movq	4077(%rip), %r10	/* Copy data into %r10 */
+	movq	%r10, 8(%rsp)		/* Save data on stack */
+	movq	4073(%rip), %r10	/* Copy code into %r10 */
+	jmp	*%r10			/* Jump to code */
+	nop				/* Pad to 8 byte boundary */
+	nop
+	nop
+	nop
+	nop
+	nop
+	.endr
+ENDF(C(trampoline_code_table))
+	.align	UNIX64_TRAMP_MAP_SIZE
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 /* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
 

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -200,6 +200,10 @@ C(ffi_go_closure_win64):
 C(ffi_closure_win64):
 	cfi_startproc
 	_CET_ENDBR
+#ifdef FFI_EXEC_STATIC_TRAMP
+	movq	8(%rsp), %r10
+	addq	$16, %rsp
+#endif
 	/* Save all integer arguments into the incoming reg stack space.  */
 	movq	%rcx, 8(%rsp)
 	movq	%rdx, 16(%rsp)

--- a/testsuite/libffi.closures/closure_loc_fn0.c
+++ b/testsuite/libffi.closures/closure_loc_fn0.c
@@ -83,7 +83,10 @@ int main (void)
   CHECK(ffi_prep_closure_loc(pcl, &cif, closure_loc_test_fn0,
 			 (void *) 3 /* userdata */, codeloc) == FFI_OK);
   
+#ifndef FFI_EXEC_STATIC_TRAMP
+  /* With static trampolines, the codeloc does not point to closure */
   CHECK(memcmp(pcl, codeloc, sizeof(*pcl)) == 0);
+#endif
 
   res = (*((closure_loc_test_type0)codeloc))
     (1LL, 2, 3LL, 4, 127, 429LL, 7, 8, 9.5, 10, 11, 12, 13,


### PR DESCRIPTION
I have submitted an RFC for this change to the libffi alias. I am submitting this PR to trigger CI testing.

Closure trampolines are defined as dynamic code today - that is, either hand-crafted and placed in a data buffer or runtime generated. The trampolines need to be mapped with executable permissions. Executable data pages can potentially be hacked by an attacker. To address this, we need to define the trampolines statically in a source file so they can be compiled, placed in a text segment and mapped using traditional methods. An example of this has already been implemented in MACH for the ARM architecture. However, we need to generalize the implementation for all architectures and also make sure that no ABI breaks on any architecture.

The Static Trampolines work is an attempt to achieve that. I have added support for X86 and ARM, 32-bit and 64-bit. Support for other architectures can be added easily in the future. For more information, please refer to the RFC I have submitted on the libffi alias.