### PR TITLE
ci: drop ineffective __USE_MINGW_ANSI_STDIO from Win64 mingw test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,14 +221,7 @@ jobs:
           # sanity-check
           file */.libs/*ffi-*.dll
 
-          # mingw-w64 gcc/clang default to the MS C runtime printf, where the
-          # %L length modifier means double, not long double -- so every long
-          # double test trips -Wformat and dejagnu fails it as "excess errors".
-          # __USE_MINGW_ANSI_STDIO selects mingw's ISO-C99 printf, where %Lf/%Lg
-          # handle long double correctly (fixing both the warning and runtime
-          # output). It's a no-op on the Cygwin targets.
-          TERM=none DEJAGNU=$(pwd)/.ci/site.exp BOARDSDIR=$(pwd)/.ci GCC_COLORS= \
-            make check RUNTESTFLAGS="TOOL_OPTIONS=-D__USE_MINGW_ANSI_STDIO=1" || true
+          TERM=none DEJAGNU=$(pwd)/.ci/site.exp BOARDSDIR=$(pwd)/.ci GCC_COLORS= make check || true
           ./rlgl.exe e \
                           -l project=libffi \
                           -l sha=${GITHUB_SHA:0:7} \


### PR DESCRIPTION
The `RUNTESTFLAGS="TOOL_OPTIONS=-D__USE_MINGW_ANSI_STDIO=1"` I added in #973 to silence the long-double `%Lf`/`%Lg` `-Wformat` warnings on `x86_64-w64-mingw32` **doesn't work**. Verified on master: the flag *is* on the compile line, but gcc's `-Wformat` still uses the MS-printf archetype with the runner's mingw headers, so the ~10 long-double `(test for excess errors)` failures persist.

The rlgl policy already XFAILs those as the environmental printf-format quirk they are, so the flag is just inert noise in the workflow. Removing it — the baseline handles these correctly, and a non-working "fix" in `build.yml` is worse than none.

(No change to which tests pass/fail: they were failing *with* the flag too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)