### PR TITLE
Add mold linker support to prevent disabling shared library symbols

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -180,6 +180,10 @@ AC_DEFUN([LIBFFI_CHECK_LINKER_FEATURES], [
   if $LD --version 2>/dev/null | grep 'LLD '> /dev/null 2>&1; then
     libat_ld_is_lld=yes
   fi
+  libat_ld_is_mold=no
+  if $LD --version 2>/dev/null | grep 'mold '> /dev/null 2>&1; then
+    libat_ld_is_mold=yes
+  fi
   changequote(,)
   ldver=`$LD --version 2>/dev/null |
          sed -e 's/GNU gold /GNU ld /;s/GNU ld version /GNU ld /;s/GNU ld ([^)]*) /GNU ld /;s/GNU ld \([0-9.][0-9.]*\).*/\1/; q'`
@@ -335,6 +339,8 @@ if test $enable_symvers != no && test $libat_shared_libgcc = yes; then
     elif test $libat_ld_is_gold = yes ; then
       enable_symvers=gnu
     elif test $libat_ld_is_lld = yes ; then
+      enable_symvers=gnu
+    elif test $libat_ld_is_mold = yes ; then
       enable_symvers=gnu
     else
       # The right tools, the right setup, but too old.  Fallbacks?


### PR DESCRIPTION
Fixes #867 

Currently using[ mold linker](https://github.com/rui314/mold) leads to versioning on shared library symbols being disabled:
```
checking for shared libgcc... yes
configure: WARNING: === Linker version 3401 is too old for
configure: WARNING: === full symbol versioning support in this release of GCC.
configure: WARNING: === You would need to upgrade your binutils to version
configure: WARNING: === 21400 or later and rebuild GCC.
configure: WARNING: === Symbol versioning will be disabled.
configure: versioning on shared library symbols is no 
```

This is because the ld version logic is not bypassed for mold linker like it is for `gold` and `lld`.

