### PR TITLE
Clarify intro and closure documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,32 @@ page for updates: <URL:http://sourceware.org/libffi/>.
 What is libffi?
 ===============
 
-Compilers for high level languages generate code that follow certain
-conventions. These conventions are necessary, in part, for separate
-compilation to work. One such convention is the "calling
-convention". The "calling convention" is essentially a set of
-assumptions made by the compiler about where function arguments will
-be found on entry to a function. A "calling convention" also specifies
-where the return value for a function is found.
+To expose and call functions between programs and libraries distributed
+as machine executable binaries, certain conventions are followed.  One
+such convention is the "calling convention".  The calling convention is
+a set of assumptions made by the compiler about where function arguments
+will be found on entry to a function.  A calling convention also
+specifies where the return value for a function is found.  The calling
+convention is also sometimes called the "ABI" or "Application Binary
+Interface".
 
-Some programs may not know at the time of compilation what arguments
-are to be passed to a function. For instance, an interpreter may be
-told at run-time about the number and types of arguments used to call
-a given function. Libffi can be used in such programs to provide a
-bridge from the interpreter program to compiled code.
+Some programs may not know at the time of compilation into a binary the
+functions called nor what arguments those functions expect.  For
+instance, an interpreter may find the number and types of arguments used
+to call a given function in the interpreted program at run-time. Libffi
+can be used in such programs to provide a bridge from the interpreted
+program to compiled code.
 
-The libffi library provides a portable, high level programming
-interface to various calling conventions. This allows a programmer to
-call any function specified by a call interface description at run
-time.  
+The libffi library provides a portable, high level programming interface
+to various calling conventions.  This allows a programmer to call any
+function specified by a call interface description at run time.
 
-FFI stands for Foreign Function Interface.  A foreign function
-interface is the popular name for the interface that allows code
-written in one language to call code written in another language. The
-libffi library really only provides the lowest, machine dependent
-layer of a fully featured foreign function interface. A layer must
-exist above libffi that handles type conversions for values passed
-between the two languages.
+FFI stands for Foreign Function Interface.  A foreign function interface
+is the popular name for the interface that allows code written in one
+language to call code written in another language. The libffi library
+really only provides the lowest, machine dependent layer of a fully
+featured foreign function interface.  A layer must exist above libffi
+that handles type conversions for the local function interface.
 
 
 Supported Platforms
@@ -137,15 +137,15 @@ install autoconf, automake and libtool.
 
 You may want to tell configure where to install the libffi library and
 header files. To do that, use the ``--prefix`` configure switch.  Libffi
-will install under /usr/local by default. 
+will install under /usr/local by default.
 
 If you want to enable extra run-time debugging checks use the the
 ``--enable-debug`` configure switch. This is useful when your program dies
-mysteriously while using libffi. 
+mysteriously while using libffi.
 
 Another useful configure switch is ``--enable-purify-safety``. Using this
 will add some extra code which will suppress certain warnings when you
-are using Purify with libffi. Only use this switch when using 
+are using Purify with libffi. Only use this switch when using
 Purify, as it will slow down the library.
 
 If you don't want to build documentation, use the ``--disable-docs``
@@ -164,7 +164,7 @@ For 64-bit Windows builds, use ``CC="path/to/msvcc.sh -m64"`` and
 It is also possible to build libffi on Windows platforms with the LLVM
 project's clang-cl compiler, like below:
 
-    path/to/configure CC="path/to/msvcc.sh -clang-cl" CXX="path/to/msvcc.sh -clang-cl" LD=link CPP="clang-cl -EP" 
+    path/to/configure CC="path/to/msvcc.sh -clang-cl" CXX="path/to/msvcc.sh -clang-cl" LD=link CPP="clang-cl -EP"
 
 When building with MSVC under a MingW environment, you may need to
 remove the line in configure that sets 'fix_srcfile_path' to a 'cygpath'
@@ -216,10 +216,10 @@ See the git log for details at http://github.com/libffi/libffi.
         Raw java (gcj) API deprecated.
         Add pre-built PDF documentation to source distribution.
         Many new test cases and bug fixes.
-        
+
     3.2.1 Nov-12-14
         Build fix for non-iOS AArch64 targets.
-    
+
     3.2 Nov-11-14
         Add C99 Complex Type support (currently only supported on
           s390).
@@ -227,7 +227,7 @@ See the git log for details at http://github.com/libffi/libffi.
           Windows/Linux.
         Add OpenRISC and Cygwin-64 support.
         Bug fixes.
-    
+
     3.1 May-19-14
         Add AArch64 (ARM64) iOS support.
         Add Nios II support.
