### PR TITLE
Fix `ffi_call` and closures for `FFI_PASCAL` and `FFI_REGISTER` ABIs on x86

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -59,6 +59,15 @@
 #define STACK_ALIGN(bytes) FFI_ALIGN (bytes, 16)
 #endif
 
+static int
+is_type_passed_by_pointer (int cabi, ffi_type *ty)
+{
+  /* PASCAL and REGISTER pass these by-value records through a pointer. */
+  return ((cabi == FFI_PASCAL || cabi == FFI_REGISTER)
+	  && ty->type == FFI_TYPE_STRUCT
+	  && ty->size > FFI_SIZEOF_ARG);
+}
+
 /* Perform machine dependent cif processing.  */
 ffi_status FFI_HIDDEN
 ffi_prep_cif_machdep(ffi_cif *cif)
@@ -138,6 +147,8 @@ ffi_prep_cif_machdep(ffi_cif *cif)
               case FFI_FASTCALL:
               case FFI_STDCALL:
               case FFI_MS_CDECL:
+              case FFI_PASCAL:
+              case FFI_REGISTER:
                 flags = X86_RET_STRUCTARG;
                 break;
               default:
@@ -183,14 +194,22 @@ ffi_prep_cif_machdep(ffi_cif *cif)
   for (i = 0, n = cif->nargs; i < n; i++)
     {
       ffi_type *t = cif->arg_types[i];
+      size_t align = t->alignment;
+      size_t size = t->size;
+
+      if (is_type_passed_by_pointer (cabi, t))
+        {
+          align = FFI_SIZEOF_ARG;
+          size = sizeof(void *);
+        }
 
 #if defined(X86_WIN32)
       if (cabi == FFI_STDCALL)
         bytes = FFI_ALIGN (bytes, FFI_SIZEOF_ARG);
       else
 #endif
-        bytes = FFI_ALIGN (bytes, t->alignment);
-      bytes += FFI_ALIGN (t->size, FFI_SIZEOF_ARG);
+        bytes = FFI_ALIGN (bytes, align);
+      bytes += FFI_ALIGN (size, FFI_SIZEOF_ARG);
     }
   cif->bytes = bytes;
 
@@ -251,6 +270,57 @@ static const struct abi_params abi_params[FFI_LAST_ABI] = {
   [FFI_MS_CDECL] = { 1, R_ECX, 0 }
 };
 
+/* Count actual bytes used on stack for FFI_REGISTER call. This is needed to
+   ensure that arguments end up at the right position on the stack for calls
+   and to clean up after closures. */
+static size_t
+register_stack_bytes (ffi_cif *cif)
+{
+  size_t bytes = 0;
+  int i, n, narg_reg = 0;
+  const struct abi_params *pabi = &abi_params[FFI_REGISTER];
+
+  for (i = 0, n = cif->nargs; i < n; i++)
+    {
+      ffi_type *ty = cif->arg_types[i];
+      size_t z = ty->size;
+      int t = ty->type;
+
+      if ((z <= FFI_SIZEOF_ARG
+	   && t != FFI_TYPE_STRUCT
+	   && t != FFI_TYPE_FLOAT)
+	  || is_type_passed_by_pointer (FFI_REGISTER, ty))
+        {
+	  if (narg_reg < pabi->nregs)
+	    {
+	      narg_reg++;
+	    }
+	  else
+	    {
+	      bytes += FFI_ALIGN (sizeof(void *), FFI_SIZEOF_ARG);
+	    }
+	}
+      else
+	{
+	  bytes += FFI_ALIGN (z, FFI_SIZEOF_ARG);
+	}
+    }
+
+  if (cif->flags == X86_RET_STRUCTARG)
+    {
+      if (narg_reg < pabi->nregs)
+	{
+	  narg_reg++;
+	}
+      else
+	{
+	  bytes += FFI_ALIGN (sizeof(void *), FFI_SIZEOF_ARG);
+	}
+    }
+
+  return bytes;
+}
+
 #ifdef HAVE_FASTCALL
   #ifdef _MSC_VER
     #define FFI_DECLARE_FASTCALL __fastcall
