### PR TITLE
x86-64: content-based plan-cache key and thread-exit cleanup

### DIFF
--- a/src/plan-cache-impl.h
+++ b/src/plan-cache-impl.h
@@ -6,27 +6,71 @@
 #define FFI_PLAN_CACHE_IMPL_H
 
 #include <stdlib.h>
+#include <pthread.h>
 #include "plan-cache.h"
 
 FFI_TLS struct ffi_plan_slot ffi_plan_cache[FFI_PLAN_CACHE_SIZE];
+
+/* Free a thread's cached plans when it exits.  pthread is referenced through
+   weak symbols so this adds no hard dependency: in a single-threaded program
+   that never links pthread the registration is simply skipped (the cache is
+   already bounded to FFI_PLAN_CACHE_SIZE plans per thread). */
+#pragma weak pthread_key_create
+#pragma weak pthread_once
+#pragma weak pthread_setspecific
+
+static pthread_key_t ffi_plan_key;
+static pthread_once_t ffi_plan_once = PTHREAD_ONCE_INIT;
+
+static void
+ffi_plan_thread_cleanup (void *ignored)
+{
+  unsigned i;
+  (void) ignored;
+  for (i = 0; i < FFI_PLAN_CACHE_SIZE; i++)
+    if (ffi_plan_cache[i].plan != NULL && ffi_plan_cache[i].plan != FFI_PLAN_NONE)
+      {
+	free (ffi_plan_cache[i].plan);
+	ffi_plan_cache[i].plan = NULL;
+      }
+}
+
+static void
+ffi_plan_key_init (void)
+{
+  pthread_key_create (&ffi_plan_key, ffi_plan_thread_cleanup);
+}
+
+static void
+ffi_plan_thread_register (void)
+{
+  if (pthread_once && pthread_setspecific && pthread_key_create)
+    {
+      pthread_once (&ffi_plan_once, ffi_plan_key_init);
+      /* A non-NULL value makes the destructor run for this thread at exit. */
+      pthread_setspecific (ffi_plan_key, (void *) 1);
+    }
+}
 
 /* Direct-mapped miss: free the evicted plan, build this signature's plan once,
    record the key.  A non-plan-able signature caches FFI_PLAN_NONE so it isn't
    rebuilt every call.  Plans are self-contained -> plain free(). */
 void *
-ffi_plan_miss (ffi_cif *cif, struct ffi_plan_slot *s)
+ffi_plan_miss (ffi_cif *cif, struct ffi_plan_slot *s, uint64_t fp)
 {
   void *p;
 
   if (s->plan != NULL && s->plan != FFI_PLAN_NONE)
     free (s->plan);
+  else if (s->plan == NULL)
+    ffi_plan_thread_register ();	/* first use of an empty slot */
 
   p = ffi_build_plan_arch (cif);
-  s->abi    = cif->abi;
-  s->nargs  = cif->nargs;
-  s->rtype  = cif->rtype;
-  s->atypes = cif->arg_types;
-  s->plan   = (p == NULL) ? FFI_PLAN_NONE : p;
+  s->fp    = fp;
+  s->abi   = cif->abi;
+  s->nargs = cif->nargs;
+  s->rtype = cif->rtype;
+  s->plan  = (p == NULL) ? FFI_PLAN_NONE : p;
   return p;
 }
 

--- a/src/plan-cache.h
+++ b/src/plan-cache.h
@@ -2,12 +2,14 @@
 
    ffi_call and the closure paths call ffi_plan_get(cif) to obtain a plan that
    captures a signature's argument placement, so they can skip re-classifying it
-   on every call.  The key is (abi, nargs, rtype, arg_types): an O(1) compare,
-   since arg_types is a single pointer and libffi already requires it to remain
-   stable between ffi_prep_cif and ffi_call.  A per-thread direct-mapped cache
-   holds one plan per slot; a miss builds the plan once and frees the slot's
-   previous plan.  Plans are opaque (each backend casts the void* to its own
-   type) and are self-contained single allocations, released with plain free().
+   on every call.  Each signature is identified by a 64-bit fingerprint folded
+   from its abi, nargs, return type and the *contents* of arg_types (the element
+   ffi_type pointers) -- so a freed arg_types array whose address is later reused
+   for a different signature does not alias a stale plan.  A per-thread
+   direct-mapped cache holds one plan per slot; a miss builds the plan once and
+   frees the slot's previous plan, and a thread's plans are freed when it exits.
+   Plans are opaque (each backend casts the void* to its own type) and are
+   self-contained single allocations, released with plain free().
 
    The cache is internal: no public symbols and no ABI change.  Exactly one
    translation unit per architecture must also #include "plan-cache-impl.h" to
