### PR TITLE
Print more information when an assertion fails in test suite

### DIFF
--- a/testsuite/libffi.call/ffitest.h
+++ b/testsuite/libffi.call/ffitest.h
@@ -15,7 +15,13 @@
 
 #define MAX_ARGS 256
 
-#define CHECK(x) (void)(!(x) ? (abort(), 1) : 0)
+#define CHECK(x) \
+   do { \
+      if(!(x)){ \
+         printf("Check failed:\n%s\n", #x); \
+         abort(); \
+      } \
+   } while(0)
 
 /* Define macros so that compilers other than gcc can run the tests.  */
 #undef __UNUSED__

--- a/testsuite/libffi.closures/ffitest.h
+++ b/testsuite/libffi.closures/ffitest.h
@@ -15,7 +15,13 @@
 
 #define MAX_ARGS 256
 
-#define CHECK(x) (void)(!(x) ? (abort(), 1) : 0)
+#define CHECK(x) \
+   do { \
+      if(!(x)){ \
+         printf("Check failed:\n%s\n", #x); \
+         abort(); \
+      } \
+   } while(0)
 
 /* Define macros so that compilers other than gcc can run the tests.  */
 #undef __UNUSED__


### PR DESCRIPTION
Print the stringified argument of `CHECK` when the assertion fails. Makes it a bit easier to track down the failing assertion.