### PR TITLE
Add tests for single entry structs

### DIFF
--- a/testsuite/libffi.closures/single_entry_structs1.c
+++ b/testsuite/libffi.closures/single_entry_structs1.c
@@ -1,0 +1,86 @@
+/* Area:       ffi_call, closure_call
+   Purpose:    Single argument structs have a different ABI in emscripten.
+   Limitations:        none.
+   PR:         none.
+   Originator: <hood@mit.edu>  */
+
+/* { dg-do run } */
+#include "ffitest.h"
+
+typedef struct A {
+  int a;
+} A;
+
+static struct A A_fn(int b0, struct A b1)
+{
+  b1.a += b0;
+  return b1;
+}
+
+static void
+A_gn(ffi_cif* cif __UNUSED__, void* resp, void** args,
+     void* userdata __UNUSED__)
+{
+  int b0;
+  struct A b1;
+
+  b0 = *(int*)(args[0]);
+  b1 = *(struct A*)(args[1]);
+
+  *(A*)resp = A_fn(b0, b1);
+}
+
+int main (void)
+{
+  printf("123\n");
+  ffi_cif cif;
+  void *code;
+  ffi_closure *pcl = ffi_closure_alloc(sizeof(ffi_closure), &code);
+  void* args_dbl[3];
+  ffi_type* cls_struct_fields[2];
+  ffi_type cls_struct_type, cls_struct_type1;
+  ffi_type* dbl_arg_types[3];
+
+  int e_dbl = 12125;
+  struct A f_dbl = { 31625 };
+
+  struct A res_dbl;
+
+  cls_struct_type.size = 0;
+  cls_struct_type.alignment = 0;
+  cls_struct_type.type = FFI_TYPE_STRUCT;
+  cls_struct_type.elements = cls_struct_fields;
+
+  cls_struct_fields[0] = &ffi_type_sint;
+  cls_struct_fields[1] = NULL;
+
+  dbl_arg_types[0] = &ffi_type_sint;
+  dbl_arg_types[1] = &cls_struct_type;
+  dbl_arg_types[2] = NULL;
+
+  res_dbl = A_fn(e_dbl, f_dbl);
+  printf("0 res: %d\n", res_dbl.a);
+  /* { dg-output "0 res: 43750" } */
+
+  CHECK(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 2, &cls_struct_type,
+                    dbl_arg_types) == FFI_OK);
+
+  args_dbl[0] = &e_dbl;
+  args_dbl[1] = &f_dbl;
+  args_dbl[2] = NULL;
+
+
+  ffi_call(&cif, FFI_FN(A_fn), &res_dbl, args_dbl);
+  printf("1 res: %d \n", res_dbl.a);
+  /* { dg-output "\n1 res: 43750" } */
+  CHECK( res_dbl.a == (e_dbl + f_dbl.a));
+
+  CHECK(ffi_prep_closure_loc(pcl, &cif, A_gn, NULL, code) == FFI_OK);
+
+  res_dbl = ((A(*)(int, A))(code))(e_dbl, f_dbl);
+  printf("2 res: %d \n", res_dbl.a);
+  /* { dg-output "\n2 res: 43750" } */
+  CHECK( res_dbl.a == (e_dbl + f_dbl.a));
+
+  exit(0);
+}

--- a/testsuite/libffi.closures/single_entry_structs2.c
+++ b/testsuite/libffi.closures/single_entry_structs2.c
@@ -1,0 +1,102 @@
+/* Area:       ffi_call, closure_call
+   Purpose:    Single argument structs have a different ABI in emscripten.
+   Limitations:        none.
+   PR:         none.
+   Originator: <hood@mit.edu>  */
+
+/* { dg-do run } */
+#include "ffitest.h"
+
+typedef struct A {
+  int a, b;
+} A;
+
+typedef struct B {
+  struct A y;
+} B;
+
+static struct B B_fn(int b0, struct B b1)
+{
+  b1.y.a += b0;
+  b1.y.b -= b0;
+  return b1;
+}
+
+static void
+B_gn(ffi_cif* cif __UNUSED__, void* resp, void** args,
+     void* userdata __UNUSED__)
+{
+  int b0;
+  struct B b1;
+
+  b0 = *(int*)(args[0]);
+  b1 = *(struct B*)(args[1]);
+
+  *(B*)resp = B_fn(b0, b1);
+}
+
+int main (void)
+{
+  ffi_cif cif;
+  void *code;
+  ffi_closure *pcl = ffi_closure_alloc(sizeof(ffi_closure), &code);
+  void* args_dbl[3];
+  ffi_type* cls_struct_fields[3];
+  ffi_type* cls_struct_fields1[2];
+  ffi_type cls_struct_type, cls_struct_type1;
+  ffi_type* dbl_arg_types[3];
+
+  int e_dbl = 12125;
+  struct B f_dbl = { { 31625, 16723 } };
+
+  struct B res_dbl;
+
+  cls_struct_type.size = 0;
+  cls_struct_type.alignment = 0;
+  cls_struct_type.type = FFI_TYPE_STRUCT;
+  cls_struct_type.elements = cls_struct_fields;
+
+  cls_struct_type1.size = 0;
+  cls_struct_type1.alignment = 0;
+  cls_struct_type1.type = FFI_TYPE_STRUCT;
+  cls_struct_type1.elements = cls_struct_fields1;
+
+  cls_struct_fields[0] = &ffi_type_sint;
+  cls_struct_fields[1] = &ffi_type_sint;
+  cls_struct_fields[2] = NULL;
+
+  cls_struct_fields1[0] = &cls_struct_type;
+  cls_struct_fields1[1] = NULL;
+
+
+  dbl_arg_types[0] = &ffi_type_sint;
+  dbl_arg_types[1] = &cls_struct_type1;
+  dbl_arg_types[2] = NULL;
+
+  res_dbl = B_fn(e_dbl, f_dbl);
+  printf("0 res: %d %d\n", res_dbl.y.a, res_dbl.y.b);
+  /* { dg-output "0 res: 43750 4598" } */
+
+  CHECK(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 2, &cls_struct_type1,
+                    dbl_arg_types) == FFI_OK);
+
+  args_dbl[0] = &e_dbl;
+  args_dbl[1] = &f_dbl;
+  args_dbl[2] = NULL;
+
+  ffi_call(&cif, FFI_FN(B_fn), &res_dbl, args_dbl);
+  printf("1 res: %d %d\n", res_dbl.y.a, res_dbl.y.b);
+  /* { dg-output "\n1 res: 43750 4598" } */
+  CHECK( res_dbl.y.a == (f_dbl.y.a + e_dbl));
+  CHECK( res_dbl.y.b == (f_dbl.y.b - e_dbl));
+
+  CHECK(ffi_prep_closure_loc(pcl, &cif, B_gn, NULL, code) == FFI_OK);
+
+  res_dbl = ((B(*)(int, B))(code))(e_dbl, f_dbl);
+  printf("2 res: %d %d\n", res_dbl.y.a, res_dbl.y.b);
+  /* { dg-output "\n2 res: 43750 4598" } */
+  CHECK( res_dbl.y.a == (f_dbl.y.a + e_dbl));
+  CHECK( res_dbl.y.b == (f_dbl.y.b - e_dbl));
+
+  exit(0);
+}

