### PR TITLE
aarch64: support GCS in assembly

### DIFF
--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -74,6 +74,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.text
 	.align 4
 
+#if defined(__ARM_FEATURE_GCS_DEFAULT) && __ARM_FEATURE_GCS_DEFAULT == 1
+#define GNU_PROPERTY_AARCH64_GCS (1<<2)
+#else
+#define GNU_PROPERTY_AARCH64_GCS 0 /* No GCS */
+#endif
+
 /* ffi_call_SYSV
    extern void ffi_call_SYSV (void *stack, void *frame,
 			      void (*fn)(void), void *rvalue,
@@ -692,7 +698,7 @@ CNAME(ffi_go_closure_SYSV):
 	.asciz "GNU";
 	.long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
 	.long 4;
-	.long GNU_PROPERTY_AARCH64_BTI | GNU_PROPERTY_AARCH64_POINTER_AUTH;
+	.long GNU_PROPERTY_AARCH64_BTI | GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_GCS;
 	.long 0;
 	.popsection;
 #endif


### PR DESCRIPTION
When building with GCC15+, binutils 2.44+, glibc 2.41+ and `-mbranch-protection=standard` on (openSUSE Tumbleweed) aarch64, this enables PAC, BTI and GCS (Guarded Control Stack).
PAC and BTI are already supported in libffi.
For GCS, we need to add some gnu properties when assembler code is used, similarly to what we already did for PAC/BTI.

Before this PR, `readelf -n /usr/lib64/libffi.so.8 | grep feature` returns:
```
      Properties: AArch64 feature: BTI, PAC
```
After this PR, `readelf -n /usr/lib64/libffi.so.8 | grep feature` returns:
```
      Properties: AArch64 feature: BTI, PAC, GCS
```

More details on GCS:
* https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/gcc-15-continuously-improving#guarded
* https://docs.kernel.org/next/arch/arm64/gcs.html