### PR TITLE
testsuite/libffi.closures: Fix PowerPC 64

### DIFF
--- a/testsuite/libffi.closures/cls_align_longdouble_split.c
+++ b/testsuite/libffi.closures/cls_align_longdouble_split.c
@@ -5,7 +5,7 @@
    Originator:	<hos@tamanegi.org> 20031203	 */
 
 /* { dg-do run { xfail strongarm*-*-* xscale*-*-* } } */
-/* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
+/* { dg-options -mlong-double-128 { target powerpc64*-*-linux-gnu* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.closures/cls_align_longdouble_split2.c
+++ b/testsuite/libffi.closures/cls_align_longdouble_split2.c
@@ -6,7 +6,7 @@
 */
 
 /* { dg-do run { xfail strongarm*-*-* } } */
-/* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
+/* { dg-options -mlong-double-128 { target powerpc64*-*-linux-gnu* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.closures/cls_longdouble.c
+++ b/testsuite/libffi.closures/cls_longdouble.c
@@ -7,7 +7,7 @@
 /* This test is known to PASS on armv7l-unknown-linux-gnueabihf, so I have
    remove the xfail for arm*-*-* below, until we know more.  */
 /* { dg-do run { xfail strongarm*-*-* xscale*-*-* } } */
-/* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
+/* { dg-options -mlong-double-128 { target powerpc64*-*-linux-gnu* } } */
 
 #include "ffitest.h"
 

--- a/testsuite/libffi.closures/huge_struct.c
+++ b/testsuite/libffi.closures/huge_struct.c
@@ -6,7 +6,7 @@
 */
 
 /* { dg-do run { xfail strongarm*-*-* xscale*-*-* wasm32*-*-* } } */
-/* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
+/* { dg-options -mlong-double-128 { target powerpc64*-*-linux-gnu* } } */
 /* { dg-options -Wformat=0 { target moxie*-*-elf or1k-*-* } } */
 
 #include <inttypes.h>


### PR DESCRIPTION
-mlong-double-128 is only supported on glibc.

This test still passes on glibc targets, and now passes on musl targets
as well (which uses 64-bit ldbl).