### PR TITLE
Modify Apple code generation to use explicit cross-compilation

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1126,7 +1126,7 @@ case $cpu-$vendor in
 	xscale-* | xscalee[bl]-*)
 		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
 		;;
-	arm64-* | aarch64le-*)
+	arm64-* | arm64_32-* | aarch64le-*)
 		cpu=aarch64
 		;;
 
@@ -1728,7 +1728,7 @@ case $os in
 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
 	     | hiux* | abug | nacl* | netware* | windows* \
-	     | os9* | macos* | osx* | ios* \
+	     | os9* | macos* | osx* | ios* | watchos* | tvos* \
 	     | mpw* | magic* | mmixware* | mon960* | lnews* \
 	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
 	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
@@ -1789,6 +1789,8 @@ case $kernel-$os in
 	nto-qnx*)
 		;;
 	os2-emx)
+		;;
+	ios*-simulator | tvos*-simulator | watchos*-simulator)
 		;;
 	*-eabi* | *-gnueabi*)
 		;;

--- a/generate-darwin-source-and-headers.py
+++ b/generate-darwin-source-and-headers.py
@@ -48,7 +48,6 @@ class armv7_platform(Platform):
 
 
 class ios_simulator_i386_platform(i386_platform):
-    triple = 'i386-apple-darwin11'
     target = 'i386-apple-ios-simulator'
     directory = 'darwin_ios'
     sdk = 'iphonesimulator'
@@ -56,7 +55,6 @@ class ios_simulator_i386_platform(i386_platform):
 
 
 class ios_simulator_x86_64_platform(x86_64_platform):
-    triple = 'x86_64-apple-darwin13'
     target = 'x86_64-apple-ios-simulator'
     directory = 'darwin_ios'
     sdk = 'iphonesimulator'
@@ -64,7 +62,6 @@ class ios_simulator_x86_64_platform(x86_64_platform):
 
 
 class ios_simulator_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin20'
     target = 'arm64-apple-ios-simulator'
     directory = 'darwin_ios'
     sdk = 'iphonesimulator'
@@ -72,7 +69,6 @@ class ios_simulator_arm64_platform(arm64_platform):
 
 
 class ios_device_armv7_platform(armv7_platform):
-    triple = 'arm-apple-darwin11'
     target = 'armv7-apple-ios'
     directory = 'darwin_ios'
     sdk = 'iphoneos'
@@ -80,7 +76,6 @@ class ios_device_armv7_platform(armv7_platform):
 
 
 class ios_device_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin13'
     target = 'arm64-apple-ios'
     directory = 'darwin_ios'
     sdk = 'iphoneos'
@@ -88,7 +83,6 @@ class ios_device_arm64_platform(arm64_platform):
 
 
 class desktop_x86_64_platform(x86_64_platform):
-    triple = 'x86_64-apple-darwin10'
     target = 'x86_64-apple-macos'
     directory = 'darwin_osx'
     sdk = 'macosx'
@@ -96,7 +90,6 @@ class desktop_x86_64_platform(x86_64_platform):
 
 
 class desktop_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin20'
     target = 'arm64-apple-macos'
     directory = 'darwin_osx'
     sdk = 'macosx'
@@ -104,7 +97,6 @@ class desktop_arm64_platform(arm64_platform):
 
 
 class tvos_simulator_x86_64_platform(x86_64_platform):
-    triple = 'x86_64-apple-darwin13'
     target = 'x86_64-apple-tvos-simulator'
     directory = 'darwin_tvos'
     sdk = 'appletvsimulator'
@@ -112,7 +104,6 @@ class tvos_simulator_x86_64_platform(x86_64_platform):
 
 
 class tvos_simulator_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin20'
     target = 'arm64-apple-tvos-simulator'
     directory = 'darwin_tvos'
     sdk = 'appletvsimulator'
@@ -120,7 +111,6 @@ class tvos_simulator_arm64_platform(arm64_platform):
 
 
 class tvos_device_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin13'
     target = 'arm64-apple-tvos'
     directory = 'darwin_tvos'
     sdk = 'appletvos'
@@ -128,7 +118,6 @@ class tvos_device_arm64_platform(arm64_platform):
 
 
 class watchos_simulator_i386_platform(i386_platform):
-    triple = 'i386-apple-darwin11'
     target = 'i386-apple-watchos-simulator'
     directory = 'darwin_watchos'
     sdk = 'watchsimulator'
@@ -136,7 +125,6 @@ class watchos_simulator_i386_platform(i386_platform):
 
 
 class watchos_simulator_x86_64_platform(x86_64_platform):
-    triple = 'x86_64-apple-darwin13'
     target = 'x86_64-apple-watchos-simulator'
     directory = 'darwin_watchos'
     sdk = 'watchsimulator'
@@ -144,7 +132,6 @@ class watchos_simulator_x86_64_platform(x86_64_platform):
 
 
 class watchos_simulator_arm64_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin20'
     target = 'arm64-apple-watchos-simulator'
     directory = 'darwin_watchos'
     sdk = 'watchsimulator'
@@ -152,7 +139,6 @@ class watchos_simulator_arm64_platform(arm64_platform):
 
 
 class watchos_device_armv7k_platform(armv7_platform):
-    triple = 'arm-apple-darwin11'
     target = 'armv7k-apple-watchos'
     directory = 'darwin_watchos'
     sdk = 'watchos'
@@ -161,7 +147,6 @@ class watchos_device_armv7k_platform(armv7_platform):
 
 
 class watchos_device_arm64_32_platform(arm64_platform):
-    triple = 'aarch64-apple-darwin13'
     target = 'arm64_32-apple-watchos'
     directory = 'darwin_watchos'
     sdk = 'watchos'
@@ -229,7 +214,15 @@ def build_target(platform, platform_headers):
     working_dir = os.getcwd()
     try:
         os.chdir(build_dir)
-        subprocess.check_call(['../configure', '-host', platform.triple], env=env)
+        subprocess.check_call(
+            [
+                "../configure",
+                f"--host={platform.target}",
+            ] + (
+                [] if platform.sdk == "macosx" else [f"--build={os.uname().machine}-apple-darwin"]
+            ),
+            env=env
+        )
     finally:
         os.chdir(working_dir)
 


### PR DESCRIPTION
Absent of other details, `configure` attempts to determine if cross-compilation is required by attempting to compile and run a binary. 

However, at some point in the Ventura/Xcode 14.3 lifespan, the behavior of the iOS simulator has changed slightly; attempting to invoke an iOS binary on an M1 MacBook now causes a lockup - the process doesn't start, but the process doesn't return, either. You can work around this by running `configure` with `sudo`, but... No. :-)

This issue is easy enough to avoid - explicitly specify both `--host` *and* `--build`, so that the cross-compilation status is unambiguous.

This is also a good opportunity to simplify the specification of platforms; there's very little difference between `triple` and `target`; and with some minor modifications to `config.sub`, it can convert from the target format to triple format.
