### PR TITLE
MIPS: Dont import asm/sgidefs.h on linux

### DIFF
--- a/src/mips/ffitarget.h
+++ b/src/mips/ffitarget.h
@@ -32,16 +32,14 @@
 #error "Please do not include ffitarget.h directly into your source.  Use ffi.h instead."
 #endif
 
-#ifdef __linux__
-# include <asm/sgidefs.h>
-#elif defined(__rtems__)
+#ifdef __rtems__
 /*
  * Subprogram calling convention - copied from sgidefs.h
  */
 #define _MIPS_SIM_ABI32		1
 #define _MIPS_SIM_NABI32	2
 #define _MIPS_SIM_ABI64		3
-#elif !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#elif !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__linux__)
 # include <sgidefs.h>
 #endif
 


### PR DESCRIPTION
Removed from Linux since Linux 3.7

Ref: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=61730c538f8281efa7ac12596da9f3f9a31b9272