### PR TITLE
Put optional symbols behind ifdefs

### DIFF
--- a/libffi.map.in
+++ b/libffi.map.in
@@ -33,7 +33,10 @@ LIBFFI_BASE_8.0 {
 	ffi_raw_to_ptrarray;
 	ffi_raw_size;
 
+#if !FFI_NATIVE_RAW_API
 	ffi_java_raw_call;
+#endif
+
 	ffi_java_ptrarray_to_raw;
 	ffi_java_raw_to_ptrarray;
 	ffi_java_raw_size;
@@ -62,8 +65,10 @@ LIBFFI_CLOSURE_8.0 {
 	ffi_prep_closure_loc;
 	ffi_prep_raw_closure;
 	ffi_prep_raw_closure_loc;
+#if !FFI_NATIVE_RAW_API
 	ffi_prep_java_raw_closure;
 	ffi_prep_java_raw_closure_loc;
+#endif
 } LIBFFI_BASE_8.0;
 #endif
 


### PR DESCRIPTION
These symbols are only available if FFI_NATIVE_RAW_API is disabled, so do the same in the symbol versioning file.

```
/bin/sh ./libtool  --tag=CC   --mode=link clang -m32 -mfpmath=sse  -Wall -O3 -pipe -march=znver3 -flto=thin -fexceptions -no-undefined -version-info `grep -v '^#' /var/tmp/portage/dev-libs/libffi-3.4.4-r1/work/libffi-3.4.4/libtool-version` -Wl,--version-script,libffi.map  '-Wl,-O1' '-Wl,--as-needed' '-Wl,--as-needed' '-Wl,--defsym=__gentoo_check_ldflags__=0'  -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -o libffi.la -rpath /usr/lib src/prep_cif.lo src/types.lo src/raw_api.lo src/java_raw_api.lo src/closures.lo src/tramp.lo  src/x86/ffi.lo src/x86/sysv.lo 
libtool: link: clang -m32 -mfpmath=sse -shared  -fPIC -DPIC  src/.libs/prep_cif.o src/.libs/types.o src/.libs/raw_api.o src/.libs/java_raw_api.o src/.libs/closures.o src/.libs/tramp.o src/x86/.libs/ffi.o src/x86/.libs/sysv.o    -m32 -mfpmath=sse -O3 -march=znver3 -flto=thin -Wl,--version-script -Wl,libffi.map -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0   -Wl,-soname -Wl,libffi.so.8 -o .libs/libffi.so.8.1.2
x86_64-pc-linux-gnu-ld: error: version script assignment of 'LIBFFI_BASE_8.0' to symbol 'ffi_java_raw_call' failed: symbol not defined
x86_64-pc-linux-gnu-ld: error: version script assignment of 'LIBFFI_CLOSURE_8.0' to symbol 'ffi_prep_java_raw_closure' failed: symbol not defined
x86_64-pc-linux-gnu-ld: error: version script assignment of 'LIBFFI_CLOSURE_8.0' to symbol 'ffi_prep_java_raw_closure_loc' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Bug: https://bugs.gentoo.org/915086