### PR TITLE
configure.ac: use grep -E instead of egrep if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ AC_SUBST(CFLAGS)
 
 AM_PROG_AS
 AM_PROG_CC_C_O
+AC_PROG_EGREP
 AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -294,7 +295,7 @@ if test "x$GCC" = "xyes"; then
   	echo 'int __attribute__ ((visibility ("hidden"))) foo (void) { return 1  ; }' > conftest.c
   	libffi_cv_hidden_visibility_attribute=no
   	if AC_TRY_COMMAND(${CC-cc} -Werror -S conftest.c -o conftest.s 1>&AS_MESSAGE_LOG_FD); then
-  	    if egrep '(\.hidden|\.private_extern).*foo' conftest.s >/dev/null; then
+  	    if $EGREP '(\.hidden|\.private_extern).*foo' conftest.s >/dev/null; then
   		libffi_cv_hidden_visibility_attribute=yes
   	    fi
   	fi


### PR DESCRIPTION
Upstream will start to emit a warning if egrep is invoked in the next
grep release.  Stop invoking it explicitly.  Use AC_PROG_EGREP to try
"grep -E" first, and fallback to egrep if "grep -E" does not work.  We
need this fallback for some non-GNU grep implementations (like Solaris).

Url: https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a951562