### PR TITLE
add CFLAGS -mcmodel=medium for loongarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,9 @@ case "$TARGET" in
     fi
     CFLAGS="$CFLAGS -sMEMORY64=$WASM64_MEMORY64"
     ;;
+  LOONGARCH64)
+    CFLAGS="$CFLAGS -mcmodel=medium"
+    ;;
 esac
 
 AC_CACHE_CHECK([whether compiler supports pointer authentication],


### PR DESCRIPTION
The default code model of gcc for loongarch64 platform provides 256MiB PC-relative addressing space[1], which is not enough for linking large binaries like chromium. Setting it to medium can let libffi_pic.a get linked to large binaries successfully.

[1] https://github.com/loongson/la-abi-specs/blob/release/laelf.adoc#code_models