### PR TITLE
aarch64: Don't split an int128 between x7 and the stack on Darwin

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -550,7 +550,9 @@ allocate_int128_to_reg_or_stack (struct call_context *context,
   ngrn += ngrn & 1;
 #endif
 
-  if (ngrn < N_X_ARG_REG)
+  /* The value must fit entirely in registers, i.e. the low half may
+     not be allocated to x7 with the high half spilled to the stack.  */
+  if (ngrn + 2 <= N_X_ARG_REG)
     {
       ret = &context->x[ngrn];
       ngrn += 2;


### PR DESCRIPTION
Fixes #993.

The Apple arm64 ABI does not round NGRN up to an even number for 128-bit integer arguments, but like AAPCS64 it still requires the value to fit entirely in registers: if only x7 remains, the whole value goes on the stack. (LLVM's `CC_AArch64_DarwinPCS` assigns the split i64 halves to X0–X6 only — *"i128 is split to two i64s, we can't fit half to register X7"* — otherwise both halves go to the 16-byte-aligned stack, shadowing x7.)

`allocate_int128_to_reg_or_stack` only checked `ngrn < 8` on Darwin, so with `ngrn == 7` it wrote the low half to x7 and the high half past the end of the register array, while the callee reads the argument from the stack. This is why `libffi.call/i128-1.c` (added in #951, first shipped in 3.7.0) fails on aarch64-darwin at iteration 7 — seven `int` args followed by an `__int128`. Iterations 0–6 and 8 were already correct, and Linux is unaffected since AAPCS64 rounds `ngrn` to even first, making `ngrn + 2 <= 8` equivalent to the old check there.

The same helper serves the closure path, so closures receiving an int128 after seven integer args are fixed as well.

Verification: the macOS CI jobs run `make check` on Apple Silicon (macos-14/15), which exercises exactly the failing configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)