### PR TITLE
powerpc: Add static trampoline support (#894)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ noinst_HEADERS = src/aarch64/ffitarget.h src/aarch64/internal.h		\
 	src/moxie/ffitarget.h \
 	src/or1k/ffitarget.h src/pa/ffitarget.h				\
 	src/powerpc/ffitarget.h src/powerpc/asm.h			\
-	src/powerpc/ffi_powerpc.h src/riscv/ffitarget.h			\
+	src/powerpc/ffi_powerpc.h src/powerpc/internal.h		\
+	src/riscv/ffitarget.h						\
 	src/s390/ffitarget.h src/s390/internal.h src/sh/ffitarget.h	\
 	src/sh64/ffitarget.h src/sparc/ffitarget.h			\
 	src/sparc/internal.h src/tile/ffitarget.h src/vax/ffitarget.h	\

--- a/configure.ac
+++ b/configure.ac
@@ -382,7 +382,8 @@ case "$target" in
                    [Define this if you want statically defined trampolines])
        fi
      ;;
-     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* | loongarch*-*-linux-* | s390x*-linux-*)
+     *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* \
+     | loongarch*-*-linux-* | s390x*-linux-* | powerpc*-linux-*)
        AC_DEFINE(FFI_EXEC_STATIC_TRAMP, 1,
                  [Define this if you want statically defined trampolines])
      ;;

--- a/src/powerpc/ffi.c
+++ b/src/powerpc/ffi.c
@@ -31,6 +31,8 @@
 #include "ffi.h"
 #include "ffi_common.h"
 #include "ffi_powerpc.h"
+#include "internal.h"
+#include <tramp.h>
 
 #if HAVE_LONG_DOUBLE_VARIANT
 /* Adjust ffi_type_longdouble.  */
@@ -173,3 +175,14 @@ ffi_prep_go_closure (ffi_go_closure *closure,
   closure->fun = fun;
   return FFI_OK;
 }
+
+#ifdef FFI_EXEC_STATIC_TRAMP
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+  *tramp_size = PPC_TRAMP_SIZE;
+  *map_size = PPC_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif

--- a/src/powerpc/internal.h
+++ b/src/powerpc/internal.h
@@ -1,0 +1,10 @@
+#ifdef FFI_EXEC_STATIC_TRAMP
+/* For the trampoline code table mapping, a mapping size of 64K is chosen.  */
+#define PPC_TRAMP_MAP_SHIFT	16
+#define PPC_TRAMP_MAP_SIZE	(1 << PPC_TRAMP_MAP_SHIFT)
+# ifdef __PCREL__
+#  define PPC_TRAMP_SIZE	24
+# else
+#  define PPC_TRAMP_SIZE	40
+# endif /* __PCREL__ */
+#endif /* FFI_EXEC_STATIC_TRAMP */

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -27,6 +27,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include "internal.h"
 
 	.file	"linux64_closure.S"
 
@@ -559,7 +560,53 @@ ffi_go_closure_linux64:
 	.size	.ffi_go_closure_linux64,.-.ffi_go_closure_linux64
 #  endif
 # endif
+
+#ifdef FFI_EXEC_STATIC_TRAMP
+	.text
+	.align PPC_TRAMP_MAP_SHIFT
+	FFI_HIDDEN (trampoline_code_table)
+	.globl  trampoline_code_table
+# if _CALL_ELF == 2
+	.type   trampoline_code_table,@function
+trampoline_code_table:
+	.localentry trampoline_code_table,.-trampoline_code_table
+# else
+	.section	".opd","aw"
+	.align  3
+trampoline_code_table:
+	.quad   .L.trampoline_code_table,.TOC.@tocbase,0
+	.type   trampoline_code_table,@function
+	.text
+.L.trampoline_code_table:
+# endif
+	.rept	PPC_TRAMP_MAP_SIZE / PPC_TRAMP_SIZE
+#ifdef __PCREL__
+	pla	%r2,PPC_TRAMP_MAP_SIZE
+	ld	%r11,0(%r2)
+	ld	%r12,8(%r2)
+	mtctr	%r12
+	bctr
+#else
+	mflr	%r0
+	bcl	20,31,$+4
+	mflr	%r11
+	addis	%r11,%r11,PPC_TRAMP_MAP_SIZE@ha
+	mtlr	%r0
+	ld	%r12,(PPC_TRAMP_MAP_SIZE+0)@l(%r11)
+	mtctr	%r12
+	ld	%r11,(PPC_TRAMP_MAP_SIZE-8)@l(%r11)
+	bctr
+	nop
 #endif
+	.endr
+	.align PPC_TRAMP_MAP_SHIFT
+#if _CALL_ELF == 2
+	.size	trampoline_code_table,.-trampoline_code_table
+#else
+	.size	trampoline_code_table,.-.L.trampoline_code_table
+#endif
+#endif /* FFI_EXEC_STATIC_TRAMP */
+#endif /* POWERPC64 */
 
 #if (defined __ELF__ && defined __linux__) || _CALL_ELF == 2
 	.section	.note.GNU-stack,"",@progbits

--- a/src/powerpc/ppc_closure.S
+++ b/src/powerpc/ppc_closure.S
@@ -27,6 +27,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include "internal.h"
 #include <powerpc/asm.h>
 
 	.file   "ppc_closure.S"
@@ -390,6 +391,29 @@ ENTRY(ffi_go_closure_sysv)
 	b .Ldoclosure
 	.cfi_endproc
 END(ffi_go_closure_sysv)
+
+#ifdef FFI_EXEC_STATIC_TRAMP
+	.text
+	.align PPC_TRAMP_MAP_SHIFT
+	FFI_HIDDEN (trampoline_code_table)
+	.globl  trampoline_code_table
+	.type   trampoline_code_table,@function
+trampoline_code_table:
+	.rept   PPC_TRAMP_MAP_SIZE / PPC_TRAMP_SIZE
+	mflr    %r0
+	bcl     20,31,$+4
+	mflr    %r11
+	addis   %r11,%r11,PPC_TRAMP_MAP_SIZE@ha
+	mtlr    %r0
+	lwz     %r0,(PPC_TRAMP_MAP_SIZE-4)@l(%r11)
+	mtctr   %r0
+	lwz     %r11,(PPC_TRAMP_MAP_SIZE-8)@l(%r11)
+	bctr
+	nop
+	.endr
+	.size   trampoline_code_table,.-trampoline_code_table
+	.align PPC_TRAMP_MAP_SHIFT
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if defined __ELF__ && defined __linux__
 	.section	.note.GNU-stack,"",@progbits


### PR DESCRIPTION
Add static trampoline support to all three powerpc Linux ABIs, specifically powerpc-linux (32-bit SYSV BE), powerpc64-linux (64-bit ELFv1 BE) and powerpc64le-linux (64-bit ELFv2 LE).  This follows the s390x implementation and does not introduce a `ffi_closure_*_alt` function, but rather jumps directly to the `ffi_closure_*` function itself.  If compiling with `--with-gcc-arch=power10` and pc-relative is enabled, we use a simpler and smaller trampoline that utilizes Power10's new pc-relative load instructions.

I tested this on a little-endian Power10 system with builds using `--with-gcc-arch={power8,power9,power10}` and on a big-endian Power10 system using `--with-gcc-arch={power4,power5,power6,power7,power8,power9,power10}` in both 32-bit and 64-bit modes and saw no testsuite FAILs.

Previous to this support, rubygem-libffi in Fedora was failing on powerpc because of its lack of static trampoline support. A scratch build on Fedora using this implementation was performed and it was verified that rubygem-libffi now passes.