### PR TITLE
Put more optional symbols behind ifdefs

### DIFF
--- a/libffi.map.in
+++ b/libffi.map.in
@@ -20,7 +20,9 @@ LIBFFI_BASE_8.0 {
 	ffi_type_sint64;
 	ffi_type_float;
 	ffi_type_double;
+#ifdef HAVE_LONG_DOUBLE
 	ffi_type_longdouble;
+#endif
 	ffi_type_pointer;
 
 	/* Exported functions.  */
@@ -52,7 +54,9 @@ LIBFFI_COMPLEX_8.0 {
 	/* Exported data variables.  */
 	ffi_type_complex_float;
 	ffi_type_complex_double;
+#ifdef HAVE_LONG_DOUBLE
 	ffi_type_complex_longdouble;
+#endif
 } LIBFFI_BASE_8.0;
 #endif
 


### PR DESCRIPTION
On some systems like 32-bit Android, `HAVE_LONG_DOUBLE` is not defined and these symbols aren't defined.

```
ld.lld: error: version script assignment of 'LIBFFI_BASE_8.0' to symbol 'ffi_type_longdouble' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBFFI_COMPLEX_8.0' to symbol 'ffi_type_complex_longdouble' failed: symbol not defined
clang-17: error: linker command failed with exit code 1 (use -v to see invocation)
```

See https://github.com/termux/termux-packages/issues/18804