### PR TITLE
Update the Simple Example from the Docs to fix a compile error

### DIFF
--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -263,14 +263,14 @@ int main()
 		       &ffi_type_sint, args) == FFI_OK)
     @{
       s = "Hello World!";
-      ffi_call(&cif, puts, &rc, values);
+      ffi_call(&cif, (void(*)())puts, &rc, values);
       /* rc now holds the result of the call to puts */
 
       /* values holds a pointer to the function's arg, so to
          call puts() again all we need to do is change the
          value of s */
       s = "This is cool!";
-      ffi_call(&cif, puts, &rc, values);
+      ffi_call(&cif, (void(*)())puts, &rc, values);
     @}
 
   return 0;


### PR DESCRIPTION
It seems like the Simple Example from the Docs was outdated, so it couldn't be compiled.
This PR fixes the following compile error:
`candidate function not viable: no known conversion from 'int (const char *)' to 'void (*)()' for 2nd argument`