### PR TITLE
Add the "ABI_ATTR" attribute to called functions (#891)

### DIFF
--- a/testsuite/libffi.call/overread.c
+++ b/testsuite/libffi.call/overread.c
@@ -12,7 +12,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-static int fn(unsigned char a, unsigned short b, unsigned int c, unsigned long d)
+static int ABI_ATTR fn(unsigned char a, unsigned short b, unsigned int c, unsigned long d)
 {
 	return (int)(a + b + c + d);
 }

--- a/testsuite/libffi.call/x32.c
+++ b/testsuite/libffi.call/x32.c
@@ -8,7 +8,7 @@
 
 #include "ffitest.h"
 
-static int fn(int *a)
+static int ABI_ATTR fn(int *a)
 {
 	if (a)
 		return *a;


### PR DESCRIPTION
I accidentally omitted the "ABI_ATTR" attribute, so that the testsuite fails when testing the Microsoft ABI.

Fixes: fe203ffbb2bd ("Fix bugs in the x86-64 and x32 target (#887) (#889)")