@@ -240,7 +240,7 @@ See the git log for details at http://github.com/libffi/libffi.
           failures, and respect the $CC and $CXX environment variables.
         Archive off the manually maintained ChangeLog in favor of git
           log.
-    
+
     3.0.13 Mar-17-13
         Add Meta support.
         Add missing Moxie bits.
@@ -250,7 +250,7 @@ See the git log for details at http://github.com/libffi/libffi.
         Fix the install dir location for some platforms when building
           with GCC (OS X, Solaris).
         Fix Cygwin regression.
-    
+
     3.0.12 Feb-11-13
         Add Moxie support.
         Add AArch64 support.
@@ -262,7 +262,7 @@ See the git log for details at http://github.com/libffi/libffi.
         Add support for native vendor compilers on
           Solaris and AIX.
         Work around LLVM/GCC interoperability issue on x86_64.
-    
+
     3.0.11 Apr-11-12
         Lots of build fixes.
         Add support for variadic functions (ffi_prep_cif_var).
@@ -273,7 +273,7 @@ See the git log for details at http://github.com/libffi/libffi.
         Integration with iOS' xcode build tools.
         Fix Octeon and MC68881 support.
         Fix code pessimizations.
-    
+
     3.0.10 Aug-23-11
         Add support for Apple's iOS.
         Add support for ARM VFP ABI.
@@ -287,128 +287,128 @@ See the git log for details at http://github.com/libffi/libffi.
           Solaris compiler.
         Testsuite fixes for Tru64 Unix.
         Additional platform support.
-    
+
     3.0.9 Dec-31-09
         Add AVR32 and win64 ports.  Add ARM softfp support.
         Many fixes for AIX, Solaris, HP-UX, *BSD.
         Several PowerPC and x86-64 bug fixes.
         Build DLL for windows.
-    
+
     3.0.8 Dec-19-08
         Add *BSD, BeOS, and PA-Linux support.
-    
+
     3.0.7 Nov-11-08
         Fix for ppc FreeBSD.
         (thanks to Andreas Tobler)
-    
+
     3.0.6 Jul-17-08
         Fix for closures on sh.
         Mark the sh/sh64 stack as non-executable.
         (both thanks to Kaz Kojima)
-    
+
     3.0.5 Apr-3-08
         Fix libffi.pc file.
         Fix #define ARM for IcedTea users.
         Fix x86 closure bug.
-    
+
     3.0.4 Feb-24-08
         Fix x86 OpenBSD configury.
-    
+
     3.0.3 Feb-22-08
         Enable x86 OpenBSD thanks to Thomas Heller, and
           x86-64 FreeBSD thanks to Björn König and Andreas Tobler.
         Clean up test instruction in README.
-    
+
     3.0.2 Feb-21-08
         Improved x86 FreeBSD support.
         Thanks to Björn König.
-    
+
     3.0.1 Feb-15-08
         Fix instruction cache flushing bug on MIPS.
         Thanks to David Daney.
-    
+
     3.0.0 Feb-15-08
         Many changes, mostly thanks to the GCC project.
         Cygnus Solutions is now Red Hat.
-    
+
       [10 years go by...]
-    
+
     1.20 Oct-5-98
         Raffaele Sena produces ARM port.
-    
+
     1.19 Oct-5-98
         Fixed x86 long double and long long return support.
         m68k bug fixes from Andreas Schwab.
         Patch for DU assembler compatibility for the Alpha from Richard
           Henderson.
-    
+
     1.18 Apr-17-98
         Bug fixes and MIPS configuration changes.
-    
+
     1.17 Feb-24-98
         Bug fixes and m68k port from Andreas Schwab. PowerPC port from
         Geoffrey Keating. Various bug x86, Sparc and MIPS bug fixes.
-    
+
     1.16 Feb-11-98
         Richard Henderson produces Alpha port.
-    
+
     1.15 Dec-4-97
         Fixed an n32 ABI bug. New libtool, auto* support.
-    
+
     1.14 May-13-97
         libtool is now used to generate shared and static libraries.
         Fixed a minor portability problem reported by Russ McManus
         <mcmanr@eq.gs.com>.
-    
+
     1.13 Dec-2-96
         Added --enable-purify-safety to keep Purify from complaining
           about certain low level code.
         Sparc fix for calling functions with < 6 args.
         Linux x86 a.out fix.
-    
+
     1.12 Nov-22-96
-        Added missing ffi_type_void, needed for supporting void return 
-          types. Fixed test case for non MIPS machines. Cygnus Support 
-          is now Cygnus Solutions. 
-    
+        Added missing ffi_type_void, needed for supporting void return
+          types. Fixed test case for non MIPS machines. Cygnus Support
+          is now Cygnus Solutions.
+
     1.11 Oct-30-96
         Added notes about GNU make.
