### PR TITLE
Fix testsuite for C23 `va_start`

### DIFF
--- a/testsuite/libffi.call/va_struct2.c
+++ b/testsuite/libffi.call/va_struct2.c
@@ -33,6 +33,7 @@ test_fn (int n, ...)
   struct small_tag s2;
   struct large_tag l;
 
+  (void) n;
   va_start (ap, n);
   s1 = va_arg (ap, struct small_tag);
   l = va_arg (ap, struct large_tag);

--- a/testsuite/libffi.call/va_struct3.c
+++ b/testsuite/libffi.call/va_struct3.c
@@ -33,6 +33,7 @@ test_fn (int n, ...)
   struct small_tag s2;
   struct large_tag l;
 
+  (void) n;
   va_start (ap, n);
   s1 = va_arg (ap, struct small_tag);
   l = va_arg (ap, struct large_tag);


### PR DESCRIPTION
In the C23 revision of the C standard, `va_start` ignores its second argument, which is no longer required (previously the last named function parameter - which the compiler knows anyway, so it's redundant information).

This has the consequence for the libffi testsuite, when making GCC default to `-std=gnu23`, of making two tests fail with warnings about an unused function argument (only passed to `va_start` and not otherwise used).  Fix those test failures by explicitly casting the argument to `void`.