### PR TITLE
Upstream FreeBSD riscv patch

### DIFF
--- a/src/riscv/ffi.c
+++ b/src/riscv/ffi.c
@@ -442,7 +442,9 @@ ffi_status ffi_prep_closure_loc(ffi_closure *closure, ffi_cif *cif, void (*fun)(
     closure->fun = fun;
     closure->user_data = user_data;
 
+#if !defined(__FreeBSD__)
     __builtin___clear_cache(codeloc, codeloc + FFI_TRAMPOLINE_SIZE);
+#endif
 
     return FFI_OK;
 }


### PR DESCRIPTION
Like 8276f812a99b10d1f2c387dbd6ef2ca4f597c733 commit message:
    > devel/libffi: Fix abort() on ARM related to __clear_cache()
    >
    > The current FreeBSD __clear_cache() implementation does nothing #if
    > __i386__ || __x86_64__ #else abort();
    >
    > cognet@ advises this is an issue for anything !Apple that is using the
    > libcompiler_rt provided by Clang on ARM, and requires upstreaming.