### PR TITLE
Repair struct result on x86 Darwin (OS X)

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -118,7 +118,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       break;
     case FFI_TYPE_STRUCT:
       {
-#ifdef X86_WIN32
+#if defined(X86_WIN32) || defined(X86_DARWIN)
         size_t size = cif->rtype->size;
         if (size == 1)
           flags = X86_RET_STRUCT_1B;


### PR DESCRIPTION
On x86 Darwin, structs of size 1, 2, 4, and 8 are returned in registers, the same as on Windows.