### PR TITLE
Fix config.sub on Apple platforms

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1127,7 +1127,7 @@ case $cpu-$vendor in
 	xscale-* | xscalee[bl]-*)
 		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
 		;;
-	arm64-* | aarch64le-*)
+	arm64-* | arm64_32-* | aarch64le-*)
 		cpu=aarch64
 		;;
 
@@ -1863,6 +1863,8 @@ case $kernel-$os-$obj in
 	nto-qnx*-)
 		;;
 	os2-emx-)
+		;;
+	ios*-simulator | tvos*-simulator | watchos*-simulator)
 		;;
 	*-eabi*- | *-gnueabi*-)
 		;;

--- a/config.sub
+++ b/config.sub
@@ -1864,8 +1864,8 @@ case $kernel-$os-$obj in
 		;;
 	os2-emx-)
 		;;
-	ios*-simulator | tvos*-simulator | watchos*-simulator)
-		;;
+	ios*-simulator* | tvos*-simulator* | watchos*-simulator*)
+		;;	
 	*-eabi*- | *-gnueabi*-)
 		;;
 	none--*)


### PR DESCRIPTION
I found that `./generate-darwin-source-and-headers.py` got failed since [this commit](https://github.com/libffi/libffi/commit/6993bc14dad1cd24294d64bf91e4503a4d7835d6).
- **Fail reason**: `config.sub` can't resolve the new case `$kernel-$os-$obj`, it worked fine in case `$kernel-$os`
- **Solution**: update the pattern with `ios*-simulator* | tvos*-simulator* | watchos*-simulator*`
- **Verification**: I added the building Example of iOS platform in my branch, and ran [CI verification](https://github.com/yulingtianxia/libffi/actions/runs/10995691182/job/30527092401) for iOS platform.
