### PR TITLE
arm: Fix compilation for Windows ARM targets

### DIFF
--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -120,9 +120,11 @@
 #endif
 
 
+#ifdef __ELF__
 	/* We require interworking on LDM, which implies ARMv5T,
 	   which implies the existance of BLX.  */
  	.arch	armv5t
+#endif
 
 	/* Note that we use STC and LDC to encode VFP instructions,
 	   so that we do not need ".fpu vfp", nor get that added to


### PR DESCRIPTION
The .arch directive is only relevant for ELF targets, it is unsupported for COFF and MachO targets.

Before 170bab47c90626a33cd08f2169034600cfd9589c, this was not an issue as the directive was filtered out by the `#ifndef __clang__`.