### PR TITLE
Allow system to have overlapping mallopt defines

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -592,6 +592,11 @@ DEFAULT_MMAP_THRESHOLD       default: 256K
   malloc does support the following options.
 */
 
+/* The system's malloc.h may have conflicting defines. */
+#undef M_TRIM_THRESHOLD
+#undef M_GRANULARITY
+#undef M_MMAP_THRESHOLD
+
 #define M_TRIM_THRESHOLD     (-1)
 #define M_GRANULARITY        (-2)
 #define M_MMAP_THRESHOLD     (-3)


### PR DESCRIPTION
Which is the case on some OSes, such as QNX.