### PR TITLE
aarch64: add feature build attributes

### DIFF
--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -91,10 +91,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
   #define SIGN_LR_LINUX_ONLY
   #define BRANCH_TO_REG braaz
   #define PAC_CFI_WINDOW_SAVE
-  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0
+  #define AARCH64_POINTER_AUTH 0
   /* Linux PAC Support */
   #elif defined(__ARM_FEATURE_PAC_DEFAULT)
-    #define GNU_PROPERTY_AARCH64_POINTER_AUTH (1 << 1)
+    #define AARCH64_POINTER_AUTH (1 << 1)
     #define PAC_CFI_WINDOW_SAVE cfi_window_save
     #define TMP_REG x9
     #define BRANCH_TO_REG br
@@ -141,6 +141,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
     #define SIGN_LR_LINUX_ONLY
     #define BRANCH_TO_REG br
     #define PAC_CFI_WINDOW_SAVE
-    #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0
+    #define AARCH64_POINTER_AUTH 0
   #endif /* HAVE_ARM64E_PTRAUTH */
 #endif /* LIBFFI_ASM */

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -70,14 +70,14 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
  * The ELF Notes section needs to indicate if BTI is supported, as the first ELF loaded that doesn't
  * declare this support disables it for memory region containing the loaded library.
  */
-# define GNU_PROPERTY_AARCH64_BTI (1 << 0)         /* Has Branch Target Identification */
+# define AARCH64_BTI (1 << 0)         /* Has Branch Target Identification */
 	.text
 	.align 4
 
 #if defined(__ARM_FEATURE_GCS_DEFAULT) && __ARM_FEATURE_GCS_DEFAULT == 1
-#define GNU_PROPERTY_AARCH64_GCS (1<<2)
+#define AARCH64_GCS (1<<2)
 #else
-#define GNU_PROPERTY_AARCH64_GCS 0 /* No GCS */
+#define AARCH64_GCS 0 /* No GCS */
 #endif
 
 /* ffi_call_SYSV
@@ -687,19 +687,44 @@ CNAME(ffi_go_closure_SYSV):
 #endif /* FFI_CLOSURES */
 #endif /* __arm64__ */
 
+#define GNU_PROPERTY(value)						\
+	.pushsection .note.gnu.property, "a";				\
+	.balign 8;							\
+	.long 4;							\
+	.long 0x10;							\
+	.long 0x5;							\
+	.asciz "GNU";							\
+	.long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */	\
+	.long 4;							\
+	.long value;							\
+	.long 0;							\
+	.popsection;
+
+#ifdef __ARM_BUILDATTR64_FV
+/* Add AArch64 feature bits build attributes.  */
+# define FEATURE_1_AND_MARK(value)					\
+    .aeabi_subsection aeabi_feature_and_bits, optional, ULEB128;	\
+    .if ((value) & AARCH64_BTI);					\
+    .aeabi_attribute Tag_Feature_BTI, 1;				\
+    .else;								\
+    .aeabi_attribute Tag_Feature_BTI, 0;				\
+    .endif;								\
+    .if ((value) & AARCH64_POINTER_AUTH);				\
+    .aeabi_attribute Tag_Feature_PAC, 1;				\
+    .else;								\
+    .aeabi_attribute Tag_Feature_PAC, 0;				\
+    .endif;								\
+    .if ((value) & AARCH64_GCS);					\
+    .aeabi_attribute Tag_Feature_GCS, 1;				\
+    .else;								\
+    .aeabi_attribute Tag_Feature_GCS, 0;				\
+    .endif;
+#else
+/* Add a NT_GNU_PROPERTY_TYPE_0 note.  */
+# define FEATURE_1_AND_MARK(value) GNU_PROPERTY (value)
+#endif /* __ARM_BUILDATTR64_FV */
+
 #if defined __ELF__ && defined __linux__
 	.section .note.GNU-stack,"",%progbits
-
-	.pushsection .note.gnu.property, "a";
-	.balign 8;
-	.long 4;
-	.long 0x10;
-	.long 0x5;
-	.asciz "GNU";
-	.long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
-	.long 4;
-	.long GNU_PROPERTY_AARCH64_BTI | GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_GCS;
-	.long 0;
-	.popsection;
+FEATURE_1_AND_MARK(AARCH64_BTI | AARCH64_POINTER_AUTH | AARCH64_GCS)
 #endif
-


### PR DESCRIPTION
Emit AArch64 feature build attributes when assembler support is available, and keep using GNU property notes as the fallback.

Rename the feature bit macros so they can be shared by both metadata formats.

	* src/aarch64/internal.h (AARCH64_POINTER_AUTH): Rename from GNU_PROPERTY_AARCH64_POINTER_AUTH.
	* src/aarch64/sysv.S (AARCH64_BTI): Rename from GNU_PROPERTY_AARCH64_BTI. (AARCH64_GCS): Rename from GNU_PROPERTY_AARCH64_GCS. (GNU_PROPERTY): New macro. (FEATURE_1_AND_MARK): New macro. Emit feature build attributes when __ARM_BUILDATTR64_FV is defined.