### PR TITLE
Fix signature of function pointer in test cls_dbls_struct

### DIFF
--- a/testsuite/libffi.closures/cls_dbls_struct.c
+++ b/testsuite/libffi.closures/cls_dbls_struct.c
@@ -56,7 +56,7 @@ int main(int argc __UNUSED__, char** argv __UNUSED__)
 
 	CHECK(ffi_prep_closure_loc(pcl, &cif, closure_test_gn, NULL, code) == FFI_OK);
 
-	((void*(*)(Dbls))(code))(arg);
+	((void (*)(Dbls))(code))(arg);
 	/* { dg-output "1.0 2.0" } */
 
 	closure_test_fn(arg);


### PR DESCRIPTION
Function returns void, but the test casts it to a function pointer that returns `void*`.