### PR TITLE
Emscripten tests: Remove -sSTRICT_JS

### DIFF
--- a/testsuite/emscripten/build-tests.sh
+++ b/testsuite/emscripten/build-tests.sh
@@ -30,7 +30,6 @@ export LDFLAGS=" \
     -sEXPORT_ALL \
     -sMODULARIZE \
     -sMAIN_MODULE \
-    -sSTRICT_JS \
     -sNO_DISABLE_EXCEPTION_CATCHING \
     $EXTRA_LD_FLAGS \
 "


### PR DESCRIPTION
This raises an error on newer versions of the emscripten compiler.