@@ -277,9 +347,9 @@ static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      void **avalue, void *closure)
 {
-  size_t rsize, bytes;
+  size_t rsize, rsizea, bytes, struct_copies_size;
   struct call_frame *frame;
-  char *stack, *argp;
+  char *stack, *argp, *copy_argp;
   ffi_type **arg_types;
   int flags, cabi, i, n, dir, narg_reg;
   const struct abi_params *pabi;
@@ -310,12 +380,37 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	}
     }
 
-  bytes = STACK_ALIGN (cif->bytes);
-  stack = alloca(bytes + sizeof(*frame) + rsize);
+  bytes = (cif->abi == FFI_REGISTER
+	   ? register_stack_bytes (cif) : cif->bytes);
+
+  if (dir > 0)
+    {
+      bytes = STACK_ALIGN (bytes);
+    }
+
+  rsizea = FFI_ALIGN (rsize, FFI_SIZEOF_ARG);
+
+  struct_copies_size = 0;
+  if (cif->abi == FFI_PASCAL || cif->abi == FFI_REGISTER)
+    {
+      /* Calculate how much space must be used to copy structs that are
+	 passed by pointer on FFI_PASCAL and FFI_REGISTER ABIs. */
+      for (i = 0, n = cif->nargs; i < n; i++)
+        {
+	  if (is_type_passed_by_pointer (cabi, cif->arg_types[i]))
+	    {
+	      struct_copies_size += FFI_ALIGN (cif->arg_types[i]->size,
+					       FFI_SIZEOF_ARG);
+	    }
+	}
+    }
+
+  stack = alloca(bytes + sizeof(*frame) + rsizea + struct_copies_size);
   argp = (dir < 0 ? stack + bytes : stack);
   frame = (struct call_frame *)(stack + bytes);
   if (rsize)
     rvalue = frame + 1;
+  copy_argp = (char *)(frame + 1) + rsizea;
 
   frame->fn = fn;
   frame->flags = flags;
@@ -323,21 +418,26 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
   frame->regs[pabi->static_chain] = (unsigned)closure;
 
   narg_reg = 0;
-  switch (flags)
+  /* For RTL ABIs, handle struct returns before arguments. */
+  if (dir > 0)
     {
-    case X86_RET_STRUCTARG:
-      /* The pointer is passed as the first argument.  */
-      if (pabi->nregs > 0)
+      switch (flags)
 	{
-	  frame->regs[pabi->regs[0]] = (unsigned)rvalue;
-	  narg_reg = 1;
+	case X86_RET_STRUCTARG:
+	  /* The pointer is passed as the first argument.  */
+	  if (pabi->nregs > 0)
+	    {
+	      frame->regs[pabi->regs[0]] = (unsigned)rvalue;
+	      narg_reg = 1;
+	      break;
+	    }
+
+	  /* fallthru */
+	case X86_RET_STRUCTPOP:
+	  *(void **)argp = rvalue;
+	  argp += sizeof(void *);
 	  break;
 	}
-      /* fallthru */
-    case X86_RET_STRUCTPOP:
-      *(void **)argp = rvalue;
-      argp += sizeof(void *);
-      break;
     }
 
   arg_types = cif->arg_types;
@@ -348,7 +448,28 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
       size_t z = ty->size;
       int t = ty->type;
 
