### PR TITLE
More accurate explanation of wasm32 state in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ tested:
 | SPARC64         | Solaris          | Oracle Solaris Studio C |
 | TILE-Gx/TILEPro | Linux            | GCC                     |
 | VAX             | OpenBSD/vax      | GCC                     |
-| WASM32          | Chrome           | GCC                     |
-| WASM32          | Firefox          | GCC                     |
+| WASM32          | Emscripten       | EMCC                    |
 | X86             | FreeBSD          | GCC                     |
 | X86             | GNU HURD         | GCC                     |
 | X86             | Interix          | GCC                     |


### PR DESCRIPTION
There are three main wasm32 target triples:
* wasm32-unknown-unknown
* wasm32-unknown-emscripten
* wasm32-unknown-wasi

The wasm32 port is only for the wasm32-unknown-emscripten target triple.
(The other triples have no dynamic linking support so libffi would be both hard to port and of limited utility.)