### PR TITLE
Portability: strict-C99 and clang-assembler fixes (#795, #851, #947)

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -351,6 +351,11 @@ typedef struct {
   void *trampoline_table;
   void *trampoline_table_entry;
 #else
+  /* Anonymous unions are C11 (a GNU extension in C99); __extension__ keeps
+     the field names without tripping -Wpedantic under -std=c99 (#795).  */
+#ifdef __GNUC__
+  __extension__
+#endif
   union {
     char tramp[FFI_TRAMPOLINE_SIZE];
     void *ftramp;

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -388,7 +388,7 @@ extend_hfa_type (void *dest, void *src, int h)
   void *x0;
 
 #define BTI_J "hint #36"
-  asm volatile (
+  __asm__ volatile (
 	"adr	%0, 0f\n"
 "	add	%0, %0, %1\n"
 "	br	%0\n"
@@ -468,18 +468,18 @@ compress_hfa_type (void *dest, void *reg, int h)
 	*(float *)dest = *(float *)reg;
       break;
     case AARCH64_RET_S2:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "st2 { v16.s, v17.s }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17");
       break;
     case AARCH64_RET_S3:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "ldr q18, [%1, #32]\n\t"
 	   "st3 { v16.s, v17.s, v18.s }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17", "v18");
       break;
     case AARCH64_RET_S4:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "ldp q18, q19, [%1, #32]\n\t"
 	   "st4 { v16.s, v17.s, v18.s, v19.s }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17", "v18", "v19");
@@ -496,18 +496,18 @@ compress_hfa_type (void *dest, void *reg, int h)
 	*(double *)dest = *(double *)reg;
       break;
     case AARCH64_RET_D2:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "st2 { v16.d, v17.d }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17");
       break;
     case AARCH64_RET_D3:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "ldr q18, [%1, #32]\n\t"
 	   "st3 { v16.d, v17.d, v18.d }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17", "v18");
       break;
     case AARCH64_RET_D4:
-      asm ("ldp q16, q17, [%1]\n\t"
+      __asm__ ("ldp q16, q17, [%1]\n\t"
 	   "ldp q18, q19, [%1, #32]\n\t"
 	   "st4 { v16.d, v17.d, v18.d, v19.d }[0], [%0]"
 	   : : "r"(dest), "r"(reg) : "memory", "v16", "v17", "v18", "v19");

--- a/src/alpha/ffi.c
+++ b/src/alpha/ffi.c
@@ -52,14 +52,14 @@ extern void ffi_go_closure_osf(void) FFI_HIDDEN;
 static inline UINT64 lds(void *ptr)
 {
   UINT64 ret;
-  asm("lds %0,%1" : "=f"(ret) : "m"(*(UINT32 *)ptr));
+  __asm__("lds %0,%1" : "=f"(ret) : "m"(*(UINT32 *)ptr));
   return ret;
 }
 
 /* And the reverse.  */
 static inline void sts(void *ptr, UINT64 val)
 {
-  asm("sts %1,%0" : "=m"(*(UINT32 *)ptr) : "f"(val));
+  __asm__("sts %1,%0" : "=m"(*(UINT32 *)ptr) : "f"(val));
 }
 
 ffi_status FFI_HIDDEN
@@ -357,7 +357,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
      instead, since both Compaq as and gas can handle it.
 
      0x86 is PAL_imb in Tru64 UNIX <alpha/pal.h>.  */
-  asm volatile ("call_pal 0x86" : : : "memory");
+  __asm__ volatile ("call_pal 0x86" : : : "memory");
 
   return FFI_OK;
 }

--- a/src/frv/ffi.c
+++ b/src/frv/ffi.c
@@ -240,8 +240,8 @@ void ffi_closure_eabi (unsigned arg1, unsigned arg2, unsigned arg3,
       /* Functions return 4-byte or smaller results in gr8.  8-byte
 	 values also use gr9.  We fill the both, even for small return
 	 values, just to avoid a branch.  */ 
-      asm ("ldi  @(%0, #0), gr8" : : "r" (&rvalue));
-      asm ("ldi  @(%0, #0), gr9" : : "r" (&((int *) &rvalue)[1]));
+      __asm__ ("ldi  @(%0, #0), gr8" : : "r" (&rvalue));
+      __asm__ ("ldi  @(%0, #0), gr9" : : "r" (&((int *) &rvalue)[1]));
     }
 }
 

