### PR TITLE
Fix building on aarch64 after e409225b41b60c490a094bb068e639a2364202fd

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -311,7 +311,7 @@ allocate_and_copy_struct_to_stack (struct arg_state *state, void *stack,
   size_t dest = state->next_struct_area - size;
 
   /* Round down to the natural alignment of the value.  */
-  dest = ALIGN_DOWN (dest, alignment);
+  dest = FFI_ALIGN_DOWN (dest, alignment);
   state->next_struct_area = dest;
 
   return memcpy ((char *) stack + dest, value, size);


### PR DESCRIPTION
The ALIGN_DOWN macro was renamed in 2018 in
e6eac7863e2bf1a009ea863041b354bdb4af6b67.