### PR TITLE
Add support for Haikuos on PowerPC

### DIFF
--- a/configure.host
+++ b/configure.host
@@ -205,7 +205,7 @@ case "${host}" in
   powerpc-*-eabi*)
 	TARGET=POWERPC; TARGETDIR=powerpc
 	;;
-  powerpc-*-beos*)
+  powerpc-*-beos* | powerpc-*-haiku*)
 	TARGET=POWERPC; TARGETDIR=powerpc
 	;;
   powerpc-*-darwin* | powerpc64-*-darwin*)


### PR DESCRIPTION
HaikuOS (https://www.haiku-os.org/ a BeOS offspring) PowerPC port needs libffi for its build process. Adding it to the configure.host file is sufficient, could you please consider applying this pull request ? 
Thanks for your help ! 