-      if (z <= FFI_SIZEOF_ARG && t != FFI_TYPE_STRUCT)
+      if (is_type_passed_by_pointer (cabi, ty))
+        {
+	  memcpy (copy_argp, valp, z);
+	  valp = copy_argp;
+	  copy_argp += FFI_ALIGN (z, FFI_SIZEOF_ARG);
+
+	  if (narg_reg < pabi->nregs)
+	    {
+	      frame->regs[pabi->regs[narg_reg++]] = (unsigned)valp;
+	    }
+	  else if (dir < 0)
+	    {
+	      argp -= sizeof(void *);
+	      *(void **)argp = valp;
+	    }
+	  else
+	    {
+	      *(void **)argp = valp;
+	      argp += sizeof(void *);
+	    }
+	}
+      else if (z <= FFI_SIZEOF_ARG && t != FFI_TYPE_STRUCT)
         {
 	  ffi_arg val = extend_basic_type (valp, t);
 
@@ -404,6 +525,25 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	    }
 	}
     }
+
+  /* For LTR ABIs, handle struct returns after arguments. */
+  if (dir < 0)
+    switch (flags)
+      {
+      case X86_RET_STRUCTARG:
+	if (narg_reg < pabi->nregs)
+	  {
+	    frame->regs[pabi->regs[narg_reg++]] = (unsigned)rvalue;
+	    break;
+	  }
+
+	/* fallthru */
+      case X86_RET_STRUCTPOP:
+	argp -= sizeof(void *);
+	*(void **)argp = rvalue;
+	break;
+      }
+
   FFI_ASSERT (dir > 0 || argp == stack);
 
   ffi_call_i386 (frame, stack);

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -597,6 +597,7 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
   char *argp;
   void *rvalue;
   void **avalue;
+  size_t bytes;
 
   cabi = cif->abi;
   flags = cif->flags;
@@ -604,24 +605,39 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
   rvalue = frame->rettemp;
   pabi = &abi_params[cabi];
   dir = pabi->dir;
-  argp = (dir < 0 ? stack + STACK_ALIGN (cif->bytes) : stack);
 
-  switch (flags)
+  if (dir > 0)
     {
-    case X86_RET_STRUCTARG:
-      if (pabi->nregs > 0)
+      argp = stack;
+    }
+  else
+    {
+      bytes = (cif->abi == FFI_REGISTER
+	       ? register_stack_bytes (cif) : cif->bytes);
+      argp = stack + bytes;
+    }
+
+  /* For RTL ABIs, handle struct returns before arguments. */
+  if (dir > 0)
+    {
+      switch (flags)
 	{
-	  rvalue = (void *)frame->regs[pabi->regs[0]];
-	  narg_reg = 1;
+	case X86_RET_STRUCTARG:
+	  if (pabi->nregs > 0)
+	    {
+	      rvalue = (void *)frame->regs[pabi->regs[0]];
+	      narg_reg = 1;
+	      frame->rettemp[0] = (unsigned)rvalue;
+	      break;
+	    }
+
+	  /* fallthru */
+	case X86_RET_STRUCTPOP:
+	  rvalue = *(void **)argp;
+	  argp += sizeof(void *);
 	  frame->rettemp[0] = (unsigned)rvalue;
 	  break;
 	}
-      /* fallthru */
-    case X86_RET_STRUCTPOP:
-      rvalue = *(void **)argp;
-      argp += sizeof(void *);
-      frame->rettemp[0] = (unsigned)rvalue;
-      break;
     }
 
   n = cif->nargs;
@@ -635,7 +651,24 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
       int t = ty->type;
       void *valp;
 
-      if (z <= FFI_SIZEOF_ARG && t != FFI_TYPE_STRUCT)
+      if (is_type_passed_by_pointer (cabi, ty))
+	{
+	  if (narg_reg < pabi->nregs)
+      {
+        valp = (void *)frame->regs[pabi->regs[narg_reg++]];
+      }
+	  else if (dir < 0)
+	    {
+	      argp -= sizeof(void *);
+	      valp = *(void **)argp;
+	    }
+	  else
+	    {
+	      valp = *(void **)argp;
+	      argp += sizeof(void *);
+	    }
+	}
+      else if (z <= FFI_SIZEOF_ARG && t != FFI_TYPE_STRUCT)
 	{
 	  if (t != FFI_TYPE_FLOAT && narg_reg < pabi->nregs)
 	    valp = &frame->regs[pabi->regs[narg_reg++]];
@@ -686,16 +719,40 @@ ffi_closure_inner (struct closure_frame *frame, char *stack)
       avalue[i] = valp;
     }
 
