### PR TITLE
fix tsan tests on FreeBSD by linking to pthread

### DIFF
--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -407,6 +407,10 @@ proc libffi_target_compile { source dest type options } {
             lappend options "libs= -lpthread"
         }
 
+        if { [string match "*-*-freebsd*" $target_triplet] } {
+            lappend options "libs= -lpthread"
+        }
+
         lappend options "libs= -lffi"
 
         if { [string match "aarch64*-*-linux*" $target_triplet] } {


### PR DESCRIPTION
I noticed that tsan.c fails to compile during `make check` on FreeBSD:

```
Running ../../testsuite/libffi.threads/threads.exp ...
set_ld_library_path_env_vars: ld_library_path=.:/home/user/dev/freebsd-ports/devel/libffi/work/libffi-3.5.1/amd64-portbld-freebsd15.0/testsuite/../.libs:/home/user/dev/freebsd-ports/devel/libffi/work/libffi-3.5.1/amd64-portbld-freebsd15.0/testsuite/../.libs:/home/user/dev/freebsd-ports/devel/libffi/work/libffi-3.5.1/amd64-portbld-freebsd15.0/testsuite/../.libs
Executing on host: cc  ../../testsuite/libffi.threads/tsan.c   -W -Wall -O0  -I ../include -I ../../testsuite/../include  -I .. -L ../.libs  -lffi -lm  -o ./tsan.exe    (timeout = 300)
spawn -ignore SIGHUP cc ../../testsuite/libffi.threads/tsan.c -W -Wall -O0 -I ../include -I ../../testsuite/../include -I .. -L ../.libs -lffi -lm -o ./tsan.exe
ld: error: undefined symbol: pthread_create
>>> referenced by tsan.c
>>>               /tmp/tsan-11970c.o:(main)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
compiler exited with status 1
FAIL: libffi.threads/tsan.c -W -Wall -O0 (test for excess errors)
Excess errors:
ld: error: undefined symbol: pthread_create
>>> referenced by tsan.c
>>>               /tmp/tsan-11970c.o:(main)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
UNRESOLVED: libffi.threads/tsan.c -W -Wall -O0 compilation failed to produce executable
Executing on host: cc  ../../testsuite/libffi.threads/tsan.c   -W -Wall -O2  -I ../include -I ../../testsuite/../include  -I .. -L ../.libs  -lffi -lm  -o ./tsan.exe    (timeout = 300)
spawn -ignore SIGHUP cc ../../testsuite/libffi.threads/tsan.c -W -Wall -O2 -I ../include -I ../../testsuite/../include -I .. -L ../.libs -lffi -lm -o ./tsan.exe
ld: error: undefined symbol: pthread_create
>>> referenced by tsan.c
>>>               /tmp/tsan-fb10c5.o:(main)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
compiler exited with status 1
FAIL: libffi.threads/tsan.c -W -Wall -O2 (test for excess errors)
Excess errors:
ld: error: undefined symbol: pthread_create
>>> referenced by tsan.c
>>>               /tmp/tsan-fb10c5.o:(main)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
UNRESOLVED: libffi.threads/tsan.c -W -Wall -O2 compilation failed to produce executable
testcase ../../testsuite/libffi.threads/threads.exp completed in 1 seconds
                === libffi Summary ===
# of expected passes            1654
# of unexpected failures        2
# of unresolved testcases       2
runtest completed at Tue Oct 28 17:35:54 2025
```

`-lpthread` is needed, just like on OpenBSD

With this patch, the threading tests compile and pass.