### PR TITLE
riscv: Add static trampoline support (#931)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ noinst_HEADERS = src/aarch64/ffitarget.h src/aarch64/internal.h		\
 	src/or1k/ffitarget.h src/pa/ffitarget.h				\
 	src/powerpc/ffitarget.h src/powerpc/asm.h			\
 	src/powerpc/ffi_powerpc.h src/powerpc/internal.h		\
-	src/riscv/ffitarget.h						\
+	src/riscv/ffitarget.h src/riscv/internal.h			\
 	src/s390/ffitarget.h src/s390/internal.h src/sh/ffitarget.h	\
 	src/sh64/ffitarget.h src/sparc/ffitarget.h			\
 	src/sparc/internal.h src/tile/ffitarget.h src/vax/ffitarget.h	\

--- a/configure.ac
+++ b/configure.ac
@@ -392,7 +392,8 @@ case "$target" in
        fi
      ;;
      *arm*-*-linux-* | aarch64*-*-linux-* | i*86-*-linux-* | x86_64-*-linux-* \
-     | loongarch*-*-linux-* | s390x*-linux-* | powerpc*-linux-*)
+     | loongarch*-*-linux-* | s390x*-linux-* | powerpc*-linux-* \
+     | riscv*-linux-*)
        AC_DEFINE(FFI_EXEC_STATIC_TRAMP, 1,
                  [Define this if you want statically defined trampolines])
      ;;

--- a/src/riscv/internal.h
+++ b/src/riscv/internal.h
@@ -1,0 +1,7 @@
+#ifdef FFI_EXEC_STATIC_TRAMP
+/* For the trampoline table mapping, a mapping size of 4K (base page size)
+   is chosen.  */
+#define RISCV_TRAMP_MAP_SHIFT	12
+#define RISCV_TRAMP_MAP_SIZE	(1 << RISCV_TRAMP_MAP_SHIFT)
+#define RISCV_TRAMP_SIZE	16
+#endif /* FFI_EXEC_STATIC_TRAMP */

--- a/src/riscv/sysv.S
+++ b/src/riscv/sysv.S
@@ -29,6 +29,7 @@
 #define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
+#include "internal.h"
 
 /* Define aliases so that we can handle all ABIs uniformly */
 
@@ -291,3 +292,26 @@ ffi_go_closure_asm:
     ret
     .cfi_endproc
     .size ffi_go_closure_asm, .-ffi_go_closure_asm
+
+#ifdef FFI_EXEC_STATIC_TRAMP
+/*
+  trampoline_code_table.
+*/
+    .globl trampoline_code_table
+    .hidden trampoline_code_table
+    .type trampoline_code_table, @function
+    .align RISCV_TRAMP_MAP_SHIFT
+trampoline_code_table:
+    .option push
+    # Do not allow the jr insn to be encoded as c.jr for alignment purposes
+    .option norvc
+    .rept   RISCV_TRAMP_MAP_SIZE / RISCV_TRAMP_SIZE
+    auipc   t2, RISCV_TRAMP_MAP_SIZE >> 12
+    LARG    t1, 0(t2)
+    LARG    t2, PTRS(t2)
+    jr      t2
+    .endr
+    .option pop
+    .size   trampoline_code_table,.-trampoline_code_table
+    .align RISCV_TRAMP_MAP_SHIFT
+#endif /* FFI_EXEC_STATIC_TRAMP */


### PR DESCRIPTION
Add static trampoline support to riscv32 and riscv64 Linux ABIs. The implementation follows the s390x and powerpc implementations which does not introduce a ffi_closure_*_alt function, but rather jumps directly to the ffi_closure_asm function itself.