-    
+
     1.10 Oct-29-96
         Added configuration fix for non GNU compilers.
-    
+
     1.09 Oct-29-96
-        Added --enable-debug configure switch. Clean-ups based on LCLint 
-        feedback. ffi_mips.h is always installed. Many configuration 
+        Added --enable-debug configure switch. Clean-ups based on LCLint
+        feedback. ffi_mips.h is always installed. Many configuration
         fixes. Fixed ffitest.c for sparc builds.
-    
+
     1.08 Oct-15-96
         Fixed n32 problem. Many clean-ups.
-    
+
     1.07 Oct-14-96
         Gordon Irlam rewrites v8.S again. Bug fixes.
-    
+
     1.06 Oct-14-96
-        Gordon Irlam improved the sparc port. 
-    
+        Gordon Irlam improved the sparc port.
+
     1.05 Oct-14-96
         Interface changes based on feedback.
-    
+
     1.04 Oct-11-96
         Sparc port complete (modulo struct passing bug).
-    
+
     1.03 Oct-10-96
         Passing struct args, and returning struct values works for
         all architectures/calling conventions. Expanded tests.
-    
+
     1.02 Oct-9-96
         Added SGI n32 support. Fixed bugs in both o32 and Linux support.
         Added "make test".
-    
+
     1.01 Oct-8-96
         Fixed float passing bug in mips version. Restructured some
         of the code. Builds cleanly with SGI tools.
-    
+
     1.00 Oct-7-96
         First release. No public announcement.
 

--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -75,23 +75,24 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 @node Introduction
 @chapter What is libffi?
 
-Compilers for high level languages generate code that follow certain
-conventions.  These conventions are necessary, in part, for separate
-compilation to work.  One such convention is the @dfn{calling
-convention}.  The calling convention is a set of assumptions made by
-the compiler about where function arguments will be found on entry to
-a function.  A calling convention also specifies where the return
-value for a function is found.  The calling convention is also
-sometimes called the @dfn{ABI} or @dfn{Application Binary Interface}.
+To expose and call functions between programs and libraries distributed
+as machine executable binaries, certain conventions are followed.  One
+such convention is the @dfn{calling convention}.  The calling convention
+is a set of assumptions made by the compiler about where function
+arguments will be found on entry to a function.  A calling convention
+also specifies where the return value for a function is found.  The
+calling convention is also sometimes called the @dfn{ABI} or
+@dfn{Application Binary Interface}.
 @cindex calling convention
 @cindex ABI
 @cindex Application Binary Interface
 
-Some programs may not know at the time of compilation what arguments
-are to be passed to a function.  For instance, an interpreter may be
-told at run-time about the number and types of arguments used to call
-a given function.  @samp{Libffi} can be used in such programs to
-provide a bridge from the interpreter program to compiled code.
+Some programs may not know at the time of compilation into a binary the
+functions called nor what arguments those functions expect.  For
+instance, an interpreter may find the number and types of arguments used
+to call a given function in the interpreted program at run-time.
+@samp{Libffi} can be used in such programs to provide a bridge from the
+interpreted program to compiled code.
 
 The @samp{libffi} library provides a portable, high level programming
 interface to various calling conventions.  This allows a programmer to
@@ -104,7 +105,7 @@ code written in one language to call code written in another language.
 The @samp{libffi} library really only provides the lowest, machine
 dependent layer of a fully featured foreign function interface.  A
 layer must exist above @samp{libffi} that handles type conversions for
-values passed between the two languages.
+the local function interface.
 @cindex FFI
 @cindex Foreign Function Interface
 
@@ -114,6 +115,7 @@ values passed between the two languages.
 
 @menu
 * The Basics::                  The basic libffi API.
+* Calling a function::          Making a call to a foreign function.
 * Simple Example::              A simple example.
 * Types::                       libffi type descriptions.
 * Multiple ABIs::               Different passing styles on one platform.
@@ -126,9 +128,11 @@ values passed between the two languages.
 @node The Basics
 @section The Basics
 
-@samp{Libffi} assumes that you have a pointer to the function you wish
-to call and that you know the number and types of arguments to pass
-it, as well as the return type of the function.
+@samp{Libffi} assumes that any function is identified by a pointer
+value. You also must know the number and types of arguments, as well as
+the return type of the function. The arguments, return type and calling
+convention are called the @dfn{function signature}.
+@cindex function signature
 
 The first thing you must do is create an @code{ffi_cif} object that
 matches the signature of the function you wish to call.  This is a
@@ -181,7 +185,9 @@ function when different numbers of arguments are passed.
 
 Also note that a call to @code{ffi_prep_cif_var} with
 @var{nfixedargs}=@var{nototalargs} is NOT equivalent to a call to
