### PR TITLE
pa: add .note.GNU-stack marker to linux.S

### DIFF
--- a/src/pa/linux.S
+++ b/src/pa/linux.S
@@ -425,3 +425,7 @@ ffi_closure_pa32:
 
 	.align 4
 .LEFDE2:
+
+#if defined(__ELF__) && defined(__linux__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Similarly to f515eac04cf8e5f594d5d9dee5fb7dfc3a186a4c, add a .note.GNU-stack marker to pa/linux.S as it doesn't need an executable stack. Absence of the note means that GNU Binutils will consider it as needing an executable stack and mark it as such automatically.

When building libffi on HPPA with `-Wl,--warn-warn-execstack`, we get:
```
ld: warning: src/pa/.libs/linux.o: missing .note.GNU-stack section implies executable stack
ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

That becomes more problematic with glibc-2.41 which forbids dlopen()
of a library with an executable stack, and libffi is commonly dlopen()'d,
especially by Python.

I suspect the reason it didn't show up on Debian is that since February,
Debian has been building Binutils with --disable-default-execstack.

Bug: https://bugs.gentoo.org/953805
Bug: https://github.com/libffi/libffi/issues/898