### PR TITLE
Fix compilation for Cortex-A53

### DIFF
--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -120,11 +120,9 @@
 #endif
 
 
-#ifndef __clang__
 	/* We require interworking on LDM, which implies ARMv5T,
 	   which implies the existance of BLX.  */
  	.arch	armv5t
-#endif
 
 	/* Note that we use STC and LDC to encode VFP instructions,
 	   so that we do not need ".fpu vfp", nor get that added to


### PR DESCRIPTION
When cross-compiling with clang and flags "--target=armv7-linux-gnueabihf -mcpu=cortex-a53" compilation failed on instructions, used coprocessor.