### PR TITLE
configure.ac: allow user to specify READELF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,8 @@ AM_PROG_CC_C_O
 AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
 
+AC_CHECK_TOOL(READELF, readelf)
+
 # Test for 64-bit build.
 AC_CHECK_SIZEOF([size_t])
 
@@ -271,7 +273,7 @@ if test "x$GCC" = "xyes"; then
   	libffi_cv_ro_eh_frame=yes
   	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c
   	if $CC $CFLAGS -c -fpic -fexceptions $libffi_cv_no_lto -o conftest.o conftest.c > /dev/null 2>&1; then
-	    if readelf -WS conftest.o | grep -q -n 'eh_frame .* WA'; then
+	    if $READELF -WS conftest.o | grep -q -n 'eh_frame .* WA'; then
 	        libffi_cv_ro_eh_frame=no
 	    fi
   	fi


### PR DESCRIPTION
Before the change with x86_64-pc-linux-gnu cross-compiler
installed the configure was not able to find cross-readelf:

```
$ ./configure --host=x86_64-pc-linux-gnu
...
checking whether .eh_frame section should be read-only... .././configure: line 19540: readelf: command not found
yes
...
```

The change uses AC_CHECK_TOOL to automatically seatch for ${host}-readelf,
readelf. And as a bonus it also allows user to override readelf with
something like READELF=llvm-readelf.