### PR TITLE
powerpc: Fix closures on powerpc64-linux when statically linking (#900)

### DIFF
--- a/src/powerpc/ffi.c
+++ b/src/powerpc/ffi.c
@@ -183,6 +183,12 @@ ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
   extern void *trampoline_code_table;
   *tramp_size = PPC_TRAMP_SIZE;
   *map_size = PPC_TRAMP_MAP_SIZE;
+#ifdef _CALL_AIX
+  /* The caller wants the entry point address of the trampoline code,
+     not the address of the function descriptor.  */
+  return *(void **)trampoline_code_table;
+#else
   return &trampoline_code_table;
+#endif
 }
 #endif


### PR DESCRIPTION
Closures on powerpc64-linux using static trampolines do not work when statically linking libffi.  The problem is the usage of tramp_globals.text in libffi assumes it contains the entry point address of the first trampoline. Powerpc's ffi_tramp_arch code returns &trampoline_code_table which for ABIs that use function descriptors, ends up returning trampoline_code_table's function discriptor address instead of its entry point address.  Update the code to always return the entry point address for all ABIs.

This passed make check testing on both --enable-shared and --disable-shared builds with no regressions.