### PR TITLE
dlmalloc: cast Win32 spin-lock word to LONG volatile* in CAS_LOCK/CLEAR_LOCK

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -1916,8 +1916,8 @@ static FORCEINLINE void x86_clear_lock(int* sl) {
 #define CLEAR_LOCK(sl)   x86_clear_lock(sl)
 
 #else /* Win32 MSC */
-#define CAS_LOCK(sl)     interlockedexchange(sl, (LONG)1)
-#define CLEAR_LOCK(sl)   interlockedexchange (sl, (LONG)0)
+#define CAS_LOCK(sl)     interlockedexchange((LONG volatile *)(sl), (LONG)1)
+#define CLEAR_LOCK(sl)   interlockedexchange ((LONG volatile *)(sl), (LONG)0)
 
 #endif /* ... gcc spins locks ... */
 


### PR DESCRIPTION
`MLOCK_T` is `int`, but on the Win32 MSC path `CAS_LOCK`/`CLEAR_LOCK` map to `_InterlockedExchange(LONG volatile *, LONG)`, so the `int*` lock word is passed to a `LONG volatile *` parameter. clang 22 promotes `-Wincompatible-pointer-types` to an error by default, which breaks the clang-cl build (32- and 64-bit) with:

```
error: incompatible pointer types passing 'int *' to parameter of type 'volatile long *' [-Wincompatible-pointer-types]
```

Cast to `(LONG volatile *)`, matching what the `ffi_spin_peek` macro just below already does in its `_MSC_VER` branch. `LONG` and `int` are both 32-bit on Windows, so this is a type-correctness fix with no behavioral change.