### PR TITLE
Make test helper methods static

### DIFF
--- a/testsuite/libffi.closures/cls_20byte.c
+++ b/testsuite/libffi.closures/cls_20byte.c
@@ -14,7 +14,7 @@ typedef struct cls_struct_20byte {
   int c;
 } cls_struct_20byte;
 
-cls_struct_20byte cls_struct_20byte_fn(struct cls_struct_20byte a1,
+static cls_struct_20byte cls_struct_20byte_fn(struct cls_struct_20byte a1,
 			    struct cls_struct_20byte a2)
 {
   struct cls_struct_20byte result;

--- a/testsuite/libffi.closures/cls_20byte1.c
+++ b/testsuite/libffi.closures/cls_20byte1.c
@@ -16,7 +16,7 @@ typedef struct cls_struct_20byte {
   double c;
 } cls_struct_20byte;
 
-cls_struct_20byte cls_struct_20byte_fn(struct cls_struct_20byte a1,
+static cls_struct_20byte cls_struct_20byte_fn(struct cls_struct_20byte a1,
 			    struct cls_struct_20byte a2)
 {
   struct cls_struct_20byte result;

--- a/testsuite/libffi.closures/cls_5_1_byte.c
+++ b/testsuite/libffi.closures/cls_5_1_byte.c
@@ -16,7 +16,7 @@ typedef struct cls_struct_5byte {
   unsigned char e;
 } cls_struct_5byte;
 
-cls_struct_5byte cls_struct_5byte_fn(struct cls_struct_5byte a1,
+static cls_struct_5byte cls_struct_5byte_fn(struct cls_struct_5byte a1,
 			    struct cls_struct_5byte a2)
 {
   struct cls_struct_5byte result;

--- a/testsuite/libffi.closures/cls_5byte.c
+++ b/testsuite/libffi.closures/cls_5byte.c
@@ -14,7 +14,7 @@ typedef struct cls_struct_5byte {
   unsigned char c;
 } cls_struct_5byte;
 
-cls_struct_5byte cls_struct_5byte_fn(struct cls_struct_5byte a1,
+static cls_struct_5byte cls_struct_5byte_fn(struct cls_struct_5byte a1,
 			    struct cls_struct_5byte a2)
 {
   struct cls_struct_5byte result;

--- a/testsuite/libffi.closures/cls_6_1_byte.c
+++ b/testsuite/libffi.closures/cls_6_1_byte.c
@@ -17,7 +17,7 @@ typedef struct cls_struct_6byte {
   unsigned char f;
 } cls_struct_6byte;
 
-cls_struct_6byte cls_struct_6byte_fn(struct cls_struct_6byte a1,
+static cls_struct_6byte cls_struct_6byte_fn(struct cls_struct_6byte a1,
 			    struct cls_struct_6byte a2)
 {
   struct cls_struct_6byte result;

--- a/testsuite/libffi.closures/cls_6byte.c
+++ b/testsuite/libffi.closures/cls_6byte.c
@@ -16,7 +16,7 @@ typedef struct cls_struct_6byte {
   unsigned char d;
 } cls_struct_6byte;
 
-cls_struct_6byte cls_struct_6byte_fn(struct cls_struct_6byte a1,
+static cls_struct_6byte cls_struct_6byte_fn(struct cls_struct_6byte a1,
 			    struct cls_struct_6byte a2)
 {
   struct cls_struct_6byte result;

--- a/testsuite/libffi.closures/cls_7_1_byte.c
+++ b/testsuite/libffi.closures/cls_7_1_byte.c
@@ -18,7 +18,7 @@ typedef struct cls_struct_7byte {
   unsigned char g;
 } cls_struct_7byte;
 
-cls_struct_7byte cls_struct_7byte_fn(struct cls_struct_7byte a1,
+static cls_struct_7byte cls_struct_7byte_fn(struct cls_struct_7byte a1,
 			    struct cls_struct_7byte a2)
 {
   struct cls_struct_7byte result;

--- a/testsuite/libffi.closures/cls_7byte.c
+++ b/testsuite/libffi.closures/cls_7byte.c
@@ -15,7 +15,7 @@ typedef struct cls_struct_7byte {
   unsigned short d;
 } cls_struct_7byte;
 
-cls_struct_7byte cls_struct_7byte_fn(struct cls_struct_7byte a1,
+static cls_struct_7byte cls_struct_7byte_fn(struct cls_struct_7byte a1,
 			    struct cls_struct_7byte a2)
 {
   struct cls_struct_7byte result;

--- a/testsuite/libffi.closures/cls_9byte1.c
+++ b/testsuite/libffi.closures/cls_9byte1.c
@@ -15,7 +15,7 @@ typedef struct cls_struct_9byte {
   double b;
 } cls_struct_9byte;
 
-cls_struct_9byte cls_struct_9byte_fn(struct cls_struct_9byte b1,
+static cls_struct_9byte cls_struct_9byte_fn(struct cls_struct_9byte b1,
 			    struct cls_struct_9byte b2)
 {
   struct cls_struct_9byte result;

--- a/testsuite/libffi.closures/cls_9byte2.c
+++ b/testsuite/libffi.closures/cls_9byte2.c
@@ -15,7 +15,7 @@ typedef struct cls_struct_9byte {
   int b;
 } cls_struct_9byte;
 
-cls_struct_9byte cls_struct_9byte_fn(struct cls_struct_9byte b1,
+static cls_struct_9byte cls_struct_9byte_fn(struct cls_struct_9byte b1,
 			    struct cls_struct_9byte b2)
 {
   struct cls_struct_9byte result;

--- a/testsuite/libffi.closures/cls_align_double.c
+++ b/testsuite/libffi.closures/cls_align_double.c
@@ -15,7 +15,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_float.c
+++ b/testsuite/libffi.closures/cls_align_float.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_longdouble.c
+++ b/testsuite/libffi.closures/cls_align_longdouble.c
@@ -14,7 +14,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_longdouble_split.c
+++ b/testsuite/libffi.closures/cls_align_longdouble_split.c
@@ -19,7 +19,7 @@ typedef struct cls_struct_align {
   long double g;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(
+static cls_struct_align cls_struct_align_fn(
 	cls_struct_align	a1,
 	cls_struct_align	a2)
 {

--- a/testsuite/libffi.closures/cls_align_longdouble_split2.c
+++ b/testsuite/libffi.closures/cls_align_longdouble_split2.c
@@ -20,7 +20,7 @@ typedef struct cls_struct_align {
   long double g;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(
+static cls_struct_align cls_struct_align_fn(
 	cls_struct_align	a1,
 	cls_struct_align	a2)
 {

--- a/testsuite/libffi.closures/cls_align_pointer.c
+++ b/testsuite/libffi.closures/cls_align_pointer.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_sint16.c
+++ b/testsuite/libffi.closures/cls_align_sint16.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_sint32.c
+++ b/testsuite/libffi.closures/cls_align_sint32.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_sint64.c
+++ b/testsuite/libffi.closures/cls_align_sint64.c
@@ -14,7 +14,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_uint16.c
+++ b/testsuite/libffi.closures/cls_align_uint16.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_uint32.c
+++ b/testsuite/libffi.closures/cls_align_uint32.c
@@ -13,7 +13,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_align_uint64.c
+++ b/testsuite/libffi.closures/cls_align_uint64.c
@@ -15,7 +15,7 @@ typedef struct cls_struct_align {
   unsigned char c;
 } cls_struct_align;
 
-cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
+static cls_struct_align cls_struct_align_fn(struct cls_struct_align a1,
 			    struct cls_struct_align a2)
 {
   struct cls_struct_align result;

--- a/testsuite/libffi.closures/cls_multi_schar.c
+++ b/testsuite/libffi.closures/cls_multi_schar.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-signed char test_func_fn(signed char a1, signed char a2)
+static signed char test_func_fn(signed char a1, signed char a2)
 {
   signed char result;
 

--- a/testsuite/libffi.closures/cls_multi_sshort.c
+++ b/testsuite/libffi.closures/cls_multi_sshort.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-signed short test_func_fn(signed short a1, signed short a2)
+static signed short test_func_fn(signed short a1, signed short a2)
 {
   signed short result;
 

--- a/testsuite/libffi.closures/cls_multi_sshortchar.c
+++ b/testsuite/libffi.closures/cls_multi_sshortchar.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-signed short test_func_fn(signed char a1, signed short a2,
+static signed short test_func_fn(signed char a1, signed short a2,
 			  signed char a3, signed short a4)
 {
   signed short result;

--- a/testsuite/libffi.closures/cls_multi_uchar.c
+++ b/testsuite/libffi.closures/cls_multi_uchar.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-unsigned char test_func_fn(unsigned char a1, unsigned char a2,
+static unsigned char test_func_fn(unsigned char a1, unsigned char a2,
 			   unsigned char a3, unsigned char a4)
 {
   unsigned char result;

--- a/testsuite/libffi.closures/cls_multi_ushort.c
+++ b/testsuite/libffi.closures/cls_multi_ushort.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-unsigned short test_func_fn(unsigned short a1, unsigned short a2)
+static unsigned short test_func_fn(unsigned short a1, unsigned short a2)
 {
   unsigned short result;
 

--- a/testsuite/libffi.closures/cls_multi_ushortchar.c
+++ b/testsuite/libffi.closures/cls_multi_ushortchar.c
@@ -7,7 +7,7 @@
 /* { dg-do run } */
 #include "ffitest.h"
 
-unsigned short test_func_fn(unsigned char a1, unsigned short a2,
+static unsigned short test_func_fn(unsigned char a1, unsigned short a2,
 			    unsigned char a3, unsigned short a4)
 {
   unsigned short result;

--- a/testsuite/libffi.closures/nested_struct.c
+++ b/testsuite/libffi.closures/nested_struct.c
@@ -25,7 +25,7 @@ typedef struct cls_struct_combined {
   cls_struct_16byte2 e;
 } cls_struct_combined;
 
-cls_struct_combined cls_struct_combined_fn(struct cls_struct_16byte1 b0,
+static cls_struct_combined cls_struct_combined_fn(struct cls_struct_16byte1 b0,
 			    struct cls_struct_16byte2 b1,
 			    struct cls_struct_combined b2)
 {

--- a/testsuite/libffi.closures/nested_struct1.c
+++ b/testsuite/libffi.closures/nested_struct1.c
@@ -25,7 +25,7 @@ typedef struct cls_struct_combined {
   cls_struct_16byte2 e;
 } cls_struct_combined;
 
-cls_struct_combined cls_struct_combined_fn(struct cls_struct_16byte1 b0,
+static cls_struct_combined cls_struct_combined_fn(struct cls_struct_16byte1 b0,
 					   struct cls_struct_16byte2 b1,
 					   struct cls_struct_combined b2,
 					   struct cls_struct_16byte1 b3)

--- a/testsuite/libffi.closures/nested_struct2.c
+++ b/testsuite/libffi.closures/nested_struct2.c
@@ -19,7 +19,7 @@ typedef struct B {
   unsigned char y;
 } B;
 
-B B_fn(struct A b0, struct B b1)
+static B B_fn(struct A b0, struct B b1)
 {
   struct B result;
 

--- a/testsuite/libffi.closures/nested_struct3.c
+++ b/testsuite/libffi.closures/nested_struct3.c
@@ -19,7 +19,7 @@ typedef struct B {
   unsigned char y;
 } B;
 
-B B_fn(struct A b0, struct B b1)
+static B B_fn(struct A b0, struct B b1)
 {
   struct B result;
 

--- a/testsuite/libffi.closures/stret_medium.c
+++ b/testsuite/libffi.closures/stret_medium.c
@@ -21,7 +21,7 @@ typedef struct struct_72byte {
 	double i;
 } struct_72byte;
 
-struct_72byte cls_struct_72byte_fn(
+static struct_72byte cls_struct_72byte_fn(
 	struct_72byte b0,
 	struct_72byte b1,
 	struct_72byte b2,

--- a/testsuite/libffi.closures/stret_medium2.c
+++ b/testsuite/libffi.closures/stret_medium2.c
@@ -22,7 +22,7 @@ typedef struct struct_72byte {
 	long long i;
 } struct_72byte;
 
-struct_72byte cls_struct_72byte_fn(
+static struct_72byte cls_struct_72byte_fn(
 	struct_72byte b0,
 	struct_72byte b1,
 	struct_72byte b2,

--- a/testsuite/libffi.closures/testclosure.c
+++ b/testsuite/libffi.closures/testclosure.c
@@ -14,7 +14,7 @@ typedef struct cls_struct_combined {
   float d;
 } cls_struct_combined;
 
-void cls_struct_combined_fn(struct cls_struct_combined arg)
+static void cls_struct_combined_fn(struct cls_struct_combined arg)
 {
   printf("%g %g %g %g\n",
 	 arg.a, arg.b,


### PR DESCRIPTION
I'm working on porting libffi to Emscripten. The Emscripten "binaries" are quite large and take a long time to link and to load, so it is be preferable to link all of the functions into one binary. I've been using `sed` to replace `main` with `test__<file-name-here>` but linking causes duplicate symbol errors. Would be helpful if we could make all these helper methods as static.