### PR TITLE
x86: add FFI_ASAN_NO_SANITIZE to ffi_call_int in ffiw64.c

### DIFF
--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -116,6 +116,7 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
 #if defined(_MSC_VER)
 #pragma runtime_checks("s", off)
 #endif
+FFI_ASAN_NO_SANITIZE
 static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      void **avalue, void *closure)


### PR DESCRIPTION
ffi_call_int in ffiw64.c uses the same alloca-as-stack trick as
ffi_call_int in ffi64.c and ffi.c: it alloca's a block and passes it
to ffi_call_win64() which uses it as its own stack frame. This
confuses ASan's shadow memory tracking.

ffi64.c and ffi.c already have FFI_ASAN_NO_SANITIZE on their
ffi_call_int (added alongside the macro definition in ffi_common.h),
but ffiw64.c was missed. Add it for consistency.