### PR TITLE
Fix C2491 error on MSVC

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -39,6 +39,7 @@ struct struct_align_##name {			\
   type x;					\
 };						\
 FFI_EXTERN					\
+maybe_const ffi_type ffi_type_##name;		\
 maybe_const ffi_type ffi_type_##name = {	\
   sizeof(type),					\
   offsetof(struct struct_align_##name, x),	\
@@ -54,6 +55,7 @@ struct struct_align_complex_##name {			\
   _Complex type x;					\
 };							\
 FFI_EXTERN						\
+maybe_const ffi_type ffi_type_complex_##name;		\
 maybe_const ffi_type ffi_type_complex_##name = {	\
   sizeof(_Complex type),				\
   offsetof(struct struct_align_complex_##name, x),	\
@@ -62,7 +64,8 @@ maybe_const ffi_type ffi_type_complex_##name = {	\
 }
 
 /* Size and alignment are fake here. They must not be 0. */
-FFI_EXTERN const ffi_type ffi_type_void = {
+FFI_EXTERN const ffi_type ffi_type_void;
+const ffi_type ffi_type_void = {
   1, 1, FFI_TYPE_VOID, NULL
 };
 


### PR DESCRIPTION
This PR fixes C2491 errors on the latest version of MSVC by splitting the `__declspec(dllimport)` declaration and definition into two statements.

- Closes #782

---

https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/cpp/language-compilers/c2491-define-data-member-dllimport

``` c
//defining data member
extern __declspec(dllimport) int code = 1;
// error C2491: 'code' : definition of dllimport data not allowed
```
``` c
// declaring data member
extern __declspec(dllimport) int code; // ok
int code = 1;
```

