### PR TITLE
LoongArch: Fix a build error with GCC 14

### DIFF
--- a/src/loongarch64/ffi.c
+++ b/src/loongarch64/ffi.c
@@ -28,6 +28,7 @@
 
 #include <ffi.h>
 #include <ffi_common.h>
+#include <tramp.h>
 
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Fix the build error with GCC 14:

    ../src/loongarch64/ffi.c: In function 'ffi_prep_closure_loc':
    ../src/loongarch64/ffi.c:525:7: error: implicit declaration of
    function 'ffi_tramp_set_parms' [-Wimplicit-function-declaration]