+  /* For LTR ABIs, handle struct returns before arguments. */
+  if (dir < 0)
+    {
+      switch (flags)
+	{
+	case X86_RET_STRUCTARG:
+	  if (narg_reg < pabi->nregs)
+	    {
+	      rvalue = (void *)frame->regs[pabi->regs[narg_reg++]];
+	      frame->rettemp[0] = (unsigned)rvalue;
+	      break;
+	    }
+	  /* fallthru */
+	case X86_RET_STRUCTPOP:
+	  argp -= sizeof(void *);
+	  rvalue = *(void **)argp;
+	  frame->rettemp[0] = (unsigned)rvalue;
+	  break;
+	}
+    }
+
   frame->fun (cif, rvalue, avalue, frame->user_data);
 
   switch (cabi)
     {
     case FFI_STDCALL:
+    case FFI_PASCAL:
       return flags | (cif->bytes << X86_RET_POP_SHIFT);
     case FFI_THISCALL:
     case FFI_FASTCALL:
       return flags | ((cif->bytes - (narg_reg * FFI_SIZEOF_ARG))
           << X86_RET_POP_SHIFT);
+    case FFI_REGISTER:
+      return flags | (register_stack_bytes (cif) << X86_RET_POP_SHIFT);
     default:
       return flags;
     }


### PR DESCRIPTION
My attempt at fixing the issues I reported at #964. I'll try to detail a bit more what I found and how it was fixed.

**Disclaimer** I have based these changes on the behaviour of version 3.2.2 of the `fpc` compiler. I do now know whether its behaviour is identical to older pascal compilers and have not been able to find much documentation that can help me with verifying this.

I don't see any tests regressions locally when I run libffi's test suite after these changes. I would have liked to add test cases for the pascal and register ABIs, but I don't know how many meaningful tests I could add. I could always create a test that creates a closure and calls it using those two ABIs I guess. Libffi with the changes in this PR passes all tests in [the little test suite I wrote](https://www.github.com/emiltayl/libffi_pascaltest/).
Please let me know if you want me to make any changes or there is anything else I can do to help.

### Issues fixed for function calls to functions using the pascal and register ABIs:

* Struct return values are passed with a "hidden" return pointer, which matches `X86_RET_STRUCTARG` from how I understand the current code. I set `X86_RET_STRUCTARG` for cifs that return a struct for pascal and register ABIs. There does not seem to be a functional difference from `X86_RET_STRUCTPOP` for the pascal ABI (the switch will always fall through to the pop "handler"), but I opted to flag it as `X86_RET_STRUCTARG` as I think it seems more correct.
* Since pascal and register are LTR ABIs, the return pointers need to be put into a register/onto the stack after the arguments have been processed. It could be possible to handle all arguments first, but the change I propose requires the least amount of new code from what I could see.
* Structs larger than 4 bytes are passed by passing a pointer to the struct. This is solved in `ffi_call_int` by counting how many large structs there are and allocating extra space for them.
* Thiscall and fastcall ABIs can get away with overestimating how much space they use for arguments as they only push from the beginning and extra space at the end of the stack is just wasted. This does not work for the register ABI as arguments are written with the first argument at the end of the stack. The last on-stack argument must then be placed exactly at the start of the reserved stack space. It could be possible to do this in another way, but calculating the exact space required for register ABIs seemed the most robust approach.
 
### Issues fixed for closures using the pascal and register ABIs:
* Struct return values are changed in the same way as for `ffi_call`.
* For large structs passed as arguments, we can just pass the received pointer directly on to the closure.

I was a bit unsure about code style, so I tried to have Codex mimic the code style previously used.