### PR TITLE
Darwin: Search for both shared and convenience libraries in each path.

### DIFF
--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -380,6 +380,7 @@ proc libffi_target_compile { source dest type options } {
 	 || [istarget "*-*-darwin2*"] } {
 	# lappend options "additional_flags=-Wl,-allow_stack_execute"
         lappend options "additional_flags=-Wno-unused-command-line-argument"
+        lappend options "additional_flags=-Wl,-search_paths_first"
     }
 
     # If you're building the compiler with --prefix set to a place


### PR DESCRIPTION
For several Darwin linker versions, the default behaviour is to first traverse the set of library paths, looking for shared libraries, and then a second time looking for archives.

This means that if the library is configured --disable-shared the installed system version /usr/lib/libffi.dylib will be found before the archive under test.

Using the linker option '-search-paths-first' alters the strategy to search each path for dylib and then archive before moving on to the next.