### PR TITLE
aarch64: add BTI flag to ELF notes

### DIFF
--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -66,7 +66,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #define BTI_C hint #34
 #define BTI_J hint #36
-
+/*
+ * The ELF Notes section needs to indicate if BTI is supported, as the first ELF loaded that doesn't
+ * declare this support disables it for the whole process.
+ */
+# define GNU_PROPERTY_AARCH64_BTI (1 << 0)         /* Has Branch Target Identification */
 	.text
 	.align 4
 
@@ -673,5 +677,17 @@ CNAME(ffi_go_closure_SYSV):
 
 #if defined __ELF__ && defined __linux__
 	.section .note.GNU-stack,"",%progbits
+
+	.pushsection .note.gnu.property, "a";
+	.balign 8;
+	.long 4;
+	.long 0x10;
+	.long 0x5;
+	.asciz "GNU";
+	.long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+	.long 4;
+	.long GNU_PROPERTY_AARCH64_BTI;
+	.long 0;
+	.popsection;
 #endif
 


### PR DESCRIPTION
aarch64: add BTI flag to ELF notes
    
When a program is loaded and linked, the first ELF file that doesn't
declare that BTI is supported in the GNU NOTES section disables BTI
support.
    
Example:
readelf -n ./aarch64-unknown-linux-gnu/.libs/libffi.so
Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_PROPERTY_TYPE_0
      Properties: AArch64 feature: BTI
    
Fixes: #823

Note: BTI support is present, so mark it in the ELF file.