### PR TITLE
configure.ac: add --disable-exec-static-tramp flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -366,6 +366,10 @@ AC_ARG_ENABLE(raw-api,
     AC_DEFINE(FFI_NO_RAW_API, 1, [Define this if you do not want support for the raw API.])
   fi)
 
+AC_ARG_ENABLE(exec-static-tramp,
+[  --disable-exec-static-tramp  disable use of static exec trampolines (enabled by default)])
+
+if test "$enable_exec_static_tramp" != no; then
 case "$target" in
      *-cygwin*)
      ;;
@@ -374,6 +378,7 @@ case "$target" in
                  [Define this if you want statically defined trampolines])
      ;;
 esac
+fi
 
 AC_ARG_ENABLE(purify-safety,
 [  --enable-purify-safety  purify-safe mode],


### PR DESCRIPTION
Some projects like GHC (Glasgow Haskell Compiler) and
gobject-introspection use `ffi_closure_alloc()` as a way
to allocate executable memory. exec static tramp
interferes with it (unclear how exactly yet).

GHC symptom: ffi closure freeing cimplains about unexpected
trampoline (GHC manually fills one):

```
$ ghci
GHCi, version 8.10.5: https://www.haskell.org/ghc/  :? for help
ghc: freeHaskellFunctionPtr: not for me, guv! 0x7f0417a1efe8
ghc: freeHaskellFunctionPtr: not for me, guv! 0x7f0417a1efc8
```

gobject-introspection symptom:

```
$ meld
Segmentation fault (core dumped)

$ gdb --args /usr/bin/python3.9 /usr/bin/meld
(gdb) run
...
Thread 1 "python3.9" received signal SIGSEGV, Segmentation fault.
0x00007fffe9ac1ae8 in g_callable_info_free_closure (
  callable_info=0x555555d45990, closure=0x7fffe9e70c20)
    at ../gobject-introspection-1.68.0/girepository/girffi.c:428
428       g_free (wrapper->ffi_closure.cif->arg_types);
(gdb) bt
  callable_info=0x555555d45990, closure=0x7fffe9e70c20)
    at ../gobject-introspection-1.68.0/girepository/girffi.c:428
  data=0x555555d252d0)
    at ../pygobject-3.40.1/gi/pygi-closure.c:635
...
```

To ease downstreams narrowing down the actual problem let's
provide a knob to disable exec static trampolines.

The change for not affect current default.