### PR TITLE
Don't dereference beyond the last array entry.

### DIFF
--- a/src/moxie/ffi.c
+++ b/src/moxie/ffi.c
@@ -245,7 +245,7 @@ void ffi_closure_eabi (unsigned arg1, unsigned arg2, unsigned arg3,
 	 start looking at the those passed on the stack.  */
       if (ptr == (char *) &register_args[6])
 	ptr = stack_args;
-      else if (ptr == (char *) &register_args[7])
+      else if (ptr == (register_args + sizeof(register_args)))
 	ptr = stack_args + 4;
     }
 


### PR DESCRIPTION
A static code checker complained about this.  This should quiesce the checker.