--- a/src/ia64/ffi.c
+++ b/src/ia64/ffi.c
@@ -84,7 +84,7 @@ endian_adjust (void *addr, size_t len)
 #define stf_spill(addr, value)
 #else
 #define stf_spill(addr, value)	\
-  asm ("stf.spill %0 = %1%P0" : "=m" (*addr) : "f"(value));
+  __asm__ ("stf.spill %0 = %1%P0" : "=m" (*addr) : "f"(value));
 #endif
 
 /* Load a value from ADDR, which is in the current cpu implementation's
@@ -94,7 +94,7 @@ endian_adjust (void *addr, size_t len)
 #define ldf_fill(result, addr)
 #else
 #define ldf_fill(result, addr)	\
-  asm ("ldf.fill %0 = %1%P1" : "=f"(result) : "m"(*addr));
+  __asm__ ("ldf.fill %0 = %1%P1" : "=f"(result) : "m"(*addr));
 #endif
 
 /* Return the size of the C type associated with with TYPE.  Which will

--- a/src/moxie/ffi.c
+++ b/src/moxie/ffi.c
@@ -275,7 +275,7 @@ void ffi_closure_eabi (unsigned arg1, unsigned arg2, unsigned arg3,
       /* Allocate space for the return value and call the function.  */
       long long rvalue;
       (closure->fun) (cif, &rvalue, avalue, closure->user_data);
-      asm ("mov $r12, %0\n ld.l $r0, ($r12)\n ldo.l $r1, 4($r12)" : : "r" (&rvalue));
+      __asm__ ("mov $r12, %0\n ld.l $r0, ($r12)\n ldo.l $r1, 4($r12)" : : "r" (&rvalue));
     }
 }
 

--- a/src/or1k/ffi.c
+++ b/src/or1k/ffi.c
@@ -269,7 +269,7 @@ void ffi_closure_SYSV(unsigned long r3, unsigned long r4, unsigned long r5,
       long long rvalue;
       (closure->fun) (cif, &rvalue, avalue, closure->user_data);
       if (cif->rtype)
-        asm ("l.ori r12, %0, 0x0\n l.lwz r11, 0(r12)\n l.lwz r12, 4(r12)" : : "r" (&rvalue));
+        __asm__ ("l.ori r12, %0, 0x0\n l.lwz r11, 0(r12)\n l.lwz r12, 4(r12)" : : "r" (&rvalue));
     }
 }
 

--- a/src/pa/ffi.c
+++ b/src/pa/ffi.c
@@ -429,7 +429,7 @@ ffi_status ffi_closure_inner_pa32(ffi_closure *closure, UINT32 *stack)
   char *tmp;
   int i, avn;
   unsigned int slot = FIRST_ARG_SLOT;
-  register UINT32 r28 asm("r28");
+  register UINT32 r28 __asm__("r28");
 
   cif = closure->cif;
 

--- a/src/pa/ffi64.c
+++ b/src/pa/ffi64.c
@@ -375,7 +375,7 @@ ffi_status ffi_closure_inner_pa64(ffi_closure *closure, UINT64 *stack)
   char *tmp;
   int i, avn;
   unsigned int slot = FIRST_ARG_SLOT;
-  register UINT64 r28 asm("r28");
+  register UINT64 r28 __asm__("r28");
 
   cif = closure->cif;
 

--- a/src/riscv/ffi.c
+++ b/src/riscv/ffi.c
@@ -183,12 +183,12 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
             return;
 #elif ABI_FLEN >= 32
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++].f) : "0"(*(float *)data));
+            __asm__("" : "=f"(cb->aregs->fa[cb->used_float++].f) : "0"(*(float *)data));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++].d) : "0"(*(double *)data));
+            __asm__("" : "=f"(cb->aregs->fa[cb->used_float++].d) : "0"(*(double *)data));
             return;
 #endif
         default: FFI_ASSERT(0); break;
