### PR TITLE
ci: make Win64 mingw job actually run the testsuite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,14 @@ jobs:
           # sanity-check
           file */.libs/*ffi-*.dll
 
-          TERM=none DEJAGNU=$(pwd)/.ci/site.exp BOARDSDIR=$(pwd)/.ci GCC_COLORS= make check || true
+          # mingw-w64 gcc/clang default to the MS C runtime printf, where the
+          # %L length modifier means double, not long double -- so every long
+          # double test trips -Wformat and dejagnu fails it as "excess errors".
+          # __USE_MINGW_ANSI_STDIO selects mingw's ISO-C99 printf, where %Lf/%Lg
+          # handle long double correctly (fixing both the warning and runtime
+          # output). It's a no-op on the Cygwin targets.
+          TERM=none DEJAGNU=$(pwd)/.ci/site.exp BOARDSDIR=$(pwd)/.ci GCC_COLORS= \
+            make check RUNTESTFLAGS="TOOL_OPTIONS=-D__USE_MINGW_ANSI_STDIO=1" || true
           ./rlgl.exe e \
                           -l project=libffi \
                           -l sha=${GITHUB_SHA:0:7} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,11 +166,18 @@ jobs:
       # ──────────────────────────────── Cygwin & tool-chains ────────────────────────────────
       - uses: egor-tensin/setup-cygwin@v4
         with:
-          # gcc / g++ are needed so Clang can reuse their start-files & libraries
+          # gcc / g++ are needed so Clang can reuse their start-files & libraries.
+          # mingw64-x86_64-* gives us a *Cygwin-hosted* x86_64-w64-mingw32 cross
+          # toolchain: its driver translates Cygwin POSIX paths (/cygdrive/...),
+          # so the DejaGnu test compiles find the generated ffi.h.  Without it the
+          # 64-bit job picked up a native mingw gcc that can't read those paths,
+          # and every testsuite compile failed with "ffi.h: No such file".
           packages: >
             wget make dejagnu automake autoconf libtool texinfo unzip dos2unix
             clang gcc-core gcc-g++
             cygwin32-gcc-core cygwin32-gcc-g++ cygwin32-runtime cygwin32-libgcc1
+            mingw64-x86_64-gcc-core mingw64-x86_64-gcc-g++
+            mingw64-x86_64-runtime mingw64-x86_64-winpthreads
 
       # ──────────────────────────────── Common environment ────────────────────────────────
       - name: Export build env


### PR DESCRIPTION
## Problem

The `x86_64-w64-mingw32` (Win64 mingw) CI job has been **green since 3.5.0-pre0 but tests nothing**. Every one of its ~310 testsuite compiles fails with:

```
ffitest.h:8:10: fatal error: ffi.h: No such file or directory
```

even though `configure` generates `ffi.h` at `x86_64-w64-mingw32/include/ffi.h` and the test compile's `-I` points right at that directory.

## Root cause

Path translation. DejaGnu runs under Cygwin and emits **Cygwin POSIX** include paths (`-I/cygdrive/d/.../include`), but the `x86_64-w64-mingw32-gcc` being resolved is a **native (non-Cygwin) mingw driver** that can't read `/cygdrive/...`. So no `-I` resolves and the first `#include <ffi.h>` dies. Net result: **0 real passes, 310 compile failures**, all masked GREEN by the rlgl baseline.

The 32-bit jobs work because they use genuine `*-pc-cygwin` compilers that translate the paths.

## Fix

Install Cygwin's own `mingw64-x86_64` cross toolchain. Its driver lives in `/usr/bin` (ahead of the native Windows toolchain in the login-shell `PATH`) and is itself a Cygwin process, so it translates the POSIX paths — the test programs compile and run for the first time.

## Heads up

This is **expected to surface real Win64 mingw test results that were previously invisible**, so the job may go red until the [`rlgl-policy`](https://github.com/libffi/rlgl-policy) baseline is refreshed for whatever genuinely fails. That's the point — let's see the true results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)