### PR TITLE
Don't stop test on copy failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ shallow_clone: true
 #  32- and 64-bit clang/mingw
 #  and perhaps more.
 
-image: Visual Studio 2019
+image: Visual Studio 2017
 platform:
   - x64
   - x86
@@ -65,7 +65,7 @@ install:
   - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P dejagnu -P autoconf -P automake -P libtool'
   - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
   - echo call VsDevCmd to set VS150COMNTOOLS
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
   - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
   - echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
   - call "%VSCOMNTOOLS%..\..\vc\Auxiliary\Build\vcvarsall.bat" %VCVARS_PLATFORM%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,8 +21,8 @@ configuration:
 
 environment:
   global:
-    CYG_ROOT: C:/cygwin
-    CYG_CACHE: C:/cygwin/var/cache/setup
+    CYG_ROOT: C:/cygwin64
+    CYG_CACHE: C:/cygwin64/var/cache/setup
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     VSVER: 15
   matrix:
@@ -71,13 +71,13 @@ install:
   - call "%VSCOMNTOOLS%..\..\vc\Auxiliary\Build\vcvarsall.bat" %VCVARS_PLATFORM%
 
 build_script:
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; ./autogen.sh)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; ./configure CC='%MSVCC%' CXX='%MSVCC%' LD='link' CPP='cl -nologo -EP' CXXCPP='cl -nologo -EP' CPPFLAGS='-DFFI_BUILDING_DLL' AR='/cygdrive/c/projects/libffi/.travis/ar-lib lib' NM='dumpbin -symbols' STRIP=':' --build=$BUILD --host=$HOST $DEBUG_ARG $SHARED_ARG)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cp src/%SRC_ARCHITECTURE%/ffitarget.h include)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; make)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cp `find . -name 'libffi-?.dll'` $HOST/testsuite/ || true)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; make check RUNTESTFLAGS='-v -v -v -v')"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; ./autogen.sh)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; ./configure CC='%MSVCC%' CXX='%MSVCC%' LD='link' CPP='cl -nologo -EP' CXXCPP='cl -nologo -EP' CPPFLAGS='-DFFI_BUILDING_DLL' AR='/cygdrive/c/projects/libffi/.travis/ar-lib lib' NM='dumpbin -symbols' STRIP=':' --build=$BUILD --host=$HOST $DEBUG_ARG $SHARED_ARG)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cp src/%SRC_ARCHITECTURE%/ffitarget.h include)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; make)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cp `find . -name 'libffi-?.dll'` $HOST/testsuite/ || true)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; make check RUNTESTFLAGS='-v -v -v -v')"
 
 
 on_finish:
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cat `find ./ -name libffi.log`)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cat `find ./ -name libffi.log`)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ install:
           $env:DEBUG_ARG="--disable-debug"
       }
   - 'appveyor DownloadFile https://cygwin.com/setup-x86_64.exe -FileName setup.exe'
-  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P dejagnu -P autoconf -P automake -P libtool'
+  - 'setup.exe -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P dejagnu -P autoconf -P automake -P libtool'
   - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
   - echo call VsDevCmd to set VS150COMNTOOLS
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -75,8 +75,9 @@ build_script:
   - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; ./configure CC='%MSVCC%' CXX='%MSVCC%' LD='link' CPP='cl -nologo -EP' CXXCPP='cl -nologo -EP' CPPFLAGS='-DFFI_BUILDING_DLL' AR='/cygdrive/c/projects/libffi/.travis/ar-lib lib' NM='dumpbin -symbols' STRIP=':' --build=$BUILD --host=$HOST $DEBUG_ARG $SHARED_ARG)"
   - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cp src/%SRC_ARCHITECTURE%/ffitarget.h include)"
   - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; make)"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cp $HOST/.libs/libffi.lib $HOST/testsuite/libffi-8.lib || true)"
   - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; cp `find . -name 'libffi-?.dll'` $HOST/testsuite/ || true)"
-  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; make check RUNTESTFLAGS='-v -v -v -v')"
+  - c:\cygwin64\bin\sh -lc "(cd $OLDPWD; TERM=none make check RUNTESTFLAGS='-v -v -v -v --target '$HOST  DEJAGNU=$PWD/.appveyor/site.exp SITEDIR=$PWD/.appveyor)"
 
 
 on_finish:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,8 +61,8 @@ install:
         } Else {
           $env:DEBUG_ARG="--disable-debug"
       }
-  - 'appveyor DownloadFile https://cygwin.com/setup-x86.exe -FileName setup.exe'
-  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P dejagnu,automake'
+  - 'appveyor DownloadFile https://cygwin.com/setup-x86_64.exe -FileName setup.exe'
+  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P dejagnu -P autoconf -P automake -P libtool'
   - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
   - echo call VsDevCmd to set VS150COMNTOOLS
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -75,7 +75,7 @@ build_script:
   - c:\cygwin\bin\sh -lc "(cd $OLDPWD; ./configure CC='%MSVCC%' CXX='%MSVCC%' LD='link' CPP='cl -nologo -EP' CXXCPP='cl -nologo -EP' CPPFLAGS='-DFFI_BUILDING_DLL' AR='/cygdrive/c/projects/libffi/.travis/ar-lib lib' NM='dumpbin -symbols' STRIP=':' --build=$BUILD --host=$HOST $DEBUG_ARG $SHARED_ARG)"
   - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cp src/%SRC_ARCHITECTURE%/ffitarget.h include)"
   - c:\cygwin\bin\sh -lc "(cd $OLDPWD; make)"
-  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cp `find . -name 'libffi-?.dll'` $HOST/testsuite/)"
+  - c:\cygwin\bin\sh -lc "(cd $OLDPWD; cp `find . -name 'libffi-?.dll'` $HOST/testsuite/ || true)"
   - c:\cygwin\bin\sh -lc "(cd $OLDPWD; make check RUNTESTFLAGS='-v -v -v -v')"
   
   

--- a/.appveyor/site.exp
+++ b/.appveyor/site.exp
@@ -1,0 +1,16 @@
+# Copyright (C) 2021  Anthony Green
+
+lappend boards_dir $::env(SITEDIR)
+
+verbose "Global Config File: target_triplet is $target_triplet" 1
+global target_list
+
+case "$target_triplet" in {
+    { "aarch*cygwin*" } {
+	set target_list "unix-noexec"
+    }
+    { "arm*cygwin*" } {
+	set target_list "unix-noexec"
+    }
+}
+

--- a/.appveyor/unix-noexec.exp
+++ b/.appveyor/unix-noexec.exp
@@ -1,0 +1,7 @@
+load_generic_config "remote"
+
+proc noexec_load { dest prog args } {
+  return "unsupported"  
+}
+
+set_board_info protocol "noexec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - if test x"$MEVAL" != x; then eval ${MEVAL}; fi
 
 install:
-  - travis_wait 30 ./.travis/install.sh
+  - travis_wait 60 ./.travis/install.sh
 
 script:
   - if ! test x"$MEVAL" = x; then eval ${MEVAL}; fi


### PR DESCRIPTION
Static-library tests were failing only because there were
no DLLs to copy.  This change makes a copy failure not stop
the build; if a failed copy would otherwise be relevent, the
later tests would fail anyway.

While there are more clever ways to solve this, a brute force
fix is sufficient.