@@ -210,12 +210,12 @@ static void unmarshal_atom(call_builder *cb, int type, void *data) {
             return;
 #elif ABI_FLEN >= 32
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++].f));
+            __asm__("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++].f));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++].d));
+            __asm__("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++].d));
             return;
 #endif
     }

--- a/src/sh64/ffi.c
+++ b/src/sh64/ffi.c
@@ -332,7 +332,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
   closure->user_data = user_data;
 
   /* Flush the icache.  */
-  asm volatile ("ocbwb %0,0; synco; icbi %1,0; synci" : : "r" (tramp),
+  __asm__ volatile ("ocbwb %0,0; synco; icbi %1,0; synci" : : "r" (tramp),
 		"r"(codeloc));
 
   return FFI_OK;

--- a/src/sparc/ffi.c
+++ b/src/sparc/ffi.c
@@ -332,7 +332,7 @@ static inline void
 ffi_flush_icache (void *p)
 {
   /* SPARC v8 requires 5 instructions for flush to be visible */
-  asm volatile ("iflush	%0; iflush %0+8; nop; nop; nop; nop; nop"
+  __asm__ volatile ("iflush	%0; iflush %0+8; nop; nop; nop; nop; nop"
 		: : "r" (p) : "memory");
 }
 #else

--- a/src/sparc/ffi64.c
+++ b/src/sparc/ffi64.c
@@ -469,7 +469,7 @@ ffi_call_go(ffi_cif *cif, void (*fn)(void), void *rvalue,
 static inline void
 ffi_flush_icache (void *p)
 {
-  asm volatile ("flush	%0; flush %0+8" : : "r" (p) : "memory");
+  __asm__ volatile ("flush	%0; flush %0+8" : : "r" (p) : "memory");
 }
 #else
 extern void ffi_flush_icache (void *) FFI_HIDDEN;

--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -959,6 +959,10 @@ ENDF(C(__x86.get_pc_thunk.dx))
 
 #ifdef HAVE_AS_X86_PCREL
 # define PCREL(X)	X-.
+#elif defined(__clang__)
+/* clang's integrated assembler rejects the X@rel variant (#947); the
+   pc-relative label difference works wherever @rel would.  */
+# define PCREL(X)	X - .
 #else
 # define PCREL(X)	X@rel
 #endif

--- a/src/x86/sysv_intel.S
+++ b/src/x86/sysv_intel.S
@@ -775,6 +775,10 @@ EHFrame0:
 
 #ifdef HAVE_AS_X86_PCREL
 # define PCREL(X)	X - .
+#elif defined(__clang__)
+/* clang's integrated assembler rejects the X@rel variant (#947); the
+   pc-relative label difference works wherever @rel would.  */
+# define PCREL(X)	X - .
 #else
 # define PCREL(X)	X@rel
 #endif

--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -573,6 +573,10 @@ EHFrame0:
 
 #ifdef HAVE_AS_X86_PCREL
 # define PCREL(X)	X - .
+#elif defined(__clang__)
+/* clang's integrated assembler rejects the X@rel variant (#947); the
+   pc-relative label difference works wherever @rel would.  */
+# define PCREL(X)	X - .
 #else
 # define PCREL(X)	X@rel
 #endif


### PR DESCRIPTION
Three independent, low-risk portability fixes for issues hit by strict `-std=c99` and clang's integrated assembler (commonly via the meson port / Android NDK). One commit each.

### `ffi.h`: anonymous union under C99 — **Fixes #795**
The public `ffi_closure` uses an anonymous union (C11; a GNU extension in C99), so `#include <ffi.h>` with `-std=c99 -pedantic` warned and broke `-Werror` users. Prefix it with `__extension__` on GNU compilers — keeps the field names, no API/ABI change. Verified with gcc + clang under `-std=c99 -pedantic -Werror`.

### `asm` → `__asm__` — **Fixes #851**
Clang (e.g. Android NDK) only provides the `asm` keyword in GNU modes; strict `-std=c99` errors with *"use of undeclared identifier 'asm'"*. Replaced the bare keyword with the always-available `__asm__` spelling across the affected backends (aarch64, alpha, frv, ia64, moxie, or1k, pa, riscv, sh64, sparc). Pure spelling change, identical semantics; verified the forms compile under gcc + clang `-std=c99`.

### x86 unwind `@rel` → `X - .` for clang — **Fixes #947**
When `HAVE_AS_X86_PCREL` isn't defined (builds that skip libffi's autoconf checks, e.g. meson), the unwind tables fall back to `X@rel`, which clang's integrated assembler rejects (*"invalid variant 'rel'"*). The pc-relative label difference `X - .` assembles on clang and GNU as alike, so prefer it for clang; the gcc/Solaris-`as` path is left on `@rel`. Verified end-to-end with clang (reproduced the failure, confirmed the fix assembles).

Also note: **#769** (debug `#warning` lines in 32-bit `ffitarget.h`) is **already fixed** by `d6005499` (#940) — it just needs closing.

x86_64 build + `libffi.call` suite stay green with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)