### PR TITLE
OpenRISC/or1k build fixes

### DIFF
--- a/src/or1k/ffi.c
+++ b/src/or1k/ffi.c
@@ -180,7 +180,7 @@ void ffi_closure_SYSV(unsigned long r3, unsigned long r4, unsigned long r5,
   register int *r13 __asm__ ("r13");
 
   ffi_closure* closure = (ffi_closure*) r13;
-  char *stack_args = sp;
+  char *stack_args = (char*) sp;
 
   /* Lay the register arguments down in a continuous chunk of memory.  */
   unsigned register_args[6] =

--- a/src/or1k/ffi.c
+++ b/src/or1k/ffi.c
@@ -110,7 +110,7 @@ void* ffi_prep_args(char *stack, extended_cif *ecif)
 
 extern void ffi_call_SYSV(unsigned,
                           extended_cif *,
-                          void *(*)(int *, extended_cif *),
+                          void *(*)(char *, extended_cif *),
                           unsigned *,
                           void (*fn)(void),
                           unsigned);


### PR DESCRIPTION
This small pull request fixes two build issues encounterd on OpenRISC (or1k) when building with GCC 14.x.