### PR TITLE
Check if FFI_GO_CLOSURES is defined

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -464,7 +464,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;

--- a/msvc_build/aarch64/aarch64_include/ffi.h
+++ b/msvc_build/aarch64/aarch64_include/ffi.h
@@ -429,7 +429,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;


### PR DESCRIPTION
This macro is always defined to 1 if defined, or undefined. With `-Wundef` option, checking the value without checking if it is defined causes warnings on arm64 macOS and Windows:

```
/opt/local/include/ffi.h:477:5: warning: 'FFI_GO_CLOSURES' is not defined, evaluates to 0 [-Wundef]
#if FFI_GO_CLOSURES
    ^
```