### PR TITLE
Improve README.md + remove dead statement from test

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ Configure has many other options. Use ``configure --help`` to see them all.
 Once configure has finished, type "make". Note that you must be using
 GNU make.  You can ftp GNU make from ftp.gnu.org:/pub/gnu/make .
 
-To ensure that libffi is working as advertised, type "make check".
-This will require that you have DejaGNU installed.
+To ensure that libffi is working as advertised, run the test suite by
+typing "make check".  This will require that you have DejaGNU installed.
+The output will be written to a path like x86_64-pc-linux-gnu/testsuite/libffi.log
 
 To install the library and header files, type ``make install``.
 

--- a/testsuite/libffi.call/negint.c
+++ b/testsuite/libffi.call/negint.c
@@ -40,8 +40,6 @@ int main (void)
   ss = -12;
   sc = -1;
 
-  checking (si, ss, sc);
-
   ffi_call(&cif, FFI_FN(checking), &rint, values);
 
   printf ("%d vs %d\n", (int)rint, checking (si, ss, sc));


### PR DESCRIPTION
* Change `README.md` to ensure that someone searching *test* will discover the relevant part of the readme.

* `README.md` now indicates where test output is written. [Relevant issue.](https://github.com/libffi/libffi/issues/183)

* Remove dead statement from test `negint.c`