### PR TITLE
Fix various warnings

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -49,8 +49,10 @@ extern "C" {
 #  endif
 # endif
 # define MAYBE_UNUSED __attribute__((__unused__))
+# define NORETURN __attribute__((__noreturn__))
 #else
 # define MAYBE_UNUSED
+# define NORETURN
 # if HAVE_ALLOCA_H
 #  include <alloca.h>
 # else
@@ -82,9 +84,9 @@ char *alloca ();
 #endif
 
 #ifdef FFI_DEBUG
-void ffi_assert(char *expr, char *file, int line);
+NORETURN void ffi_assert(const char *expr, const char *file, int line);
 void ffi_stop_here(void);
-void ffi_type_test(ffi_type *a, char *file, int line);
+void ffi_type_test(ffi_type *a, const char *file, int line);
 
 #define FFI_ASSERT(x) ((x) ? (void)0 : ffi_assert(#x, __FILE__,__LINE__))
 #define FFI_ASSERT_AT(x, f, l) ((x) ? 0 : ffi_assert(#x, (f), (l)))

--- a/src/closures.c
+++ b/src/closures.c
@@ -599,7 +599,7 @@ open_temp_exec_file_memfd (const char *name)
 
 /* Open a temporary file name, and immediately unlink it.  */
 static int
-open_temp_exec_file_name (char *name, int flags)
+open_temp_exec_file_name (char *name, int flags MAYBE_UNUSED)
 {
   int fd;
 
@@ -795,7 +795,7 @@ open_temp_exec_file (void)
    Failure to allocate the space will cause SIGBUS to be thrown when
    the mapping is subsequently written to.  */
 static int
-allocate_space (int fd, off_t offset, off_t len)
+allocate_space (int fd, off_t len)
 {
   static long page_size;
 
@@ -838,7 +838,7 @@ dlmmap_locked (void *start, size_t length, int prot, int flags, off_t offset)
 
   offset = execsize;
 
-  if (allocate_space (execfd, offset, length))
+  if (allocate_space (execfd, length))
     return MFAIL;
 
   flags &= ~(MAP_PRIVATE | MAP_ANONYMOUS);

--- a/src/debug.c
+++ b/src/debug.c
@@ -38,7 +38,7 @@ void ffi_stop_here(void)
 
 /* This function should only be called via the FFI_ASSERT() macro */
 
-void ffi_assert(char *expr, char *file, int line)
+NORETURN void ffi_assert(const char *expr, const char *file, int line)
 {
   fprintf(stderr, "ASSERTION FAILURE: %s at %s:%d\n", expr, file, line);
   ffi_stop_here();
@@ -47,7 +47,7 @@ void ffi_assert(char *expr, char *file, int line)
 
 /* Perform a sanity check on an ffi_type structure */
 
-void ffi_type_test(ffi_type *a, char *file, int line)
+void ffi_type_test(ffi_type *a, const char *file, int line)
 {
   FFI_ASSERT_AT(a != NULL, file, line);
 

--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -4452,7 +4452,7 @@ struct mallinfo dlmallinfo(void) {
 }
 #endif /* NO_MALLINFO */
 
-void dlmalloc_stats() {
+void dlmalloc_stats(void) {
   internal_malloc_stats(gm);
 }
 

--- a/src/tramp.c
+++ b/src/tramp.c
@@ -307,7 +307,7 @@ ffi_tramp_lock(void)
 }
 
 static void
-ffi_tramp_unlock()
+ffi_tramp_unlock(void)
 {
   pthread_mutex_unlock (&tramp_globals_mutex);
 }

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -227,7 +227,7 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
 		      ffi_cif* cif,
 		      void (*fun)(ffi_cif*, void*, void**, void*),
 		      void *user_data,
-		      void *codeloc)
+		      void *codeloc MAYBE_UNUSED)
 {
   static const unsigned char trampoline[FFI_TRAMPOLINE_SIZE - 8] = {
     /* endbr64 */


### PR DESCRIPTION
Mostly to do with unused parameters and assigning string literals to `char *` (instead of `const char *`) variables.