--- a/testsuite/libffi.closures/single_entry_structs3.c
+++ b/testsuite/libffi.closures/single_entry_structs3.c
@@ -1,0 +1,101 @@
+/* Area:       ffi_call, closure_call
+   Purpose:    Single argument structs have a different ABI in emscripten.
+   Limitations:        none.
+   PR:         none.
+   Originator: <hood@mit.edu>  */
+
+/* { dg-do run } */
+#include "ffitest.h"
+
+typedef struct A {
+  int a;
+} A;
+
+typedef struct B {
+  struct A y;
+} B;
+
+static struct B B_fn(int b0, struct B b1)
+{
+  b1.y.a += b0;
+  return b1;
+}
+
+static void
+B_gn(ffi_cif* cif __UNUSED__, void* resp, void** args,
+     void* userdata __UNUSED__)
+{
+  int b0;
+  struct B b1;
+
+  b0 = *(int*)(args[0]);
+  b1 = *(struct B*)(args[1]);
+
+  *(B*)resp = B_fn(b0, b1);
+}
+
+int main (void)
+{
+  printf("123\n");
+  ffi_cif cif;
+  void *code;
+  ffi_closure *pcl = ffi_closure_alloc(sizeof(ffi_closure), &code);
+  void* args_dbl[3];
+  ffi_type* cls_struct_fields[2];
+  ffi_type* cls_struct_fields1[2];
+  ffi_type cls_struct_type, cls_struct_type1;
+  ffi_type* dbl_arg_types[3];
+
+  int e_dbl = 12125;
+  struct B f_dbl = { { 31625 } };
+
+  struct B res_dbl;
+
+  cls_struct_type.size = 0;
+  cls_struct_type.alignment = 0;
+  cls_struct_type.type = FFI_TYPE_STRUCT;
+  cls_struct_type.elements = cls_struct_fields;
+
+  cls_struct_type1.size = 0;
+  cls_struct_type1.alignment = 0;
+  cls_struct_type1.type = FFI_TYPE_STRUCT;
+  cls_struct_type1.elements = cls_struct_fields1;
+
+  cls_struct_fields[0] = &ffi_type_sint;
+  cls_struct_fields[1] = NULL;
+
+  cls_struct_fields1[0] = &cls_struct_type;
+  cls_struct_fields1[1] = NULL;
+
+
+  dbl_arg_types[0] = &ffi_type_sint;
+  dbl_arg_types[1] = &cls_struct_type1;
+  dbl_arg_types[2] = NULL;
+
+  res_dbl = B_fn(e_dbl, f_dbl);
+  printf("0 res: %f\n", res_dbl.y.a);
+  /* { dg-output "0 res: 43750" } */
+
+
+  CHECK(ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 2, &cls_struct_type1,
+                    dbl_arg_types) == FFI_OK);
+
+  args_dbl[0] = &e_dbl;
+  args_dbl[1] = &f_dbl;
+  args_dbl[2] = NULL;
+
+
+  ffi_call(&cif, FFI_FN(B_fn), &res_dbl, args_dbl);
+  printf("1 res: %d\n", res_dbl.y.a);
+  /* { dg-output "\n1 res: 43750" } */
+  CHECK( res_dbl.y.a == (e_dbl + f_dbl.y.a));
+
+  CHECK(ffi_prep_closure_loc(pcl, &cif, B_gn, NULL, code) == FFI_OK);
+
+  res_dbl = ((B(*)(int, B))(code))(e_dbl, f_dbl);
+  printf("2 res: %d\n", res_dbl.y.a);
+  /* { dg-output "\n2 res: 43750" } */
+  CHECK( res_dbl.y.a == (e_dbl + f_dbl.y.a));
+
+  exit(0);
+}


### PR DESCRIPTION
In `wasm32-unknown-emscripten`, long doubles, structs, and varargs are passed on an "arguments stack" which is separate from the call stack. I believe this is related to the fact that the wasm call stack does not live in linear memory and cannot be addressed normally. But there is a special case: structs with only one entry are treated identically to the one entry. A bit like all one entry structs automatically have Rust's `#[repr(transparent)]`.

Anyways these are some tests that check that this behavior is implemented correctly.