### PR TITLE
riscv64: fix float marshal for ABI_FLEN >= 64

### DIFF
--- a/src/riscv/ffi.c
+++ b/src/riscv/ffi.c
@@ -37,10 +37,15 @@
 
 #if __riscv_float_abi_double
 #define ABI_FLEN 64
-#define ABI_FLOAT double
+typedef union {
+    uint64_t i;
+    double d;
+} float_reg;
 #elif __riscv_float_abi_single
 #define ABI_FLEN 32
-#define ABI_FLOAT float
+typedef union {
+    float f;
+} float_reg;
 #endif
 
 #define NARGREG 8
@@ -50,7 +55,7 @@
 typedef struct call_context
 {
 #if ABI_FLEN
-    ABI_FLOAT fa[8];
+    float_reg fa[8];
 #endif
     size_t a[8];
     /* used by the assembly code to in-place construct its own stack frame */
@@ -129,6 +134,30 @@ static float_struct_info struct_passed_as_elements(call_builder *cb, ffi_type *t
 
     return ret;
 }
+
+#if ABI_FLEN >= 64
+/* Float values in wider RISC-V FP registers are NaN-boxed */
+static void marshal_float(call_builder *cb, void *data) {
+    union {
+        uint32_t i;
+        float f;
+    } value;
+
+    value.f = *(float *)data;
+    cb->aregs->fa[cb->used_float++].i =
+        UINT64_C(0xffffffff00000000) | value.i;
+}
+
+static void unmarshal_float(call_builder *cb, void *data) {
+    union {
+        uint32_t i;
+        float f;
+    } value;
+
+    value.i = (uint32_t)cb->aregs->fa[cb->used_float++].i;
+    *(float *)data = value.f;
+}
+#endif
 #endif
 
 /* allocates a single register, float register, or XLEN-sized stack slot to a datum */
@@ -148,17 +177,18 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
 #endif
         case FFI_TYPE_POINTER: value = *(size_t *)data; break;
 
-        /* float values may be recoded in an implementation-defined way
-           by hardware conforming to 2.1 or earlier, so use asm to
-           reinterpret floats as doubles */
-#if ABI_FLEN >= 32
+#if ABI_FLEN >= 64
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(float *)data));
+            marshal_float(cb, data);
+            return;
+#elif ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++].f) : "0"(*(float *)data));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(double *)data));
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++].d) : "0"(*(double *)data));
             return;
 #endif
         default: FFI_ASSERT(0); break;
@@ -174,14 +204,18 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
 static void unmarshal_atom(call_builder *cb, int type, void *data) {
     size_t value;
     switch (type) {
-#if ABI_FLEN >= 32
+#if ABI_FLEN >= 64
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            unmarshal_float(cb, data);
+            return;
+#elif ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++].f));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++].d));
             return;
 #endif
     }


### PR DESCRIPTION
The original code tries to use asm to reinterpret floats as doubles. However, that does not work since the float is converted to double instead.

This patch fixes it by manually copying the 32-bit float bits and perform the required NaN-boxing when storing a narrower float type inside a wider float type.

Node.js recently enabled libffi by default and I discovered this bug when running Node.js tests on RISC-V.
The original test log is available at <https://github.com/riscv-forks/node-riscv/actions/runs/27544719447/job/81437248188>.

The failing test in `node/test/ffi/test-ffi-dynamic-library.js` is

```js
assert.strictEqual(functions.add_f32(1.25, 2.75), 4);
```

where `add_f32` is

```c
FFI_EXPORT float add_f32(float a, float b) {                                                                                  
  return a + b;                                       
} 
```

When inspecting `add_f32`, the `fa0` and `fa1` register holds `double` values instead of `float` values, which is the bug this patch trying to solve.

```c
│   0x3ff76b34ae <add_f32>                  addi    sp,sp,-16                                                                                                                                                                                              │
│   0x3ff76b34b0 <add_f32+2>                sd      s0,0(sp)                                                                                                                                                                                               │
│   0x3ff76b34b2 <add_f32+4>                sd      ra,8(sp)                                                                                                                                                                                               │
│   0x3ff76b34b4 <add_f32+6>                addi    s0,sp,16                                                                                                                                                                                               │
│   0x3ff76b34b6 <add_f32+8>                ld      ra,8(sp)                                                                                                                                                                                               │
│   0x3ff76b34b8 <add_f32+10>               ld      s0,0(sp)                                                                                                                                                                                               │
│B+>0x3ff76b34ba <add_f32+12>               fadd.s  fa0,fa0,fa1                                                                                                                                                                                            │
│   0x3ff76b34be <add_f32+16>               addi    sp,sp,16                                                                                                                                                                                               │
│   0x3ff76b34c0 <add_f32+18>               ret
(gdb) p {$fa0,$fa1}
$2 = {{float = 0, double = 1.25}, {float = 0, double = 2.75}}
```