### PR TITLE
Add Meson build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,6 +341,9 @@ done
 changequote([,])
 AC_SUBST(TARGET_OBJ)
 
+STATIC=0
+AC_SUBST(STATIC)
+
 AC_SUBST(SHELL)
 
 AC_ARG_ENABLE(debug,

--- a/fficonfig.h.meson
+++ b/fficonfig.h.meson
@@ -1,0 +1,177 @@
+/* fficonfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+#mesondefine AC_APPLE_UNIVERSAL_BUILD
+
+/* Define to the flags needed for the .section .eh_frame directive. */
+#mesondefine EH_FRAME_FLAGS
+
+/* Define this if you want extra debugging. */
+#mesondefine FFI_DEBUG
+
+/* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
+#mesondefine FFI_EXEC_TRAMPOLINE_TABLE
+
+/* Define this if you want to enable pax emulated trampolines */
+#mesondefine FFI_MMAP_EXEC_EMUTRAMP_PAX
+
+/* Cannot use malloc on this target, so, we revert to alternative means */
+#mesondefine FFI_MMAP_EXEC_WRIT
+
+/* Define this if you do not want support for the raw API. */
+#mesondefine FFI_NO_RAW_API
+
+/* Define this if you do not want support for aggregate types. */
+#mesondefine FFI_NO_STRUCTS
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#mesondefine HAVE_ALLOCA
+
+/* Define to 1 if you have <alloca.h> and it should be used */
+#mesondefine HAVE_ALLOCA_H
+
+/* Define if your assembler supports .ascii. */
+#mesondefine HAVE_AS_ASCII_PSEUDO_OP
+
+/* Define if your assembler supports .cfi_* directives. */
+#mesondefine HAVE_AS_CFI_PSEUDO_OP
+
+/* Define if your assembler supports .register. */
+#mesondefine HAVE_AS_REGISTER_PSEUDO_OP
+
+/* Define if your assembler and linker support unaligned PC relative relocs.
+   */
+#mesondefine HAVE_AS_SPARC_UA_PCREL
+
+/* Define if your assembler supports .string. */
+#mesondefine HAVE_AS_STRING_PSEUDO_OP
+
+/* Define if your assembler supports unwind section type. */
+#mesondefine HAVE_AS_X86_64_UNWIND_SECTION_TYPE
+
+/* Define if your assembler supports PC relative relocs. */
+#mesondefine HAVE_AS_X86_PCREL
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#mesondefine HAVE_DLFCN_H
+
+/* Define if __attribute__((visibility("hidden"))) is supported. */
+#mesondefine HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#mesondefine HAVE_INTTYPES_H
+
+/* Define if you have the long double type and it is bigger than a double */
+#mesondefine HAVE_LONG_DOUBLE
+
+/* Define if you support more than one size of the long double type */
+#mesondefine HAVE_LONG_DOUBLE_VARIANT
+
+/* Define to 1 if you have the `memcpy' function. */
+#mesondefine HAVE_MEMCPY
+
+/* Define to 1 if you have the `memfd_create' function. */
+#mesondefine HAVE_MEMFD_CREATE
+
+/* Define to 1 if you have the <memory.h> header file. */
+#mesondefine HAVE_MEMORY_H
+
+/* Define to 1 if you have the `mkostemp' function. */
+#mesondefine HAVE_MKOSTEMP
+
+/* Define to 1 if you have the `mmap' function. */
+#mesondefine HAVE_MMAP
+
+/* Define if mmap with MAP_ANON(YMOUS) works. */
+#mesondefine HAVE_MMAP_ANON
+
+/* Define if mmap of /dev/zero works. */
+#mesondefine HAVE_MMAP_DEV_ZERO
+
+/* Define if read-only mmap of a plain file works. */
+#mesondefine HAVE_MMAP_FILE
+
+/* Define if your compiler supports pointer authentication. */
+#mesondefine HAVE_PTRAUTH
+
+/* Define if .eh_frame sections should be read-only. */
+#mesondefine HAVE_RO_EH_FRAME
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#mesondefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#mesondefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#mesondefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#mesondefine HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/memfd.h> header file. */
+#mesondefine HAVE_SYS_MEMFD_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#mesondefine HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#mesondefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#mesondefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#mesondefine HAVE_UNISTD_H
+
+/* The size of `double', as computed by sizeof. */
+#mesondefine SIZEOF_DOUBLE
+
+/* The size of `long double', as computed by sizeof. */
+#mesondefine SIZEOF_LONG_DOUBLE
+
+/* The size of `size_t', as computed by sizeof. */
+#mesondefine SIZEOF_SIZE_T
+
+/* Define to 1 if standard C headers are available. */
+#mesondefine STDC_HEADERS
+
+/* Define if symbols are underscored. */
+#mesondefine SYMBOL_UNDERSCORE
+
+/* Define this if you are using Purify and want to suppress spurious messages.
+   */
+#mesondefine USING_PURIFY
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+#if defined __BIG_ENDIAN__
+#define WORDS_BIGENDIAN 1
+#endif
+#else
+#ifndef WORDS_BIGENDIAN
+#mesondefine WORDS_BIGENDIAN
+#endif
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#mesondefine size_t
+
+#ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+#ifdef LIBFFI_ASM
+#ifdef __APPLE__
+#define FFI_HIDDEN(name) .private_extern name
+#else
+#define FFI_HIDDEN(name) .hidden name
+#endif
+#else
+#define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
+#endif
+#else
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name)
+#else
+#define FFI_HIDDEN
+#endif
+#endif

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -53,6 +53,10 @@ extern "C" {
 #define @TARGET@
 #endif
 
+#if @STATIC@
+#define FFI_STATIC_BUILD
+#endif
+
 /* ---- System configuration information --------------------------------- */
 
 #include <ffitarget.h>
@@ -114,24 +118,22 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
-# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#if defined _MSC_VER && !defined FFI_STATIC_BUILD
+# ifdef FFI_BUILDING
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
-# define FFI_API
+# define FFI_API extern
 #endif
 
 /* The externally visible type declarations also need the MSVC DLL
    decorations, or they will not be exported from the object file.  */
 #if defined LIBFFI_HIDE_BASIC_TYPES
-# define FFI_EXTERN FFI_API
+# define FFI_EXTERN
 #else
-# define FFI_EXTERN extern FFI_API
+# define FFI_EXTERN FFI_API
 #endif
 
 #ifndef LIBFFI_HIDE_BASIC_TYPES

--- a/include/ffi_noarch.h.meson
+++ b/include/ffi_noarch.h.meson
@@ -1,0 +1,21 @@
+/* Include the correct @HEADER@.h automatically. This helps us create prefixes
+ * with multi-lib Linux and OSX/iOS universal builds. To avoid listing all
+ * possible architectures here, we try the configured target arch first and then
+ * include the most common multilib/universal setups in the #elif ladder */
+#ifdef __@ARCH@__
+#include "@HEADER@-@ARCH@.h"
+#elif defined(__i386__) || defined(_M_IX86)
+#include "@HEADER@-x86.h"
+#elif defined(__x86_64__) || defined(_M_X64)
+#include "@HEADER@-x86_64.h"
+#elif defined(__arm__) || defined(_M_ARM)
+#include "@HEADER@-arm.h"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include "@HEADER@-aarch64.h"
+#elif defined(__powerpc__) || defined(_M_PPC)
+#include "@HEADER@-powerpc.h"
+#elif defined(__powerpc64__)
+#include "@HEADER@-powerpc64.h"
+#else
+#error "Unsupported Architecture"
+#endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,29 @@
+# Install arch-specific ffi.h file as ffi-$ARCH.h
+configure_file(input : 'ffi.h.in',
+  output : 'ffi-@0@.h'.format(host_cpu_family),
+  configuration : ffi_conf,
+  install_dir : 'include')
+
+# Install arch-specific ffitarget.h as ffitarget-$ARCH.h
+# XXX: Hack to install the header with a different name
+configure_file(
+  input : '../src/@0@/ffitarget.h'.format(arch_subdir),
+  output : 'ffitarget-@0@.h'.format(host_cpu_family),
+  install_dir : 'include',
+  copy : true)
+
+# Install noarch ffitarget.h that includes the arch-specific ffitarget.h
+ffitarget_h_noarch_conf = configuration_data()
+ffitarget_h_noarch_conf.set('ARCH', host_cpu_family)
+ffitarget_h_noarch_conf.set('HEADER', 'ffitarget')
+configure_file(input : 'ffi_noarch.h.meson', output : 'ffitarget.h',
+  configuration : ffitarget_h_noarch_conf,
+  install_dir : 'include')
+
+# Install noarch ffi.h that includes the arch-specific ffi.h header
+ffi_h_noarch_conf = configuration_data()
+ffi_h_noarch_conf.set('ARCH', host_cpu_family)
+ffi_h_noarch_conf.set('HEADER', 'ffi')
+configure_file(input : 'ffi_noarch.h.meson', output : 'ffi.h',
+  configuration : ffi_h_noarch_conf,
+  install_dir : 'include')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,229 @@
+project('libffi', 'c', version : '3.3',
+        meson_version : '>= 0.48.0',
+        default_options : ['buildtype=debugoptimized',
+                           'warning_level=1'])
+
+cc = meson.get_compiler('c')
+
+# For FFI_EXTERN symbol exporting
+add_project_arguments('-DFFI_BUILDING', language : 'c')
+
+ffi_conf = configuration_data()
+
+# NOTE: host = "cross" or "target"
+host_cpu_family = host_machine.cpu_family()
+host_system = host_machine.system()
+message('host cpu: ' + host_machine.cpu())
+message('host cpu_family: ' + host_cpu_family)
+message('host system: ' + host_system)
+
+# IMPORTANT: Some of these use set(), others set10(), and others only set(, 1)
+# conditionally. This is on purpose.
+# Some C code uses #ifdef HAVE_XXX and some #if !HAVE_XXX. To make things worse,
+# some symbols are also used inside .h.in headers that are configured and then
+# #include-ed at build time and installed. Each symbol has been carefully
+# checked. Please double-check before changing.
+#
+# Nothing checks for STACK_DIRECTION
+
+if cc.symbols_have_underscore_prefix()
+  ffi_conf.set('SYMBOL_UNDERSCORE', 1)
+endif
+
+# Assembly directive support
+if cc.compiles('asm (".cfi_startproc\n.cfi_endproc");', name : 'ASM .cfi')
+  ffi_conf.set('HAVE_AS_CFI_PSEUDO_OP', 1)
+endif
+
+if host_cpu_family == 'sparc'
+  if cc.compiles('asm (".text; foo: nop; .data; .align 4; .byte 0; .uaword %r_disp32(foo); .text");', name : 'ASM SPARC UA PCREL')
+    ffi_conf.set('HAVE_AS_SPARC_UA_PCREL', 1)
+  endif
+  if cc.compiles('asm (".register %g2, #scratch");', name : 'ASM .register')
+    ffi_conf.set('HAVE_AS_REGISTER_PSEUDO_OP', 1)
+  endif
+endif
+
+if host_cpu_family == 'x86' or host_cpu_family == 'x86_64'
+  if cc.compiles('asm (".text; foo: nop; .data; .long foo-.; .text");', name : 'ASM x86 PCREL')
+    ffi_conf.set('HAVE_AS_X86_PCREL', 1)
+  endif
+  if cc.compiles('asm (".ascii \\"string\\"");', name : 'ASM .ascii')
+    ffi_conf.set('HAVE_AS_ASCII_PSEUDO_OP', 1)
+  endif
+  if cc.compiles('asm (".string \\"string\\"");', name : 'ASM .string')
+    ffi_conf.set('HAVE_AS_STRING_PSEUDO_OP', 1)
+  endif
+endif
+
+ptrauth = '''#ifdef __clang__
+# if __has_feature(ptrauth_calls)
+#  define HAVE_PTRAUTH 1
+# endif
+#endif
+
+#ifndef HAVE_PTRAUTH
+# error Pointer authentication not supported
+#endif
+'''
+ffi_conf.set('HAVE_PTRAUTH',
+  cc.compiles(ptrauth, name : 'pointer authentication'))
+
+# If not defined, define it as unsigned int
+size_t = cc.sizeof('size_t')
+if size_t > 0
+  ffi_conf.set('SIZEOF_SIZE_T', size_t)
+else
+  message('"size_t" is not defined, using fallback')
+  ffi_conf.set('size_t', 'unsigned int')
+endif
+
+# Checking for long double is important
+size_long_double = cc.sizeof('long double')
+size_double = cc.sizeof('double')
+ffi_conf.set('SIZEOF_LONG_DOUBLE', size_long_double)
+ffi_conf.set('SIZEOF_DOUBLE', size_double)
+ffi_conf.set('HAVE_LONG_DOUBLE', 0)
+ffi_conf.set('HAVE_LONG_DOUBLE_VARIANT', 0)
+if host_cpu_family == 'alpha'
+  message('"long double" support is detected at compile-time')
+  ffi_conf.set('HAVE_LONG_DOUBLE', 'defined(__LONG_DOUBLE_128__)')
+elif host_cpu_family == 'mips'
+  message('"long double" support is detected at compile-time')
+  ffi_conf.set('HAVE_LONG_DOUBLE', 'defined(__mips64)')
+else
+  if size_long_double > 0
+    if size_long_double > size_double
+      message('sizeof "long double" is greater than "double"')
+      ffi_conf.set('HAVE_LONG_DOUBLE', 1)
+      if host_cpu_family == 'powerpc' and host_system != 'darwin'
+        message('"long double" size can be different')
+        ffi_conf.set('HAVE_LONG_DOUBLE_VARIANT', 1)
+      endif
+    endif
+  endif
+endif
+
+# Exception handling frame
+# FIXME: Actually check for this instead of hard-coding it
+# Also, check if this is actually correct
+if host_cpu_family == 'x86_64'
+  message('.eh_frame is hard-coded to not be ro')
+  ffi_conf.set('EH_FRAME_FLAGS', '"aw"')
+else
+  message('.eh_frame is hard-coded to ro')
+  ffi_conf.set('HAVE_RO_EH_FRAME', 1)
+  ffi_conf.set('EH_FRAME_FLAGS', '"a"')
+endif
+
+if ['arm', 'aarch64'].contains(host_cpu_family) and host_system == 'darwin'
+  message('Cannot use PROT_EXEC on this target, using fallback')
+  ffi_conf.set('FFI_EXEC_TRAMPOLINE_TABLE', 1)
+else
+  ffi_conf.set('FFI_EXEC_TRAMPOLINE_TABLE', 0)
+  if ['android', 'darwin', 'openbsd', 'freebsd', 'solaris'].contains(host_system)
+    message('Cannot use malloc on this target, using fallback')
+    ffi_conf.set('FFI_MMAP_EXEC_WRIT', 1)
+  endif
+endif
+
+if host_cpu_family == 'x86_64' and cc.get_id() != 'msvc'
+  # FIXME: Actually check for this instead of hard-coding it
+  message('Assembler supports .unwind section type')
+  ffi_conf.set('HAVE_AS_X86_64_UNWIND_SECTION_TYPE', 1)
+endif
+
+# Check mmap()
+# XXX: All these are unused
+#if cc.has_function('mmap')
+#  ffi_conf.set('HAVE_MMAP', 1)
+#endif
+#ffi_conf.set('HAVE_MMAP_FILE', 1) # Works everywhere
+#ffi_conf.set('HAVE_MMAP_DEV_ZERO',
+#  host_system != 'windows' and host_system != 'darwin')
+#mmap_anon = '''#include <sys/types.h>
+##include <sys/mman.h>
+##include <unistd.h>
+#
+##ifndef MAP_ANONYMOUS
+##define MAP_ANONYMOUS MAP_ANON
+##endif
+#
+#int n = MAP_ANONYMOUS;
+#'''
+#ffi_conf.set('HAVE_MMAP_ANON',
+#  cc.compiles(mmap_anon, name : 'mmap anonymous'))
+
+ffi_conf.set10('STDC_HEADERS', 1)
+
+# Misc functions
+#ffi_conf.set('HAVE_ALLOCA', cc.has_function('alloca')) # XXX: unused
+ffi_conf.set('HAVE_MEMCPY', cc.has_function('memcpy'))
+ffi_conf.set('HAVE_MEMFD_CREATE', cc.has_function('memfd_create'))
+ffi_conf.set('HAVE_MKOSTEMP', cc.has_function('mkostemp'))
+
+# Misc headers
+ffi_conf.set10('HAVE_ALLOCA_H', cc.has_header('alloca.h'))
+ffi_conf.set('HAVE_INTTYPES_H', cc.has_header('inttypes.h'))
+ffi_conf.set('HAVE_STDINT_H', cc.has_header('stdint.h'))
+ffi_conf.set('HAVE_SYS_MEMFD_H', cc.has_header('sys/memfd.h'))
+# Checks in the configure file that aren't used
+#ffi_conf.set10('HAVE_DLFCN_H', cc.has_header('dlfcn.h'))
+#ffi_conf.set10('HAVE_MEMORY_H', cc.has_header('memory.h'))
+#ffi_conf.set10('HAVE_STDLIB_H', cc.has_header('stdlib.h'))
+#ffi_conf.set10('HAVE_STRING_H', cc.has_header('string.h'))
+#ffi_conf.set10('HAVE_STRINGS_H', cc.has_header('strings.h'))
+#ffi_conf.set10('HAVE_SYS_MMAN_H', cc.has_header('sys/mman.h'))
+#ffi_conf.set10('HAVE_SYS_STAT_H', cc.has_header('sys/stat.h'))
+#ffi_conf.set10('HAVE_SYS_TYPES_H', cc.has_header('sys/types.h'))
+#ffi_conf.set10('HAVE_UNISTD_H', cc.has_header('unistd.h'))
+
+# Misc defines
+if cc.has_function_attribute('visibility')
+  t = find_program('test-cc-supports-hidden-visibility.py')
+  res = run_command(t, cc.cmd_array())
+  if res.returncode() == 0
+    message('.hidden pseudo-op is available')
+    ffi_conf.set('HAVE_HIDDEN_VISIBILITY_ATTRIBUTE', 1)
+  else
+    message('.hidden pseudo-op is NOT available: ' + res.stdout() + res.stderr())
+  endif
+endif
+
+# User options
+if get_option('ffi-debug')
+  ffi_conf.set('FFI_DEBUG', 1)
+endif
+if not get_option('raw_api')
+  ffi_conf.set('FFI_NO_RAW_API', 1)
+endif
+if not get_option('structs')
+  ffi_conf.set('FFI_NO_STRUCTS', 1)
+endif
+if get_option('purify_safety')
+  ffi_conf.set('USING_PURIFY', 1)
+endif
+if get_option('pax_emutramp')
+  ffi_conf.set('FFI_MMAP_EXEC_EMUTRAMP_PAX', 1)
+endif
+
+msvcc = find_program('msvcc.sh')
+
+ffiinc = [include_directories('.'), include_directories('include')]
+
+# Configure ffi_conf some more and declare libffi.so
+subdir('src')
+
+# Configure and install headers
+subdir('include')
+
+# Configure fficonfig.h (not installed)
+configure_file(input : 'fficonfig.h.meson', output : 'fficonfig.h',
+  configuration : ffi_conf)
+
+# TODO: Install texinfo files
+install_man([
+  'man/ffi.3',
+  'man/ffi_call.3',
+  'man/ffi_prep_cif.3',
+  'man/ffi_prep_cif_var.3'])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,11 @@
+# Toggle this if you want extra debugging
+option('ffi-debug', type : 'boolean', value : false)
+# Toggle this if you do not want support for aggregate types
+option('structs', type : 'boolean', value : true)
+# Toggle this if you do not want support for the raw API
+option('raw_api', type : 'boolean', value : true)
+# Toggle this if you are using Purify and want to suppress spurious messages
+option('purify_safety', type : 'boolean', value : false)
+# Toggle this if you want to enable pax emulated trampolines for PaX kernels
+# On PaX enable kernels that have MPROTECT enabled we can't use PROT_EXEC
+option('pax_emutramp', type : 'boolean', value : false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,165 @@
+ffi_c_sources = [
+  'prep_cif.c',
+  'types.c',
+  'raw_api.c',
+  'java_raw_api.c',
+  'closures.c',
+]
+
+ffi_asm_sources = []
+
+if get_option('ffi-debug')
+  ffi_c_sources += ['debug.c']
+endif
+
+# This if/else ladder is based on the configure.host file
+TARGET = ''
+if host_cpu_family.startswith('x86')
+  arch_subdir = 'x86'
+  if host_system == 'windows'
+    if size_t == 4
+      TARGET = 'X86_WIN32'
+      c_sources = ['ffi.c']
+      if cc.get_id() == 'msvc'
+        asm_sources = ['sysv_intel.S']
+      else
+        asm_sources = ['sysv.S']
+      endif
+    else
+      TARGET = 'X86_WIN64'
+      c_sources = ['ffiw64.c']
+      if cc.get_id() == 'msvc'
+        asm_sources = ['win64_intel.S']
+      else
+        asm_sources = ['win64.S']
+      endif
+    endif
+  elif ['darwin', 'ios', 'linux', 'android'].contains(host_system)
+    if size_t == 4
+      if ['darwin', 'ios'].contains(host_system)
+        TARGET = 'X86_DARWIN'
+      else
+        TARGET = 'X86'
+      # FIXME: TARGET_X32 support
+      endif
+      c_sources = ['ffi.c']
+      asm_sources = ['sysv.S']
+    else
+      TARGET = 'X86_64'
+      c_sources = ['ffi64.c', 'ffiw64.c']
+      asm_sources = ['unix64.S', 'win64.S']
+    endif
+  endif
+elif host_cpu_family == 'aarch64'
+  arch_subdir = 'aarch64'
+  TARGET = 'AARCH64'
+  c_sources = ['ffi.c']
+  if cc.get_id() == 'msvc'
+    asm_sources = ['win64_armasm.S']
+  else
+    asm_sources = ['sysv.S']
+  endif
+elif host_cpu_family == 'arm'
+  arch_subdir = 'arm'
+  TARGET = 'ARM'
+  c_sources = ['ffi.c']
+  asm_sources = ['sysv.S']
+elif host_cpu_family == 'mips'
+  arch_subdir = 'mips'
+  TARGET = 'MIPS'
+  c_sources = ['ffi.c']
+  asm_sources = ['o32.S', 'n32.S']
+elif host_cpu_family == 's390x'
+  arch_subdir = 's390'
+  TARGET = 'S390'
+  c_sources = ['ffi.c']
+  asm_sources = ['sysv.S']
+endif
+
+if TARGET == ''
+  error('Unsupported pair: system "@0@", cpu family "@1@"'.format(host_system, host_cpu_family))
+endif
+
+# Translate source files to source paths
+foreach c : c_sources
+  ffi_c_sources += arch_subdir + '/' + c
+endforeach
+foreach asm : asm_sources
+  ffi_asm_sources += arch_subdir + '/' + asm
+endforeach
+
+# Used in ffi.h.in to generate ffi-$arch.h
+ffi_conf.set('TARGET', TARGET)
+ffi_conf.set('VERSION', meson.project_version())
+
+ffi_conf.set10('STATIC', get_option('default_library') == 'static')
+
+if cc.get_id() == 'msvc'
+  # GCC and Clang accept assembly files directly, but MSVC's cl.exe does not.
+  # You need to manually pass the files through the pre-processor first and
+  # then through the assembler, and then link the objects into the target.
+  # FIXME: Add native support in Meson for this.
+  cl = find_program('cl')
+  if host_cpu_family.startswith('x86')
+    if host_cpu_family == 'x86'
+      ml = find_program('ml')
+    elif host_cpu_family == 'x86_64'
+      ml = find_program('ml64')
+    else
+      error('Unknown cpu_family: ' + host_cpu_family)
+    endif
+    assembler_args = [ml]
+    if host_cpu_family == 'x86'
+      assembler_args += '/safeseh'
+    endif
+    assembler_args += ['/Fo', '@OUTPUT@', '/c', '@INPUT@']
+    if get_option('buildtype').startswith('debug')
+      assembler_args += ['/Zi', '/Zd']
+    endif
+  elif host_cpu_family == 'aarch64'
+    assembler_args = [find_program('armasm64'), '-o', '@OUTPUT@', '@INPUT@']
+    if get_option('buildtype').startswith('debug')
+      assembler_args += ['-g']
+    endif
+  else
+    error('Unsupported MSVC target: ' + host_cpu_family)
+  endif
+  ffi_asm_objs = []
+  foreach asm_source : ffi_asm_sources
+    incflags = ['/I' + join_paths(meson.current_source_dir(), '..'),
+                '/I' + join_paths(meson.current_build_dir(), '..'),
+                '/I' + join_paths(meson.current_source_dir(), '..', 'include'),
+                '/I' + join_paths(meson.current_build_dir(), '..', 'include')]
+    preproc_name = asm_source.underscorify() + '.i'
+    obj_name = asm_source.underscorify() + '.obj'
+    preproc = custom_target(preproc_name,
+        input : asm_source,
+        output : preproc_name,
+        command : [cl, '/nologo', '/EP', '/P', '/Fi@OUTPUT@',
+                   '/DFFI_BUILDING', '@INPUT@'] + incflags)
+    ffi_asm_objs += custom_target(obj_name,
+        input : preproc,
+        output : obj_name,
+        command : assembler_args)
+  endforeach
+  ffi_asm_sources = ffi_asm_objs
+endif
+
+ffi_lib = library('ffi', ffi_c_sources, ffi_asm_sources,
+  include_directories : ffiinc,
+  # Taken from the libtool-version file
+  # current - age . age . revision
+  version : '7.1.0',
+  # current - age
+  soversion : '7',
+  # current + 1
+  darwin_versions : '9',
+  install : true)
+
+pkgconf = import('pkgconfig')
+pkgconf.generate(ffi_lib,
+  description : 'Library supporting Foreign Function Interfaces',
+  filebase : 'libffi')
+
+ffi_dep = declare_dependency(link_with : ffi_lib,
+  include_directories : ffiinc)

--- a/test-cc-supports-hidden-visibility.py
+++ b/test-cc-supports-hidden-visibility.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import subprocess
+
+# Put output files in the builddir
+os.chdir(os.environ['MESON_BUILD_ROOT'])
+
+infile = 'visibility-conftest.c'
+outfile = 'visibility-conftest.S'
+
+with open(infile, 'w') as f:
+    f.write('int __attribute__ ((visibility ("hidden"))) foo (void) { return 1; }')
+
+args = sys.argv[1:]
+args += ['-Werror', '-S', infile, '-o', outfile]
+res = subprocess.run(args, stdout=subprocess.PIPE, universal_newlines=True, check=True)
+
+regex = re.compile('\.(hidden|private_extern).*foo')
+with open(outfile, 'r') as f:
+    if regex.search(f.read()):
+        sys.exit(0)
+print('.hidden not found in the outputted assembly')
+sys.exit(1)


### PR DESCRIPTION
Don't know if this is of interest upstream, but just wanted to share
this great work by @nirbheek et al.

[Meson](https://mesonbuild.com/) has become the standard build system in
projects such as Frida, GNOME, GStreamer, GTK+, Mesa, Wayland, X.org, etc.
Many of these depend on libffi either directly or indirectly, so we've
ended up maintaining these build system bits that cover the targets we
currently need to support.