### PR TITLE
build: fix make dist failure from missing README "was released on" line

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -156,7 +156,8 @@ AM_CCASFLAGS = '$(AM_CPPFLAGS)'
 dist-hook:
 	d=`(cd $(distdir); pwd)`; (cd doc; make pdf; cp *.pdf $$d/doc)
 	if [ -d $(top_srcdir)/.git ] ; then (cd $(top_srcdir); git log --no-decorate) ; else echo 'See git log for history.' ; fi > $(distdir)/ChangeLog
-	s=`awk '/was released on/{ print NR; exit}' $(top_srcdir)/README.md`; tail -n +$$(($$s-1)) $(top_srcdir)/README.md > $(distdir)/README.md
+	s=`awk '/was released on/{ print NR; exit}' $(top_srcdir)/README.md`; \
+	if [ -n "$$s" ]; then tail -n +$$(($$s-1)) $(top_srcdir)/README.md; else cat $(top_srcdir)/README.md; fi > $(distdir)/README.md
 
 # target overrides
 -include $(tmake_file)


### PR DESCRIPTION
## Problem

The `snapshot-dist-tarball` workflow fails on every master push (e.g. [run 27847162128](https://github.com/libffi/libffi/actions/runs/27847162128/job/82418662571)) in `make dist`:

```
tail: invalid number of lines: '+-1'
make[4]: *** [Makefile:2107: dist-hook] Error 1
```

## Cause

`dist-hook` in `Makefile.am` trims `README.md` by locating the `"<version> was released on ..."` line and `tail`'ing from just above it:

```make
s=`awk '/was released on/{ print NR; exit}' .../README.md`; tail -n +$(($s-1)) ...
```

Commit `35f3a8f` ("Update README.md in preparation for libffi 3.6.0") replaced that line with a `"This is WIP repo ..."` banner, so `awk` returns empty → `$(($s-1))` is `-1` → `tail -n +-1` aborts. Latent since April; it only surfaced now because the snapshot workflow runs on every master push.

## Fix

Fall back to copying `README.md` verbatim when the marker is absent. Tagged releases that restore a "was released on" line keep the original trimming behavior. Verified both paths locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)