### PR TITLE
Include .note.GNU-stack on FreeBSD/x86

### DIFF
--- a/src/x86/sysv.S
+++ b/src/x86/sysv.S
@@ -1269,6 +1269,6 @@ L(EFDE9):
 
 #endif /* ifdef __i386__ */
 
-#if defined __ELF__ && defined __linux__
+#if defined __ELF__ && (defined __linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif

--- a/src/x86/sysv_intel.S
+++ b/src/x86/sysv_intel.S
@@ -992,7 +992,7 @@ L(EFDE9):
 #endif /* ifndef _MSC_VER */
 #endif /* ifndef __x86_64__ */
 
-#if defined __ELF__ && defined __linux__
+#if defined __ELF__ && (defined __linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif
 #endif

--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -872,6 +872,6 @@ L(EFDE5):
 #endif
 
 #endif /* __x86_64__ */
-#if defined __ELF__ && defined __linux__
+#if defined __ELF__ && (defined __linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -255,6 +255,6 @@ C(ffi_closure_win64_alt):
 #endif
 #endif /* __x86_64__ */
 
-#if defined __ELF__ && defined __linux__
+#if defined __ELF__ && (defined __linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif

--- a/src/x86/win64_intel.S
+++ b/src/x86/win64_intel.S
@@ -237,7 +237,7 @@ ffi_closure_win64_2 LABEL near
 	cfi_endproc
 	C(ffi_closure_win64) endp
 
-#if defined __ELF__ && defined (__linux__ || defined __FreeBSD__)
+#if defined __ELF__ && (defined __linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif
 _text ends

--- a/src/x86/win64_intel.S
+++ b/src/x86/win64_intel.S
@@ -237,7 +237,7 @@ ffi_closure_win64_2 LABEL near
 	cfi_endproc
 	C(ffi_closure_win64) endp
 
-#if defined __ELF__ && defined __linux__
+#if defined __ELF__ && defined (__linux__ || defined __FreeBSD__)
 	.section	.note.GNU-stack,"",@progbits
 #endif
 _text ends


### PR DESCRIPTION
When building libffi on FreeBSD/x86 with --disable-shared as is done inside the GCC tree, all tests FAIL when using GNU ld:

gld-2.46: warning: win64.o: missing .note.GNU-stack section implies executable stack
gld-2.46: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

The emission of .note.GNU-stack in src/x86/*.S is currently guarded by __ELF__ && __linux__, but FreeBSD/x86 uses that NOTE section, too.  This doesn't happen with libffi.so which lacks that NOTE.

Therefore this patch extends the emission accordingly.

Tested on amd64-pc-freebsd15.1 with and without --disable-shared.