### PR TITLE
Zero initialize the cif in ffi_prep_cif_core

### DIFF
--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -123,6 +123,7 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   if (! (abi > FFI_FIRST_ABI && abi < FFI_LAST_ABI))
     return FFI_BAD_ABI;
 
+  *cif = { 0 };
   cif->abi = abi;
   cif->arg_types = atypes;
   cif->nargs = ntotalargs;

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -123,7 +123,8 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   if (! (abi > FFI_FIRST_ABI && abi < FFI_LAST_ABI))
     return FFI_BAD_ABI;
 
-  *cif = { 0 };
+  ffi_cif zero_cif = { 0 };
+  *cif = zero_cif;
   cif->abi = abi;
   cif->arg_types = atypes;
   cif->nargs = ntotalargs;


### PR DESCRIPTION
I am working on porting libffi to `wasm32-unknown-emscripten` and I have a problem with the definition of `ffi_prep_cif_core` which prevents me from implementing variadic closures correctly. I need to know `nfixedargs` in `ffi_prep_closure_loc_helper`. My thought was to define 
```C
#define FFI_TARGET_SPECIFIC_VARIADIC 1
#define FFI_EXTRA_CIF_FIELDS  unsigned int nfixedargs
```
and then in `ffi_prep_cif_machdep_var` store `nfixedargs` into the extra field. In `ffi_prep_cif_machdep`, I store `nargs` into `nfixedargs`: 
```C
ffi_status FFI_HIDDEN
ffi_prep_cif_machdep(ffi_cif *cif)
{
  cif->nfixedargs = cif->nargs;
  return FFI_OK;
}

ffi_status FFI_HIDDEN
ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned nfixedargs, unsigned ntotalargs)
{
  cif->nfixedargs = nfixedargs;
  return FFI_OK;
}
```
But there is a problem. The relevant code in `ffi_prep_cif_core` reads as follows:
```C
#ifdef FFI_TARGET_SPECIFIC_VARIADIC
  if (isvariadic)
	return ffi_prep_cif_machdep_var(cif, nfixedargs, ntotalargs);
#endif

  return ffi_prep_cif_machdep(cif);
```
According to this logic, first `ffi_prep_cif_machdep_var` gets called and stores the right value into `cif->nfixedargs` and then `ffi_prep_cif_machdep` gets called and overwrites it with the wrong value. Also, note that `cif->nfixedargs` is unitialized memory up to this point. If the cif is zero initialized, we can do something like 
```C
#define VARARGS_FLAG (1 << 31)
ffi_status FFI_HIDDEN
ffi_prep_cif_machdep(ffi_cif *cif)
{
  if(!(cif->nfixedargs & VARARGS_FLAG)){
	  cif->nfixedargs = cif->nargs;
  }
  return FFI_OK;
}

ffi_status FFI_HIDDEN
ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned nfixedargs, unsigned ntotalargs)
{
  cif->nfixedargs = nfixedargs | VARARGS_FLAG;
  return FFI_OK;
}
```