### PR TITLE
Unpoison alloca used in stack adjustments when ASAN

### DIFF
--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -88,6 +88,22 @@ NORETURN void ffi_assert(const char *expr, const char *file, int line);
 void ffi_stop_here(void);
 void ffi_type_test(ffi_type *a, const char *file, int line);
 
+#ifndef __SANITIZE_ADDRESS__
+# ifdef __clang__
+#  if __has_feature(address_sanitizer)
+#   define FFI_ASAN
+#  endif
+# endif
+#endif
+#ifdef __SANITIZE_ADDRESS__
+#define FFI_ASAN
+#endif
+
+#ifdef FFI_ASAN
+void ffi_asan_unpoison_alloca_left(void *alloca_ptr);
+#endif
+
+
 #define FFI_ASSERT(x) ((x) ? (void)0 : ffi_assert(#x, __FILE__,__LINE__))
 #define FFI_ASSERT_AT(x, f, l) ((x) ? 0 : ffi_assert(#x, (f), (l)))
 #define FFI_ASSERT_VALID_TYPE(x) ffi_type_test (x, __FILE__, __LINE__)

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -826,6 +826,13 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 #endif
     }
 
+#ifdef FFI_ASAN
+  /* ffi_call_SYSV will steal the alloca'd `stack` variable here for use
+     _as its own stack_ - so we need to remove the ASAN redzones from it
+     so that the top of the stack remains unpoisoned */
+  ffi_asan_unpoison_alloca_left(context);
+#endif
+
   ffi_call_SYSV (context, frame, fn, rvalue, flags, closure);
 
   if (flags & AARCH64_RET_NEED_COPY)

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -403,6 +403,13 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
     }
   FFI_ASSERT (dir > 0 || argp == stack);
 
+#ifdef FFI_ASAN
+  /* ffi_call_i386 will steal the alloca'd `stack` variable here for use
+     _as its own stack_ - so we need to remove the ASAN redzones from it
+     so that the top of the stack remains unpoisoned */
+  ffi_asan_unpoison_alloca_left(stack);
+#endif
+
   ffi_call_i386 (frame, stack);
 }
 #if defined(_MSC_VER)

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -670,6 +670,13 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
     }
   reg_args->rax = ssecount;
 
+#ifdef FFI_ASAN
+  /* ffi_call_unix64 will steal the alloca'd `stack` variable here for use
+     _as its own stack_ - so we need to remove the ASAN redzones from it
+     so that the top of the stack remains unpoisoned */
+  ffi_asan_unpoison_alloca_left(stack);
+#endif
+
   ffi_call_unix64 (stack, cif->bytes + sizeof (struct register_args),
 		   flags, rvalue, fn);
 }


### PR DESCRIPTION
The pattern for several of the architectures is for ffi_call_int to stack-allocate some arguments + the registers, and then ffi_call_$ARCH will pop the top of that structure into registers, and then adjust the stack pointer such that the alloca'd buffer _becomes_ the stack-passed arguments for the function being called.

If libffi is compiled with ASAN, then there will be a redzone inserted after the alloca'd buffer which is marked as poisoned. This redzone appears beyond the end of $sp upon entry to the called function.

If the called function does anything to use this stack memory, ASAN will notice that it's poisoned and report an error.

This commit fixes the situation (on the architectures that I have access to) by manually unpoisoning the alloca'd buffer's redzone. The alternative approach would be to disable instrumentation for ffi_call_int altogether, which I can also do if we think that's preferable.

This should fix the issue reported in https://github.com/libffi/libffi/issues/255