### PR TITLE
Small build cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,10 +70,6 @@ AM_MAINTAINER_MODE
 AC_CHECK_HEADERS(sys/memfd.h)
 AC_CHECK_FUNCS([memfd_create])
 
-AC_CHECK_HEADERS(sys/mman.h)
-AC_CHECK_FUNCS([mmap mkostemp mkstemp])
-AC_FUNC_MMAP_BLACKLIST
-
 dnl The -no-testsuite modules omit the test subdir.
 AM_CONDITIONAL(TESTSUBDIR, test -d $srcdir/testsuite)
 
@@ -99,7 +95,7 @@ AC_CHECK_INCLUDES_DEFAULT
 AC_PROG_EGREP
 
 AC_CHECK_FUNCS(memcpy)
-AC_FUNC_ALLOCA
+AC_CHECK_HEADERS(alloca.h)
 
 AC_CHECK_SIZEOF(double)
 AC_CHECK_SIZEOF(long double)

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -140,13 +140,11 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined _MSC_VER && !defined(FFI_STATIC_BUILD)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else  /* Importing libffi.DLL */
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
 # define FFI_API


### PR DESCRIPTION
commit 57c0fa2b12b7bac2e5da6d2479ee4f3ca679469a

    Fix FFI_API definition
    
    When doing a static build dllimport/dllexport should be disabled. It was
    also using 2 different macros FFI_BUILDING_DLL and FFI_BUILDING for no
    reason.

commit 77e26a9129d3ed3047bf6dd587610929611eb762

    configure.ac: Remove some unused checks
