### PR TITLE
Fix build on OpenBSD/mips64

### DIFF
--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -582,7 +582,7 @@ cls_epilogue:
 	.end	ffi_closure_N32
 
 #ifdef __GNUC__
-        .section        .eh_frame,"aw",@progbits
+        .section        .eh_frame,EH_FRAME_FLAGS,@progbits
 .Lframe1:
         .4byte  .LECIE1-.LSCIE1		# length
 .LSCIE1:


### PR DESCRIPTION
The build fails on OpenBSD/mips64 because clang 11's integrated assembler expects read-only .eh_frame:

```
../src/mips/n32.S:585:9: error: changed section flags for .eh_frame, expected: 0x2
        .section .eh_frame,"aw",@progbits
        ^
```

Use EH_FRAME_FLAGS to get matching flags for the section.