@@ -31,40 +33,48 @@
 
 struct ffi_plan_slot
 {
+  uint64_t   fp;	/* content fingerprint (0 = empty slot)             */
   unsigned   abi;
   unsigned   nargs;
   ffi_type  *rtype;
-  ffi_type **atypes;
   void      *plan;	/* NULL=empty, FFI_PLAN_NONE=no fast path, else plan */
 };
 
 extern FFI_TLS struct ffi_plan_slot ffi_plan_cache[FFI_PLAN_CACHE_SIZE];
 
 /* Cold miss handler + per-arch builder, defined in the impl/arch TUs. */
-void *ffi_plan_miss (ffi_cif *cif, struct ffi_plan_slot *s);
+void *ffi_plan_miss (ffi_cif *cif, struct ffi_plan_slot *s, uint64_t fp);
 void *ffi_build_plan_arch (ffi_cif *cif);
 
-static inline unsigned
-ffi_plan_hash (ffi_cif *cif)
+/* 64-bit FNV-1a-style fingerprint over the signature, including the element
+   type pointers -- so two signatures that differ only in argument types (even
+   if they happen to reuse the same arg_types array address) get distinct keys. */
+static inline uint64_t
+ffi_plan_fp (ffi_cif *cif)
 {
-  uintptr_t h = (uintptr_t) cif->arg_types;
-  h ^= (uintptr_t) cif->rtype + 0x9E3779B97F4A7C15ULL;
-  h ^= ((uintptr_t) cif->nargs << 3) ^ ((uintptr_t) cif->abi << 1);
-  h *= 0xFF51AFD7ED558CCDULL;
-  return (unsigned) (h >> 47);
+  uint64_t h = 0xCBF29CE484222325ULL;
+  unsigned i, n = cif->nargs;
+  h = (h ^ (uint64_t) (uintptr_t) cif->rtype) * 0x100000001B3ULL;
+  h = (h ^ cif->abi)                          * 0x100000001B3ULL;
+  h = (h ^ n)                                 * 0x100000001B3ULL;
+  for (i = 0; i < n; i++)
+    h = (h ^ (uint64_t) (uintptr_t) cif->arg_types[i]) * 0x100000001B3ULL;
+  return h | 1;				/* never 0 (0 marks an empty slot) */
 }
 
 /* Hot path: the plan for CIF (built and cached on first use), or NULL if the
-   signature isn't plan-able.  Key compare is 4 words; no per-arg walk. */
+   signature isn't plan-able.  Computing the fingerprint is O(nargs) of cheap
+   pointer reads -- far less than re-classifying the call. */
 static inline void *
 ffi_plan_get (ffi_cif *cif)
 {
+  uint64_t fp = ffi_plan_fp (cif);
   struct ffi_plan_slot *s =
-    &ffi_plan_cache[ffi_plan_hash (cif) & (FFI_PLAN_CACHE_SIZE - 1)];
-  if (s->atypes == cif->arg_types && s->rtype == cif->rtype
-      && s->nargs == cif->nargs && s->abi == cif->abi)
+    &ffi_plan_cache[(unsigned) fp & (FFI_PLAN_CACHE_SIZE - 1)];
+  if (s->fp == fp && s->abi == cif->abi && s->nargs == cif->nargs
+      && s->rtype == cif->rtype)
     return s->plan == FFI_PLAN_NONE ? NULL : s->plan;
-  return ffi_plan_miss (cif, s);
+  return ffi_plan_miss (cif, s, fp);
 }
 
 #endif /* FFI_PLAN_CACHE_H */


### PR DESCRIPTION
Follow-up to the plan cache (#984), hardening two things I flagged when it landed.

## 1. Content-based key (fixes a stale-plan hazard)

The cache keyed slots on `(abi, nargs, rtype, arg_types)` — but `arg_types` was
the *array pointer*. If a binding freed a cif's `arg_types` array and the
allocator later handed the same address back for a **different** signature with
the same `abi`/`nargs`/`rtype`, the keys collided and the cache could return a
**stale plan** (wrong marshalling).

Now the key is a 64-bit fingerprint that folds in the element `ffi_type`
pointers, so signatures that differ only in argument *type* always get distinct
keys. Lookup is O(nargs) cheap pointer reads — still far less than
re-classifying the call.

Deterministic regression test (reuses one `arg_types` array address as
`(int,int)` → `(double,double)` → `(ptr,ptr)`): fails with the old key, passes
now.

## 2. Thread-exit cleanup (fixes a leak)

The per-thread cache leaked its `malloc`'d plans when a thread exited. A
`pthread` key destructor now frees a thread's plans on exit. `pthread` is
referenced through **weak symbols**, so a program that never links `pthread`
just skips registration (no hard dependency; the cache is already bounded per
thread). Under valgrind the multi-threaded test is now "All heap blocks were
freed — no leaks are possible."

## Notes

x86-64 SysV only, same as #984. No API or ABI change. There is a residual
~2⁻⁶⁴ fingerprint-collision probability for two genuinely different signatures
that also share `abi`/`nargs`/`rtype`; if exact comparison is preferred I'm
happy to store the element pointers instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
