### PR TITLE
MIPS: add .note.GNU-stack section to assembly sources

### DIFF
--- a/src/mips/n32.S
+++ b/src/mips/n32.S
@@ -821,3 +821,7 @@ cls_epilogue:
 #endif /* __GNUC__ */	
 	
 #endif
+
+#if defined __ELF__ && defined __linux__
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/mips/o32.S
+++ b/src/mips/o32.S
@@ -559,3 +559,7 @@ $LASFDE2:
 $LEFDE2:
 
 #endif
+
+#if defined __ELF__ && defined __linux__
+	.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
To build ELF shared libraries that do not require executable stack on MIPS, every object file linked should have a .note.GNU-stack section, otherwise the linker defaults to executable stack.

As libffi shouldn't require executable stack, add the .note.GNU-stack section to the assembly source files under src/mips, like other architectures.