### PR TITLE
Move cfi_startproc after CNAME(label) in aarch64/sysv.S

### DIFF
--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
    x5 closure
 */
 
-	cfi_startproc
 CNAME(ffi_call_SYSV):
+	cfi_startproc
 	BTI_C
 	PAC_CFI_WINDOW_SAVE
 	/* Sign the lr with x1 since that is the CFA which is the modifer used in auth instructions */
@@ -348,8 +348,8 @@ CNAME(ffi_closure_SYSV_V):
 #endif
 
 	.align	4
-	cfi_startproc
 CNAME(ffi_closure_SYSV):
+	cfi_startproc
 	BTI_C
 	SIGN_LR
 	PAC_CFI_WINDOW_SAVE
@@ -647,8 +647,8 @@ CNAME(ffi_go_closure_SYSV_V):
 #endif
 
 	.align	4
-	cfi_startproc
 CNAME(ffi_go_closure_SYSV):
+	cfi_startproc
 	BTI_C
 	SIGN_LR_LINUX_ONLY
 	PAC_CFI_WINDOW_SAVE


### PR DESCRIPTION
The CFI for darwin arm64 was broken because the CNAME macro was being used after the cfi_startproc macro.

This is a fix for https://github.com/libffi/libffi/issues/852: error: invalid CFI advance_loc expression on apple targets.