-@code{ffi_prep_cif}.
+@code{ffi_prep_cif}. A variadic function calling convention can be
+different from the calling convention of a function with fixed arguments
+even when the arguments are the same.
 
 @end defun
 
@@ -190,7 +196,11 @@ Note that the resulting @code{ffi_cif} holds pointers to all the
 must ensure that these type objects have a lifetime at least as long
 as that of the @code{ffi_cif}.
 
-To call a function using an initialized @code{ffi_cif}, use the
+
+@node Calling a function
+@section Calling a function
+
+To make a call to function using an initialized @code{ffi_cif}, use the
 @code{ffi_call} function:
 
 @findex ffi_call
@@ -249,26 +259,26 @@ int main()
   void *values[1];
   char *s;
   ffi_arg rc;
-  
-  /* Initialize the argument info vectors */    
+
+  /* Initialize the argument info vectors */
   args[0] = &ffi_type_pointer;
   values[0] = &s;
-  
+
   /* Initialize the cif */
-  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1, 
+  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
 		       &ffi_type_sint, args) == FFI_OK)
     @{
       s = "Hello World!";
       ffi_call(&cif, puts, &rc, values);
       /* rc now holds the result of the call to puts */
-      
-      /* values holds a pointer to the function's arg, so to 
-         call puts() again all we need to do is change the 
+
+      /* values holds a pointer to the function's arg, so to
+         call puts() again all we need to do is change the
          value of s */
       s = "This is cool!";
       ffi_call(&cif, puts, &rc, values);
     @}
-  
+
   return 0;
 @}
 @end example
@@ -624,7 +634,7 @@ Here is the corresponding code to describe this struct to
       tm_type.size = tm_type.alignment = 0;
       tm_type.type = FFI_TYPE_STRUCT;
       tm_type.elements = &tm_type_elements;
-    
+
       for (i = 0; i < 9; i++)
           tm_type_elements[i] = &ffi_type_sint;
 
@@ -782,10 +792,12 @@ necessarily platform-specific.
 @node The Closure API
 @section The Closure API
 
-@code{libffi} also provides a way to write a generic function -- a
-function that can accept and decode any combination of arguments.
-This can be useful when writing an interpreter, or to provide wrappers
-for arbitrary functions.
+To receive function calls, you need to create new function pointer
+values at run time. You can pass these pointer values to foreign code
+for example as callback function pointers. Once the new function
+receives a call, you need to read parameters and provide the value on
+return. This way an interpreter can support a binary calling convention
+for functions defined in the interpreted language.
 
 This facility is called the @dfn{closure API}.  Closures are not
 supported on all platforms; you can check the @code{FFI_CLOSURES}
@@ -803,21 +815,23 @@ functions:
 @findex ffi_closure_alloc
 @defun void *ffi_closure_alloc (size_t @var{size}, void **@var{code})
 Allocate a chunk of memory holding @var{size} bytes.  This returns a
-pointer to the writable address, and sets *@var{code} to the
-corresponding executable address.
+pointer to the writable address. *@var{code} is set to the new function
+pointer value.
 
-@var{size} should be sufficient to hold a @code{ffi_closure} object.
+@var{size} must be sufficient to hold a @code{ffi_closure} object.
 @end defun
 
 @findex ffi_closure_free
 @defun void ffi_closure_free (void *@var{writable})
 Free memory allocated using @code{ffi_closure_alloc}.  The argument is
-the writable address that was returned.
+the writable address that was returned.  The allocated function pointer
+value can no longer be used and may be reused in subsequent
+@code{ffi_closure_alloc}.
 @end defun
 
 
 Once you have allocated the memory for a closure, you must construct a
-@code{ffi_cif} describing the function call.  Finally you can prepare
+@code{ffi_cif} for the function call signature.  Finally you can prepare
 the closure function:
 
 @findex ffi_prep_closure_loc
@@ -840,7 +854,7 @@ An arbitrary datum that is passed, uninterpreted, to your closure
 function.
 
 @item codeloc
-The executable address returned by @code{ffi_closure_alloc}.
+The function pointer value returned by @code{ffi_closure_alloc}.
 
 @item fun
 The function which will be called when the closure is invoked.  It is
@@ -887,7 +901,7 @@ writable and executable addresses.
 @node Closure Example
 @section Closure Example
 
-A trivial example that creates a new @code{puts} by binding 
+A trivial example that creates a new @code{puts} by binding
 @code{fputs} with @code{stdout}.
 
 @example


### PR DESCRIPTION
I found the descriptions difficult to understand. Here is an attempt to make them easier for someone without prior knowledge in the library.

I also noticed on libffi-discuss the variadic function calling convention difference from fixed arguments had not been clear.

Modified files contained some trailing whitespace that was removed by my editor. I committed the cleanup.