### PR TITLE
Fix build with Oracle Studio cc (#670)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,7 +136,7 @@ libffi_version_info = -version-info `grep -v '^\#' $(srcdir)/libtool-version`
 
 libffi.map: $(top_srcdir)/libffi.map.in
 	$(COMPILE) -D$(TARGET) -DGENERATE_LIBFFI_MAP \
-	 -E -x assembler-with-cpp -o $@ $(top_srcdir)/libffi.map.in
+	 -E -o $@ $(top_srcdir)/libffi.map.in
 
 libffi_la_LDFLAGS = -no-undefined $(libffi_version_info) $(libffi_version_script) $(LTLDFLAGS) $(AM_LTLDFLAGS)
 libffi_la_DEPENDENCIES = $(libffi_la_LIBADD) $(libffi_version_dep)

--- a/src/sparc/v8.S
+++ b/src/sparc/v8.S
@@ -52,7 +52,7 @@
 
 C(ffi_flush_icache):
 1:	iflush %o0
-	iflush %o+8
+	iflush %o0+8
 	nop
 	nop
 	nop

--- a/src/sparc/v9.S
+++ b/src/sparc/v9.S
@@ -41,6 +41,20 @@
 #endif
 #define L(Y)	C1(.L, Y)
 
+#ifndef __GNUC__
+        .align 8
+	.globl	C(ffi_flush_icache)
+	.type	C(ffi_flush_icache),#function
+	FFI_HIDDEN(C(ffi_flush_icache))
+
+C(ffi_flush_icache):
+1:	flush %o0
+	flush %o0+8
+	retl
+	 nop
+	.size	C(ffi_flush_icache), . - C(ffi_flush_icache)
+#endif
+
 #if defined(__sun__) && defined(__svr4__)
 # define E(INDEX)	.align 16
 #else


### PR DESCRIPTION
* Don't use -x assembler-with-cpp.
* Fix src/sparc/v8.S syntax.
* Provide non-gcc ffi_flush_icache in src/sparc/v9.S.