### PR TITLE
dlmalloc: use __builtin_clz/ctz bit-index on all GNU compilers (#754)

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -393,11 +393,9 @@ ffi_closure_free (void *ptr)
 
 #define USE_LOCKS 1
 #define USE_DL_PREFIX 1
-#ifdef __GNUC__
-#ifndef USE_BUILTIN_FFS
-#define USE_BUILTIN_FFS 1
-#endif
-#endif
+/* dlmalloc's bit-index macros use __builtin_clz/__builtin_ctz directly on any
+   GNU-compatible compiler, so USE_BUILTIN_FFS (and pulling in <strings.h> for
+   ffs()) is no longer needed (libffi #754).  */
 
 /* We need to use mmap, not sbrk.  */
 #define HAVE_MORECORE 0

--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -2957,8 +2957,11 @@ static size_t traverse_and_check(mstate m);
 #define smallbin_at(M, i)   ((sbinptr)((char*)&((M)->smallbins[(i)<<1])))
 #define treebin_at(M,i)     (&((M)->treebins[i]))
 
-/* assign tree index for size S to variable I. Use x86 asm if possible  */
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+/* assign tree index for size S to variable I.
+   libffi: enable the __builtin_clz path on any GNU-compatible compiler, not
+   only x86, so the log2 is an intrinsic rather than the generic C idiom that
+   the compiler can't always recognize (libffi #754).  */
+#if defined(__GNUC__)
 #define compute_tree_index(S, I)\
 {\
   unsigned int X = S >> TREEBIN_SHIFT;\
@@ -3059,9 +3062,11 @@ static size_t traverse_and_check(mstate m);
 /* mask with all bits to left of or equal to least bit of x on */
 #define same_or_left_bits(x) ((x) | -(x))
 
-/* index corresponding to given bit. Use x86 asm if possible */
+/* index corresponding to given bit.
+   libffi: use __builtin_ctz on any GNU-compatible compiler, not only x86
+   (libffi #754).  */
 
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#if defined(__GNUC__)
 #define compute_bit2idx(X, I)\
 {\
   unsigned int J;\


### PR DESCRIPTION
Implements the optimization from #754 on the current (2.8.6) dlmalloc base.

The 2.8.6 update (#975) already removed the old x86 `bsrl` inline asm in `compute_tree_index`/`compute_bit2idx`, replacing it with `__builtin_clz`/`__builtin_ctz` — but **gated to `__i386__`/`__x86_64__` only**. Every other GNU-compatible target (aarch64, riscv, power, s390x, …) fell back to the generic C bit-twiddling (or `ffs()`).

`__builtin_clz`/`__builtin_ctz` are target-independent, so this enables the intrinsic path for any `__GNUC__` compiler. It lowers to a hardware bit-count instruction (e.g. aarch64 `clz` / `rbit`+`clz`) instead of the open-coded loop. Also drops the now-unused `USE_BUILTIN_FFS` define in `closures.c` (and the `<strings.h>` include it pulled in).

#754's original diff predated the 2.8.6 update and no longer applied; this is the equivalent change on the new base, kept as a small clearly-marked libffi-local patch.

**Validation:** x86_64 closures suite 588/0 (unchanged — x86_64 already used the intrinsic); the macros compile and emit clz/ctz on aarch64, riscv64, ppc64le, s390x, arm, mips64, sparc64 (clang cross-check). CI covers the real arch matrix.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)