### PR TITLE
add NULL check in sys_trim

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -3675,6 +3675,8 @@ static int sys_trim(mstate m, size_t pad) {
                       SIZE_T_ONE) * unit;
       msegmentptr sp = segment_holding(m, (char*)m->top);
 
+      if (sp == 0)
+	CORRUPTION_ERROR_ACTION(m);
       if (!is_extern_segment(sp)) {
         if (is_mmapped_segment(sp)) {
           if (HAVE_MMAP &&

--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -3676,7 +3676,7 @@ static int sys_trim(mstate m, size_t pad) {
       msegmentptr sp = segment_holding(m, (char*)m->top);
 
       if (sp == 0)
-	CORRUPTION_ERROR_ACTION(m);
+        CORRUPTION_ERROR_ACTION(m);
       if (!is_extern_segment(sp)) {
         if (is_mmapped_segment(sp)) {
           if (HAVE_MMAP &&


### PR DESCRIPTION
Avoid null pointer dereference on heap corruption by proactively reporting the error 。