### PR TITLE
powerpc64: fix build on gcc-12 (assembly requires AltiVec)

### DIFF
--- a/src/powerpc/linux64.S
+++ b/src/powerpc/linux64.S
@@ -29,6 +29,8 @@
 #include <fficonfig.h>
 #include <ffi.h>
 
+	.machine altivec
+
 #ifdef POWERPC64
 	.hidden	ffi_call_LINUX64
 	.globl	ffi_call_LINUX64

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -30,6 +30,8 @@
 
 	.file	"linux64_closure.S"
 
+	.machine altivec
+
 #ifdef POWERPC64
 	FFI_HIDDEN (ffi_closure_LINUX64)
 	.globl  ffi_closure_LINUX64


### PR DESCRIPTION
Without the change build fails on powerpc64-gcc-12 as:

    src/powerpc/linux64_closure.S: Assembler messages:
    src/powerpc/linux64_closure.S:363: Error: unrecognized opcode: `lvx'

It's a 90205f67 "rs6000: Fix bootstrap (libffi)" patch by
Segher Boessenkool from gcc upstream repository. It's enough to get
libffi build on powerpc64.