### PR TITLE
Fix erroneous semi colon in FFI_EXTRA_CIF_FIELDS on some platforms

### DIFF
--- a/src/loongarch/ffitarget.h
+++ b/src/loongarch/ffitarget.h
@@ -92,6 +92,6 @@ typedef enum ffi_abi
 #define FFI_NATIVE_RAW_API 0
 #define FFI_EXTRA_CIF_FIELDS \
   unsigned loongarch_nfixedargs; \
-  unsigned loongarch_unused;
+  unsigned loongarch_unused
 #define FFI_TARGET_SPECIFIC_VARIADIC
 #endif

--- a/src/or1k/ffitarget.h
+++ b/src/or1k/ffitarget.h
@@ -52,7 +52,7 @@ typedef enum ffi_abi {
 #define FFI_TRAMPOLINE_SIZE (24)
 
 #define FFI_TARGET_SPECIFIC_VARIADIC 1
-#define FFI_EXTRA_CIF_FIELDS unsigned nfixedargs;
+#define FFI_EXTRA_CIF_FIELDS unsigned nfixedargs
 
 #endif
 

--- a/src/riscv/ffitarget.h
+++ b/src/riscv/ffitarget.h
@@ -62,7 +62,7 @@ typedef enum ffi_abi {
 #define FFI_GO_CLOSURES 1
 #define FFI_TRAMPOLINE_SIZE 24
 #define FFI_NATIVE_RAW_API 0
-#define FFI_EXTRA_CIF_FIELDS unsigned riscv_nfixedargs; unsigned riscv_unused;
+#define FFI_EXTRA_CIF_FIELDS unsigned riscv_nfixedargs; unsigned riscv_unused
 #define FFI_TARGET_SPECIFIC_VARIADIC
 #define FFI_TARGET_HAS_INT128
 


### PR DESCRIPTION
Seen on riscv64 when building with `clang` using the `-Werror-semi -Werror` parameters as per https://github.com/nodejs/unofficial-builds/issues/235

The `FFI_EXTRA_CIF_FIELDS` definition on some platforms has an extra trailing semicolon meaning that when it is referenced in https://github.com/libffi/libffi/blob/c5abbdad2f930f806791942776ccd45beeff1613/include/ffi.h.in#L254 (which also has a trailing semi) it triggers the compiler error due to having two consecutive semi-colons.

I've only tested with this on riscv but since I saw what seems to be the same on two other platforms I've also corrected it there.

The failure is reproducible with any source file that includes `ffi.h` on RISC-V: `clang-20 -c hello.cc -Werror-semi -Werror`