### PR TITLE
Define `WIN32_LEAN_AND_MEAN` before including windows.h

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -28,6 +28,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <ffi_common.h>
 #include "internal.h"
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h> /* FlushInstructionCache */
 #endif
 #include <tramp.h>


### PR DESCRIPTION
From GCC commit 902c7559 "Always define `WIN32_LEAN_AND_MEAN` before <windows.h>"

This is already done in src/arm/ffi.c and src/dlmalloc.c, so do it in src/aarch64/ffi.c too.