### PR TITLE
Add initializer to prevent warnings

### DIFF
--- a/testsuite/libffi.bhaible/testcases.c
+++ b/testsuite/libffi.bhaible/testcases.c
@@ -21,7 +21,7 @@
 
 #include <stdio.h>
 
-FILE* out;
+FILE* out = NULL;
 
 #define uchar unsigned char
 #define ushort unsigned short


### PR DESCRIPTION
Recent versions of clang will produce warnings on tentative definitions (`-Wtentative-definitions`), which trip up the test run:
```
Executing on host: clang  ../../testsuite/libffi.bhaible/test-call.c   -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O0  -I/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../include -I../../testsuite/../include  -I/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../include/.. -L/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../.libs  -lffi -lm  -o ./test-call.exe    (timeout = 300)
spawn -ignore SIGHUP clang ../../testsuite/libffi.bhaible/test-call.c -W -Wall -DDGTEST=1 -Wno-unused-variable -Wno-unused-parameter -Wno-uninitialized -O0 -I/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../include -I../../testsuite/../include -I/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../include/.. -L/home/daltenty/libffi/powerpc-ibm-aix/testsuite/../.libs -lffi -lm -o ./test-call.exe
In file included from ../../testsuite/libffi.bhaible/test-call.c:66:
../../testsuite/libffi.bhaible/testcases.c:24:7: warning: possible missing 'extern' on global variable definition in header [-Wtentative-definitions]
   24 | FILE* out;
      |       ^
1 warning generated.
```
so explicitly initialize this.