### PR TITLE
Fix struct padding warning reported by MSVC

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -315,6 +315,9 @@ typedef struct {
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
   void      *user_data;
+#if defined(_MSC_VER) && defined(_M_IX86)
+  void      *padding;
+#endif
 } ffi_closure
 #ifdef __GNUC__
     __attribute__((aligned (8)))


### PR DESCRIPTION
When building on 32-bit x86.