### PR TITLE
Make sure O_CLOEXEC flag is set on global tramp file descriptor

### DIFF
--- a/src/tramp.c
+++ b/src/tramp.c
@@ -208,7 +208,7 @@ ffi_tramp_get_libffi (void)
   char file[PATH_MAX], line[PATH_MAX+100], perm[10], dev[10];
   unsigned long start, end, offset, inode;
   uintptr_t addr = (uintptr_t) tramp_globals.text;
-  int nfields, found;
+  int nfields, found, flags;
 
   snprintf (file, PATH_MAX, "/proc/%d/maps", getpid());
   fp = fopen (file, "r");
@@ -236,7 +236,13 @@ ffi_tramp_get_libffi (void)
   if (!found)
     return 0;
 
-  tramp_globals.fd = open (file, O_RDONLY);
+#ifdef O_CLOEXEC
+  flags = O_CLOEXEC;
+#else
+  flags = 0;
+#endif
+
+  tramp_globals.fd = open (file, O_RDONLY|flags);
   if (tramp_globals.fd == -1)
     return 0;
 


### PR DESCRIPTION
Otherwise the file descriptor will be leaked into all child processes unless special care is taken to close open file descriptors. This copies the same approach that's already used in open_temp_exec_file_dir().