### PR TITLE
dlmalloc: Replace inline ASM with GCC bit manipulation intrinsics

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -391,11 +391,6 @@ ffi_closure_free (void *ptr)
 
 #define USE_LOCKS 1
 #define USE_DL_PREFIX 1
-#ifdef __GNUC__
-#ifndef USE_BUILTIN_FFS
-#define USE_BUILTIN_FFS 1
-#endif
-#endif
 
 /* We need to use mmap, not sbrk.  */
 #define HAVE_MORECORE 0

--- a/src/x86/ffitarget.h
+++ b/src/x86/ffitarget.h
@@ -49,7 +49,6 @@
 
 #ifdef X86_WIN64
 #define FFI_SIZEOF_ARG 8
-#define USE_BUILTIN_FFS 0 /* not yet implemented in mingw-64 */
 #endif
 
 #define FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION


### PR DESCRIPTION
Currently, neither GCC nor Clang is able to recognize the log base 2 computation idiom in `dlmalloc`'s `compute_tree_index`.

This commit replaces the GCC inline assembly implementation of this macro with a generic bit manipulation intrinsic, and enables it whenever a GCC-compatible compiler is used. For consistency, we make the use of `__builtin_ffs()` in `compute_bit2idx` dependent on `__GNUC__` rather than the `USE_BUILTIN_FFS` macro as well.

See: https://godbolt.org/z/do7dbE6ax
Proof that the pure C and intrinsic implementations are equivalent when
lowered to LLVM IR: https://alive2.llvm.org/ce/z/UdrxGE