### PR TITLE
Forward declare open_temp_exec_file

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -128,6 +128,10 @@ void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
    static trampoline. */
 int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
 
+/* Return a file descriptor of a temporary zero-sized file in a
+   writable and executable filesystem. */
+int open_temp_exec_file(void) FFI_HIDDEN;
+
 /* Extended cif, used in callback from assembly routine */
 typedef struct
 {

--- a/src/tramp.c
+++ b/src/tramp.c
@@ -39,6 +39,10 @@
 #ifdef __linux__
 #define _GNU_SOURCE 1
 #endif
+
+#include <ffi.h>
+#include <ffi_common.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
It's defined in closures.c and used in tramp.c.
Also declare it as an hidden symbol, as it should be.