### PR TITLE
aarch64: support pointer authentication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,17 +189,17 @@ AC_CACHE_CHECK([whether compiler supports pointer authentication],
    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
 #ifdef __clang__
 # if __has_feature(ptrauth_calls)
-#  define HAVE_PTRAUTH 1
+#  define HAVE_ARM64E_PTRAUTH 1
 # endif
 #endif
 
-#ifndef HAVE_PTRAUTH
+#ifndef HAVE_ARM64E_PTRAUTH
 # error Pointer authentication not supported
 #endif
 		   ]])],[libffi_cv_as_ptrauth=yes],[libffi_cv_as_ptrauth=no])
 ])
 if test "x$libffi_cv_as_ptrauth" = xyes; then
-    AC_DEFINE(HAVE_PTRAUTH, 1,
+    AC_DEFINE(HAVE_ARM64E_PTRAUTH, 1,
 	      [Define if your compiler supports pointer authentication.])
 fi
 

--- a/include/ffi_cfi.h
+++ b/include/ffi_cfi.h
@@ -49,6 +49,7 @@
 # define cfi_personality(enc, exp)	.cfi_personality enc, exp
 # define cfi_lsda(enc, exp)		.cfi_lsda enc, exp
 # define cfi_escape(...)		.cfi_escape __VA_ARGS__
+# define cfi_window_save		.cfi_window_save
 
 #else
 
@@ -71,6 +72,7 @@
 # define cfi_personality(enc, exp)
 # define cfi_lsda(enc, exp)
 # define cfi_escape(...)
+# define cfi_window_save
 
 #endif /* HAVE_AS_CFI_PSEUDO_OP */
 #endif /* FFI_CFI_H */

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -63,7 +63,7 @@ struct call_context
 #if FFI_EXEC_TRAMPOLINE_TABLE
 
 #ifdef __MACH__
-#ifdef HAVE_PTRAUTH
+#ifdef HAVE_ARM64E_PTRAUTH
 #include <ptrauth.h>
 #endif
 #include <mach/vm_param.h>
@@ -877,7 +877,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 # ifdef __MACH__
-#  ifdef HAVE_PTRAUTH
+#  ifdef HAVE_ARM64E_PTRAUTH
   codeloc = ptrauth_auth_data(codeloc, ptrauth_key_function_pointer, 0);
 #  endif
   void **config = (void **)((uint8_t *)codeloc - PAGE_MAX_SIZE);

--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -81,7 +81,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 /* Helpers for writing assembly compatible with arm ptr auth */
 #ifdef LIBFFI_ASM
 
-#ifdef HAVE_PTRAUTH
+#ifdef HAVE_ARM64E_PTRAUTH
 #define SIGN_LR pacibsp
 #define SIGN_LR_WITH_REG(x) pacib lr, x
 #define AUTH_LR_AND_RET retab

--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -81,20 +81,62 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 /* Helpers for writing assembly compatible with arm ptr auth */
 #ifdef LIBFFI_ASM
 
-#ifdef HAVE_ARM64E_PTRAUTH
-#define SIGN_LR pacibsp
-#define SIGN_LR_WITH_REG(x) pacib lr, x
-#define AUTH_LR_AND_RET retab
-#define AUTH_LR_WITH_REG(x) autib lr, x
-#define BRANCH_AND_LINK_TO_REG blraaz
-#define BRANCH_TO_REG braaz
-#else
-#define SIGN_LR
-#define SIGN_LR_WITH_REG(x)
-#define AUTH_LR_AND_RET ret
-#define AUTH_LR_WITH_REG(x)
-#define BRANCH_AND_LINK_TO_REG blr
-#define BRANCH_TO_REG br
-#endif
+  #if defined(HAVE_ARM64E_PTRAUTH)
+  /* ARM64E ABI For Darwin */
+  #define SIGN_LR pacibsp
+  #define SIGN_LR_WITH_REG(x) pacib lr, x
+  #define AUTH_LR_AND_RET retab
+  #define AUTH_LR_WITH_REG(x) autib lr, x
+  #define BRANCH_AND_LINK_TO_REG blraaz
+  #define BRANCH_TO_REG braaz
+  #define PAC_CFI_WINDOW_SAVE
+  /* Linux PAC Support */
+  #elif defined(__ARM_FEATURE_PAC_DEFAULT)
+    #define GNU_PROPERTY_AARCH64_POINTER_AUTH (1 << 1)
+    #define PAC_CFI_WINDOW_SAVE cfi_window_save
+    #define TMP_REG x9
+    #define BRANCH_TO_REG br
+    #define BRANCH_AND_LINK_TO_REG blr
+	#define SIGN_LR_LINUX_ONLY SIGN_LR
+    /* Which key to sign with? */
+    #if (__ARM_FEATURE_PAC_DEFAULT & 1) == 1
+      /* Signed with A-key */
+      #define SIGN_LR            hint #25  /* paciasp */
+      #define AUTH_LR            hint #29  /* autiasp */
+    #else
+      /* Signed with B-key */
+      #define SIGN_LR            hint #27  /* pacibsp */
+      #define AUTH_LR            hint #31  /* autibsp */
+    #endif /* __ARM_FEATURE_PAC_DEFAULT */
+    #define AUTH_LR_WITH_REG(x) _auth_lr_with_reg x
+.macro _auth_lr_with_reg modifier
+    mov TMP_REG, sp
+    mov sp, \modifier
+    AUTH_LR
+    mov sp, TMP_REG
+.endm
+  #define SIGN_LR_WITH_REG(x) _sign_lr_with_reg x
+.macro _sign_lr_with_reg modifier
+    mov TMP_REG, sp
+    mov sp, \modifier
+    SIGN_LR
+    mov sp, TMP_REG
+.endm
+  #define AUTH_LR_AND_RET _auth_lr_and_ret modifier
+.macro _auth_lr_and_ret modifier
+    AUTH_LR
+    ret
+.endm
+  #undef TMP_REG
 
-#endif
+  /* No Pointer Auth */
+  #else
+    #define SIGN_LR
+    #define SIGN_LR_WITH_REG(x)
+    #define AUTH_LR_AND_RET ret
+    #define AUTH_LR_WITH_REG(x)
+    #define BRANCH_AND_LINK_TO_REG blr
+    #define BRANCH_TO_REG br
+    #define PAC_CFI_WINDOW_SAVE
+  #endif /* HAVE_ARM64E_PTRAUTH */
+#endif /* LIBFFI_ASM */

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -102,8 +102,6 @@ CNAME(ffi_call_SYSV):
 	 * function it is necessary to point the cfa at the signing register.
 	 */
 	cfi_def_cfa(x1, 0);
-#else
-	cfi_def_cfa(x1, 40);
 #endif
 	stp	x29, x30, [x1]
 	cfi_def_cfa_register(x1)

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -92,10 +92,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	cfi_startproc
 CNAME(ffi_call_SYSV):
 	BTI_C
-	/* Sign the lr with x1 since that is where it will be stored */
+	PAC_CFI_WINDOW_SAVE
+	/* Sign the lr with x1 since that is the CFA which is the modifer used in auth instructions */
 	SIGN_LR_WITH_REG(x1)
 
-	/* Use a stack frame allocated by our caller.  */
 #if defined(HAVE_ARM64E_PTRAUTH) && defined(__APPLE__)
 	/* darwin's libunwind assumes that the cfa is the sp and that's the data
 	 * used to sign the lr.  In order to allow unwinding through this
@@ -103,6 +103,7 @@ CNAME(ffi_call_SYSV):
 	 */
 	cfi_def_cfa(x1, 0);
 #endif
+	/* Use a stack frame allocated by our caller.  */
 	stp	x29, x30, [x1]
 	cfi_def_cfa_register(x1)
 	cfi_rel_offset (x29, 0)
@@ -325,6 +326,7 @@ CNAME(ffi_closure_SYSV_V):
 	cfi_startproc
 	BTI_C
 	SIGN_LR
+	PAC_CFI_WINDOW_SAVE
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -350,6 +352,7 @@ CNAME(ffi_closure_SYSV_V):
 CNAME(ffi_closure_SYSV):
 	BTI_C
 	SIGN_LR
+	PAC_CFI_WINDOW_SAVE
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -647,6 +650,8 @@ CNAME(ffi_go_closure_SYSV_V):
 	cfi_startproc
 CNAME(ffi_go_closure_SYSV):
 	BTI_C
+	SIGN_LR_LINUX_ONLY
+	PAC_CFI_WINDOW_SAVE
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -96,7 +96,7 @@ CNAME(ffi_call_SYSV):
 	SIGN_LR_WITH_REG(x1)
 
 	/* Use a stack frame allocated by our caller.  */
-#if defined(HAVE_PTRAUTH) && defined(__APPLE__)
+#if defined(HAVE_ARM64E_PTRAUTH) && defined(__APPLE__)
 	/* darwin's libunwind assumes that the cfa is the sp and that's the data
 	 * used to sign the lr.  In order to allow unwinding through this
 	 * function it is necessary to point the cfa at the signing register.

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -106,13 +106,14 @@ CNAME(ffi_call_SYSV):
 	cfi_def_cfa(x1, 40);
 #endif
 	stp	x29, x30, [x1]
+	cfi_def_cfa_register(x1)
+	cfi_rel_offset (x29, 0)
+	cfi_rel_offset (x30, 8)
 	mov	x9, sp
 	str	x9, [x1, #32]
 	mov	x29, x1
-	mov	sp, x0
 	cfi_def_cfa_register(x29)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+	mov	sp, x0
 
 	mov	x9, x2			/* save fn */
 	mov	x8, x3			/* install structure return */

--- a/src/closures.c
+++ b/src/closures.c
@@ -164,7 +164,7 @@ ffi_tramp_is_present (__attribute__((unused)) void *ptr)
 
 #include <mach/mach.h>
 #include <pthread.h>
-#ifdef HAVE_PTRAUTH
+#ifdef HAVE_ARM64E_PTRAUTH
 #include <ptrauth.h>
 #endif
 #include <stdio.h>
@@ -223,7 +223,7 @@ ffi_trampoline_table_alloc (void)
   /* Remap the trampoline table on top of the placeholder page */
   trampoline_page = config_page + PAGE_MAX_SIZE;
 
-#ifdef HAVE_PTRAUTH
+#ifdef HAVE_ARM64E_PTRAUTH
   trampoline_page_template = (vm_address_t)(uintptr_t)ptrauth_auth_data((void *)&ffi_closure_trampoline_table_page, ptrauth_key_function_pointer, 0);
 #else
   trampoline_page_template = (vm_address_t)&ffi_closure_trampoline_table_page;
@@ -268,7 +268,7 @@ ffi_trampoline_table_alloc (void)
       ffi_trampoline_table_entry *entry = &table->free_list_pool[i];
       entry->trampoline =
 	(void *) (trampoline_page + (i * FFI_TRAMPOLINE_SIZE));
-#ifdef HAVE_PTRAUTH
+#ifdef HAVE_ARM64E_PTRAUTH
       entry->trampoline = ptrauth_sign_unauthenticated(entry->trampoline, ptrauth_key_function_pointer, 0);
 #endif
 


### PR DESCRIPTION
- aarch64: remove uneeded CFI directive
- aarch64: fix callstack in ffi_call_SYSV
- ptrauth: rename define for clarity
- aarch64: add PAC support to ffi_call_SYSV

Fixes: #836 