### PR TITLE
sh: Fix linker errors by applying __USER_LABEL_PREFIX__ in CNAME

### DIFF
--- a/src/sh/sysv.S
+++ b/src/sh/sysv.S
@@ -31,7 +31,9 @@
 #include <machine/asm.h>
 #else
 /* XXX these lose for some platforms, I'm sure. */
-#define CNAME(x) x
+#define C2(X, Y)	X ## Y
+#define C1(X, Y)	C2(X, Y)
+#define CNAME(x) C1(__USER_LABEL_PREFIX__, x)
 #define ENTRY(x) .globl CNAME(x); .type CNAME(x),%function; CNAME(x):
 #endif
 


### PR DESCRIPTION
## Summary

- The `CNAME` macro in `src/sh/sysv.S` was defined as `#define CNAME(x) x`, effectively a no-op that ignores `__USER_LABEL_PREFIX__`
- On targets where this prefix is non-empty (e.g. an underscore on some platforms), the assembler emits symbols without the expected prefix, causing linker errors when C code tries to reference them.
- This fixes the issue by using the standard C1/C2 two-level macro concatenation pattern (already used in `x86/sysv.S`) to properly prepend `__USER_LABEL_PREFIX__` to symbol names.

This supersedes the hardcoded underscore approach proposed in #809.