### PR TITLE
Fix loongarch64 soft-float build (#816)

### DIFF
--- a/src/loongarch64/ffi.c
+++ b/src/loongarch64/ffi.c
@@ -58,7 +58,9 @@
 */
 typedef struct call_context
 {
+#if !defined(__loongarch_soft_float)
   ABI_FLOAT fa[8];
+#endif
   size_t a[10];
 } call_context;
 


### PR DESCRIPTION
This patch is tested on loongarch64-linux-gnu with no regressions compared to the hard-float build.