### PR TITLE
don't skip ffi_type_longdouble symbols (#814)

### DIFF
--- a/libffi.map.in
+++ b/libffi.map.in
@@ -20,7 +20,7 @@ LIBFFI_BASE_8.0 {
 	ffi_type_sint64;
 	ffi_type_float;
 	ffi_type_double;
-#ifdef HAVE_LONG_DOUBLE
+#if defined(HAVE_LONG_DOUBLE) || defined(HAVE_LONG_DOUBLE_VARIANT)
 	ffi_type_longdouble;
 #endif
 	ffi_type_pointer;
@@ -54,7 +54,7 @@ LIBFFI_COMPLEX_8.0 {
 	/* Exported data variables.  */
 	ffi_type_complex_float;
 	ffi_type_complex_double;
-#ifdef HAVE_LONG_DOUBLE
+#if defined(HAVE_LONG_DOUBLE) || defined(HAVE_LONG_DOUBLE_VARIANT)
 	ffi_type_complex_longdouble;
 #endif
 } LIBFFI_BASE_8.0;


### PR DESCRIPTION
Seems there are configurations (eg. ppc64 or ppc64le) that define `HAVE_LONG_DOUBLE_VARIANT` in `fficonfig.h`, but do not define `HAVE_LONG_DOUBLE`, and still want `ffi_type_{,complex_}longdouble` symbols. Update the condition in `libffi.map.in` accordingly.