### PR TITLE
fix: enable FFI_MMAP_EXEC_WRIT for DragonFly BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ tested:
 | X86             | Solaris          | Oracle Solaris Studio C |
 | X86             | Windows/Cygwin   | GCC                     |
 | X86             | Windows/MinGW    | GCC                     |
+| X86-64          | DragonFly BSD    | GCC                     |
 | X86-64          | FreeBSD          | GCC                     |
 | X86-64          | Linux            | GCC                     |
 | X86-64          | Linux/x32        | GCC                     |

--- a/configure.ac
+++ b/configure.ac
@@ -230,7 +230,7 @@ case "$target" in
                  [Cannot use PROT_EXEC on this target, so, we revert to
                    alternative means])
      ;;
-     *-apple-* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris* | *-linux-android*)
+     *-apple-* | *-*-dragonfly* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris* | *-linux-android*)
        AC_DEFINE(FFI_MMAP_EXEC_WRIT, 1,
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])


### PR DESCRIPTION
Similar to PR #265 [1], we need to enable FFI_MMAP_EXEC_WRIT to use explicit write+exec mapping on DragonFly BSD.

Without this fix, we were having segfaults with Meld [2]; it would crash with SIGSEGV after 5 diff operations.  The crash was caused by it attempting to execute code from non-execute memory region.  Moreover, if we set the `machdep.pmap_nx_enable=2` tunable (i.e., strict NX mode), Meld would crash upon the first diff operation.

Fix the `configure.ac` script to enable `FFI_MMAP_EXEC_WRIT` for DragonFly BSD.  In addition, add it to the supported platforms table.

[1] https://github.com/libffi/libffi/pull/265
[2] https://meldmerge.org/