### PR TITLE
Disable go closures on Android

### DIFF
--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -83,8 +83,8 @@ typedef enum ffi_abi
 
 #if defined (__APPLE__)
 #define FFI_EXTRA_CIF_FIELDS unsigned aarch64_nfixedargs
-#elif !defined(_WIN32)
-/* iOS and Windows reserve x18 for the system.  Disable Go closures until
+#elif !defined(_WIN32) && !defined(__ANDROID__)
+/* iOS, Windows and Android reserve x18 for the system.  Disable Go closures until
    a new static chain is chosen.  */
 #define FFI_GO_CLOSURES 1
 #endif


### PR DESCRIPTION
x18 register shouldn't be used on Android due to the shadow call stack feature in llvm

https://developer.android.com/ndk/guides/abis#v7a
> On Android, the platform-specific x18 register is reserved for [ShadowCallStack](https://source.android.com/devices/tech/debug/shadow-call-stack) and should not be touched by your code. Current versions of Clang default to using the -ffixed-x18 option on Android, so unless you have hand-written assembler (or a very old compiler) you shouldn't need to worry about this.

https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/AArch64TargetParser.cpp#L139-L142