### PR TITLE
README: fold autogen.sh note into configure paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,9 @@ First you must configure the distribution for your particular
 system. Go to the directory you wish to build libffi in and run the
 "configure" program found in the root directory of the libffi source
 distribution.  Note that building libffi requires a C99 compatible
-compiler.
-
-If you're building libffi directly from git hosted sources, configure
-won't exist yet; run ./autogen.sh first.  This will require that you
-install autoconf, automake, libtool and texinfo.
+compiler.  If you're building libffi directly from git hosted sources,
+configure won't exist yet; run ./autogen.sh first.  This will require
+that you install autoconf, automake, libtool and texinfo.
 
 You may want to tell configure where to install the libffi library and
 header files. To do that, use the ``--prefix`` configure switch.  Libffi


### PR DESCRIPTION
Issue #954 was closed before all comments were read, but @gitonthescene made a concrete suggestion worth implementing: move the `./autogen.sh` note so it flows directly from the `configure` instruction, rather than sitting in a separate paragraph that's easy to skip.

The current README has two separate paragraphs:

1. "…run the `configure` program found in the root directory…"
2. "If you're building from git, `configure` won't exist yet; run `./autogen.sh` first."

Keeping them apart means a reader scanning for how to build can miss the second paragraph entirely — which is exactly what happened in the issue. This PR merges the two sentences into one paragraph so the git-build caveat is impossible to miss.

No wording was changed beyond folding the paragraphs together.

Closes #954 (follow-up — the suggestion from @gitonthescene deserved a commit even though the issue was already closed).