### PR TITLE
Prepare libffi 3.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Status
 ======
 
-This is WIP repo for what will eventually become libffi-3.6.0.
+libffi-3.6.0 was released on June 20, 2026.
 
 
 What is libffi?
@@ -203,7 +203,7 @@ History
 
 See the git log for details at http://github.com/libffi/libffi.
 
-    3.6.0 ???
+    3.6.0 Jun-20-2026
         Add LoongArch32 support.
         Add RISC-V static trampoline support.
         Add aarch64 GCS (Guarded Control Stack) support.
@@ -211,6 +211,7 @@ See the git log for details at http://github.com/libffi/libffi.
         Add ppc64le ELFv2 complex type support.
         Add conditional target support for __int128.
         Add x86_64 IEEE binary128 long double support (e.g. x86_64 Android).
+        Update bundled dlmalloc to upstream 2.8.6.
         Fix closures using FFI_REGISTER ABI.
         Fix SH linker errors with __USER_LABEL_PREFIX__.
         Fix compilation for ARM Windows targets.
@@ -219,6 +220,7 @@ See the git log for details at http://github.com/libffi/libffi.
         Fix x86 ASAN compatibility for win64.
         Fix clang -Werror-semi builds on riscv, or1k, loongarch.
         Fix NULL deref in dlmalloc sys_trim on heap corruption.
+        Fix ThreadSanitizer data race in dlmalloc mparams init (#873).
         Define WIN32_LEAN_AND_MEAN before including windows.h.
         Fix comments that trip up some toolchains.
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this with autoconf to create configure
 
 AC_PREREQ([2.68])
 
-AC_INIT([libffi],[3.5.2],[http://github.com/libffi/libffi/issues])
+AC_INIT([libffi],[3.6.0],[http://github.com/libffi/libffi/issues])
 AC_CONFIG_HEADERS([fficonfig.h])
 
 FFI_VERSION_STRING="3.5.2"

--- a/libtool-version
+++ b/libtool-version
@@ -26,4 +26,4 @@
 #    release, then set age to 0.
 #
 # CURRENT:REVISION:AGE
-11:0:3
+11:1:3


### PR DESCRIPTION
Release bookkeeping for 3.6.0. **Merge at tag time** (adjust the date first if not tagging today).

- `configure.ac`: version `3.5.2` → `3.6.0`
- `libtool-version`: `11:0:3` → **`11:1:3`** (revision++; no public interface added/removed/changed since 3.5.2 — everything new works through the existing `ffi_call`/`ffi_prep_cif`/`ffi_type_*` API)
- `README.md`: WIP banner → "libffi-3.6.0 was released on June 20, 2026" (**placeholder date**); `3.6.0 ???` → dated; added two missing history entries — *dlmalloc updated to 2.8.6* and *fix TSAN data race in dlmalloc mparams init (#873)*

`doc/version.texi` is intentionally **not** touched — it's regenerated by `make` (autoreconf + configure) at release time.

Before merging/tagging, confirm: master CI fully green, `snapshot-dist-tarball` green, and the release date above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)