### PR TITLE
Makefile: enable target overridings.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,3 +149,5 @@ dist-hook:
 	if [ -d $(top_srcdir)/.git ] ; then (cd $(top_srcdir); git log --no-decorate) ; else echo 'See git log for history.' ; fi > $(distdir)/ChangeLog
 	s=`awk '/was released on/{ print NR; exit}' $(top_srcdir)/README.md`; tail -n +$$(($$s-1)) $(top_srcdir)/README.md > $(distdir)/README.md
 
+# target overrides
+-include $(tmake_file)

--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,16 @@ else
 fi
 AC_SUBST(toolexeclibdir)
 
+# Conditionalize the makefile for this target machine.
+tmake_file_=
+for f in ${tmake_file}; do
+  if test -f ${srcdir}/src/$TARGETDIR/$f; then
+     tmake_file_="${tmake_file_} \$(srcdir)/src/$TARGETDIR/$f"
+  fi
+done
+tmake_file="${tmake_file_}"
+AC_SUBST(tmake_file)
+
 # Check linker support.
 LIBFFI_ENABLE_SYMVERS
 

--- a/configure.host
+++ b/configure.host
@@ -207,6 +207,8 @@ case "${host}" in
 	;;
   powerpc-*-aix* | rs6000-*-aix*)
 	TARGET=POWERPC_AIX; TARGETDIR=powerpc
+	# Create AIX-style "FAT" libraries.
+	tmake_file="t-aix"
 	;;
   powerpc-*-freebsd* | powerpc-*-openbsd* | powerpc-*-netbsd*)
 	TARGET=POWERPC_FREEBSD; TARGETDIR=powerpc

--- a/src/powerpc/t-aix
+++ b/src/powerpc/t-aix
@@ -1,0 +1,5 @@
+# This file is needed by GCC in order to correctly build AIX FAT
+# library for libffi.
+# However, it has no sense to include this code here, as it depends
+# on GCC multilib architecture.
+# Thus, this file is a simple stub replaced in GCC repository.


### PR DESCRIPTION
This patch allows target to provide extra files enabling the
override of Makefile rules.
This patch is not needed for libffi itself but only for GCC on AIX. The
t-aix file which is here empty will be replaced in GCC repository. We cannot
include GCC version directly here because it has no sense for a standalone
libffi.

Related issue: #659 