### PR TITLE
[configure.ac] Fix visibility checking for AIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,7 @@ if test "x$GCC" = "xyes"; then
   	echo 'int __attribute__ ((visibility ("hidden"))) foo (void) { return 1  ; }' > conftest.c
   	libffi_cv_hidden_visibility_attribute=no
   	if AC_TRY_COMMAND(${CC-cc} -Werror -S conftest.c -o conftest.s 1>&AS_MESSAGE_LOG_FD); then
-  	    if $EGREP '(\.hidden|\.private_extern).*foo' conftest.s >/dev/null; then
+  	    if $EGREP '(\.hidden|\.private_extern).*foo|foo.*,hidden' conftest.s >/dev/null; then
   		libffi_cv_hidden_visibility_attribute=yes
   	    fi
   	fi


### PR DESCRIPTION
In AIX assembly the visibility information is appended to the `.globl` directive:
https://www.ibm.com/docs/en/aix/7.3?topic=ops-globl-pseudo-op

so the assembly this configuration test is looking for actually looks like:
```
        .globl  foo[DS],hidden                  # -- Begin function foo
        .globl  .foo,hidden
```

on AIX. Update the grep pattern to reflect that. 
