### PR TITLE
Add some missing #if conditionals from Apple's code drop

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -770,6 +770,8 @@ ffi_call (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue)
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
 
+#if FFI_CLOSURES
+
 #ifdef FFI_GO_CLOSURES
 void
 ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
@@ -1053,5 +1055,7 @@ ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
   return &trampoline_code_table;
 }
 #endif
+
+#endif /* FFI_CLOSURES */
 
 #endif /* (__aarch64__) || defined(__arm64__)|| defined (_M_ARM64)*/

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -273,7 +273,9 @@ CNAME(ffi_closure_SYSV):
 	/* Load ffi_closure_inner arguments.  */
 	ldp	PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]	/* load cif, fn */
 	ldr	PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]	/* load user_data */
+#ifdef FFI_GO_CLOSURES
 .Ldo_closure:
+#endif
 	add	x3, sp, #16				/* load context */
 	add	x4, sp, #ffi_closure_SYSV_FS		/* load stack */
 	add	x5, sp, #16+CALL_CONTEXT_SIZE		/* load rvalue */

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -213,6 +213,8 @@ CNAME(ffi_call_SYSV):
 	.size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
 #endif
 
+#if FFI_CLOSURES
+
 /* ffi_closure_SYSV
 
    Closure invocation glue. This is the low level code invoked directly by
@@ -513,6 +515,7 @@ CNAME(ffi_go_closure_SYSV):
 	.size	CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */
+#endif /* FFI_CLOSURES */
 #endif /* __arm64__ */
 
 #if defined __ELF__ && defined __linux__

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -537,6 +537,8 @@ ffi_prep_incoming_args_VFP (ffi_cif *cif, void *rvalue, char *stack,
   return rvalue;
 }
 
+#if FFI_CLOSURES
+
 struct closure_frame
 {
   char vfp_space[8*8] __attribute__((aligned(8)));
@@ -685,6 +687,8 @@ ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
   return FFI_OK;
 }
 #endif
+
+#endif /* FFI_CLOSURES */
 
 /* Below are routines for VFP hard-float support. */
 

--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -208,6 +208,7 @@ E(ARM_TYPE_STRUCT)
 	UNWIND(.fnend)
 ARM_FUNC_END(ffi_call_SYSV)
 
+#if FFI_CLOSURES
 
 /*
 	int ffi_closure_inner_* (cif, fun, user_data, frame)
@@ -400,6 +401,8 @@ ARM_FUNC_START(trampoline_code_table)
 ARM_FUNC_END(trampoline_code_table)
 	.align	ARM_TRAMP_MAP_SHIFT
 #endif /* FFI_EXEC_STATIC_TRAMP */
+
+#endif /* FFI_CLOSURES */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 


### PR DESCRIPTION
This pull requests adds some missing `#ifdefs` that we added internally in Apple's sources.  Sending this in a separate pull request to reduce noise in some followup pull requests for arm64e and trampoline changes.