### PR TITLE
Suppress error console output duing configure in case not an ELF file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,7 +294,7 @@ if test "x$GCC" = "xyes"; then
   	libffi_cv_ro_eh_frame=yes
   	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c
   	if $CC $CFLAGS -c -fpic -fexceptions $libffi_cv_no_lto -o conftest.o conftest.c > /dev/null 2>&1; then
-	    if $READELF -WS conftest.o | grep -q -n 'eh_frame .* WA'; then
+	    if $READELF -WS conftest.o 2>/dev/null | grep -q -n 'eh_frame .* WA'; then
 	        libffi_cv_ro_eh_frame=no
 	    fi
   	fi


### PR DESCRIPTION
On Cygwin, MSYS and MinGW readelf is available, but files generated are no ELF files. This results in an Error output on console: 'checking whether .eh_frame section should be read-only... readelf: Error: Not an ELF file - it has the wrong magic bytes at the start yes'
With this patch the error output is suppressed resulting in only 'checking whether .eh_frame section should be read-only... yes' Setting of related variables is not changed.