### PR TITLE
Add static trampoline support for s390

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -382,7 +382,7 @@ case "$target" in
                    [Define this if you want statically defined trampolines])
        fi
      ;;
-     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* | loongarch*-*-linux-* | s390*-linux-*)
+     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* | loongarch*-*-linux-* | s390x*-linux-*)
        AC_DEFINE(FFI_EXEC_STATIC_TRAMP, 1,
                  [Define this if you want statically defined trampolines])
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -382,7 +382,7 @@ case "$target" in
                    [Define this if you want statically defined trampolines])
        fi
      ;;
-     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* | loongarch*-*-linux-*)
+     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* | loongarch*-*-linux-* | s390*-linux-*)
        AC_DEFINE(FFI_EXEC_STATIC_TRAMP, 1,
                  [Define this if you want statically defined trampolines])
      ;;

--- a/src/s390/internal.h
+++ b/src/s390/internal.h
@@ -9,3 +9,14 @@
 #define FFI390_RET_IN_MEM	8
 
 #define FFI390_RET_STRUCT	(FFI390_RET_VOID | FFI390_RET_IN_MEM)
+
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 4K is chosen.
+ */
+#define FFI390_TRAMP_MAP_SHIFT	12
+#define FFI390_TRAMP_MAP_SIZE	(1 << FFI390_TRAMP_MAP_SHIFT)
+#define FFI390_TRAMP_SIZE	16
+
+#endif

--- a/src/s390/sysv.S
+++ b/src/s390/sysv.S
@@ -28,6 +28,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include "internal.h"
 
 	.text
 
@@ -318,6 +319,43 @@ ffi_closure_SYSV:
 	br	%r14
 	.cfi_endproc
 	.size	 ffi_closure_SYSV,.-ffi_closure_SYSV
+
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * Below is the definition of the trampoline code table. Each element in
+ * the code table is a trampoline.
+ */
+/*
+ * The trampoline uses the volatile register r0 and r1. As the registers are
+ * marked volatile in the ABI, the original values are not saved.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address in r0.
+ * Finally, it jumps to the target code.
+ */
+
+	.align	FFI390_TRAMP_MAP_SIZE
+trampoline_code_table:
+	.rept	FFI390_TRAMP_MAP_SIZE / FFI390_TRAMP_SIZE
+	basr %r1,0              # load next instruction address to r1
+	lmg %r0,%r1,4094(%r1)   # load parameter block
+							# 		r0 -> data
+							# 		r1 -> code
+	br %r1                  # jump to r1/code
+	.balign	8
+	.endr
+
+	.globl trampoline_code_table
+	FFI_HIDDEN(trampoline_code_table)
+#ifdef __ELF__
+	.type	trampoline_code_table, @function
+	.size	trampoline_code_table,.- trampoline_code_table
+#endif
+	.align	FFI390_TRAMP_MAP_SIZE
+#endif /* FFI_EXEC_STATIC_TRAMP */
+
 #endif /* !s390x */
 
 #if defined __ELF__ && defined __linux__


### PR DESCRIPTION
added static trampoline support for ibm s390x. This implementation does not use an intermediate `ffi_closure_SYSV_alt` function but directly loads the address of `ffi_closure_SYSV` from the parameter code block and jumps there. 

the complete testsuite is **pass**. I tested it within docker qemu static emulation: `podman run --platform=linux/s390x ....` 

i verified manually that there is no W&X mmap during execution time with a simple test program:

```
# without static trampolins:
[root@77755a78e43a libffi]# QEMU_STRACE=1 ./a.out  2>&1 | grep PROT_EXEC
92 mmap(0x00000200007fee80,1396736,PROT_EXEC|PROT_READ,MAP_PRIVATE|MAP_DENYWRITE|MAP_FIXED,3,0x7fefc8) = 0x000002000086b000
92 mmap(0x00000200007ffff0,4096,PROT_EXEC|PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0x100ba63) = 0x0000020000a26000

# with static trampolins:
[root@77755a78e43a libffi]# QEMU_STRACE=1 ./a.out  2>&1 | grep PROT_EXEC
2171 mmap(0x00000200007fee80,1396736,PROT_EXEC|PROT_READ,MAP_PRIVATE|MAP_DENYWRITE|MAP_FIXED,3,0x7fefc8) = 0x000002000086b000
2171 mmap(0x00000200007fdd50,4096,PROT_EXEC|PROT_READ,MAP_PRIVATE|MAP_FIXED,3,0) = 0x0000020000a26000
```

i am planing to do more tests and will come back with the results:
- add `QEMU_STRACE=1` to the test.exe calls in the testsuite and check for W^X
- run testsuite on real hw with selinux deny_execmem=on 