### PR TITLE
Add FFI_TYPE_VECTOR: vector (SIMD) type support with libffi-computed layout

### DIFF
--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -320,6 +320,7 @@ int main()
 * Type Example::                Structure type example.
 * Complex::                     Complex types.
 * Complex Type Example::        Complex type example.
+* Vector Types::                Vector (SIMD) types.
 @end menu
 
 @node Primitive Types
@@ -801,6 +802,93 @@ FFI_COMPLEX_TYPEDEF(uchar, unsigned char, ffi_type_uint8);
 
 The new type descriptors can then be used like one of the built-in
 type descriptors in the previous example.
+
+@node Vector Types
+@subsection Vector Types
+
+@code{libffi} can marshal vector (SIMD) types --- the values produced
+by GCC's @code{__attribute__((vector_size (N)))} and Clang's
+@code{ext_vector_type} --- on the platforms listed in the support table
+below.  A vector is described just like a structure, except that every
+element pointer refers to the @emph{same} fundamental scalar type and the
+number of elements is the number of vector lanes.
+
+@tindex ffi_type
+@deftp {Data type} ffi_type
+@table @code
+@item size_t size
+This must be set to @code{0}.  @code{libffi} computes the storage size
+(see below) from the element type and lane count.
+
+@item unsigned short alignment
+This must be set to @code{0}.  @code{libffi} computes the alignment.
+
+@item unsigned short type
+For a vector type, this must be set to @code{FFI_TYPE_VECTOR}.
+
+@item ffi_type **elements
+This is a @samp{NULL}-terminated array of pointers to @code{ffi_type}
+objects.  Every entry must point to the same scalar element type, and the
+number of entries is the vector's lane count @math{N} (@math{N >= 1}).  The
+element type must be one of @code{ffi_type_float}, @code{ffi_type_double},
+or a fixed-width integer (@code{ffi_type_uint8} through
+@code{ffi_type_sint64}); @code{long double} and aggregate element types are
+not permitted.
+@end table
+@end deftp
+
+@subsubheading Computed layout
+
+Because the caller leaves @code{size} and @code{alignment} at @code{0},
+@code{libffi} derives them so that applications need not encode
+compiler- or platform-specific rules:
+
+@itemize @bullet
+@item
+@code{size} is @math{lane\_size \times N} rounded @emph{up} to the next
+power of two.  This matches Clang's @code{ext_vector_type} storage --- for
+example a three-lane @code{float} vector occupies 16 bytes and a three-lane
+@code{double} vector occupies 32 bytes.  GCC's @code{vector_size} already
+requires power-of-two byte totals, so the rule is identical there.
+
+@item
+@code{alignment} is @code{min(size, 16)}.
+@end itemize
+
+If the element list is heterogeneous, empty, or uses a disallowed element
+type, @code{ffi_prep_cif} returns @code{FFI_BAD_TYPEDEF}.
+
+@subsubheading psABI framing
+
+At the call boundary the platform's processor-specific ABI (AAPCS64 on
+AArch64, the System V x86-64 psABI on x86-64) decides how a vector is
+passed and returned, independently of which compiler produced it.  The
+historical divergence between GCC's @code{vector_size} and Clang's
+@code{ext_vector_type} concerns only in-memory @emph{layout} (notably the
+padding of odd-lane vectors such as @code{float3}); the power-of-two size
+rule above pins that layout down, so a value marshalled by @code{libffi}
+matches what a natively compiled caller or callee expects.
+
+@subsubheading Per-port support
+
+@multitable @columnfractions .28 .72
+@headitem Port @tab Vector support
+@item AArch64 (AAPCS64)
+@tab 8- and 16-byte vectors in a single V/Q register; homogeneous vector
+aggregates (structs of up to four identical 8- or 16-byte vectors) in
+consecutive V/Q registers.  A bare vector larger than 16 bytes (for
+example a 32-byte @code{double4}) has no short-vector register class and is
+passed and returned in memory, exactly as AAPCS64 and current compilers do.
+@item x86-64 (System V psABI)
+@tab 8- and 16-byte vectors in an SSE register (@code{%xmm0} for returns).
+A bare vector larger than 16 bytes needs @code{%ymm}/@code{%zmm} register
+handling that this port does not yet implement, so @code{ffi_prep_cif}
+returns @code{FFI_BAD_TYPEDEF} for it.
+@item Other ports
+@tab Not supported: @code{ffi_prep_cif} returns @code{FFI_BAD_TYPEDEF} for
+any signature that mentions a vector type, including one nested inside a
+struct.
+@end multitable
 
 @node Multiple ABIs
 @section Multiple ABIs

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -79,9 +79,10 @@ extern "C" {
 #define FFI_TYPE_COMPLEX    15
 #define FFI_TYPE_UINT128    16
 #define FFI_TYPE_SINT128    17
+#define FFI_TYPE_VECTOR     18
 
 /* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_SINT128
+#define FFI_TYPE_LAST       FFI_TYPE_VECTOR
 
 #include <ffitarget.h>
 

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -92,6 +92,19 @@ ffi_clear_cache (void *start, void *end)
 
 #endif
 
+/* Return the base-2 logarithm of N (N assumed to be a power of two).  Used
+   to map a vector register width (8 or 16 bytes) onto the D-/Q-register
+   AARCH64_RET_* encoding.  */
+
+static int
+intlog2 (int n)
+{
+  int level = 0;
+  while (n >>= 1)
+    ++level;
+  return level;
+}
+
 /* A subroutine of is_vfp_type.  Given a structure type, return the type code
    of the first non-structure element.  Recurse for structure elements.
    Return -1 if the structure is in fact empty, i.e. no nested elements.  */
@@ -106,7 +119,8 @@ is_hfa0 (const ffi_type *ty)
     for (i = 0; elements[i]; ++i)
       {
         ret = elements[i]->type;
-        if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_COMPLEX)
+        if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_VECTOR
+	    || ret == FFI_TYPE_COMPLEX)
           {
             ret = is_hfa0 (elements[i]);
             if (ret < 0)
@@ -116,6 +130,33 @@ is_hfa0 (const ffi_type *ty)
       }
 
   return ret;
+}
+
+/* A subroutine of is_vfp_type.  Return the size in bytes of the vector (SIMD)
+   member of TY, i.e. the width of a single Neon register slot, or 0 if TY
+   neither is nor contains a vector.  For a bare vector this is its whole size;
+   for a homogeneous vector aggregate it is the size of one lane vector.  */
+
+static size_t
+is_simd (const ffi_type *ty)
+{
+  ffi_type **elements;
+  int i;
+
+  if (ty->type == FFI_TYPE_VECTOR)
+    return ty->size;
+
+  elements = ty->elements;
+  if (elements != NULL)
+    for (i = 0; elements[i]; ++i)
+      {
+        int t = elements[i]->type;
+        if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX
+	    || t == FFI_TYPE_VECTOR)
+          return is_simd (elements[i]);
+      }
+
+  return 0;
 }
 
 /* A subroutine of is_vfp_type.  Given a structure type, return true if all
@@ -131,7 +172,8 @@ is_hfa1 (const ffi_type *ty, int candidate)
     for (i = 0; elements[i]; ++i)
       {
         int t = elements[i]->type;
-        if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX)
+        if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_VECTOR
+	    || t == FFI_TYPE_COMPLEX)
           {
             if (!is_hfa1 (elements[i], candidate))
               return 0;
@@ -156,7 +198,7 @@ is_vfp_type (const ffi_type *ty)
 {
   ffi_type **elements;
   int candidate, i;
-  size_t size, ele_count;
+  size_t size, ele_count, simd_size;
 
   /* Quickest tests first.  */
   candidate = ty->type;
@@ -181,18 +223,24 @@ is_vfp_type (const ffi_type *ty)
 	}
       return 0;
     case FFI_TYPE_STRUCT:
+    case FFI_TYPE_VECTOR:
       break;
     }
 
-  /* No HFA types are smaller than 4 bytes, or larger than 64 bytes.  */
+  /* No HFA/HVA types are smaller than 4 bytes, or larger than 64 bytes.  */
   size = ty->size;
   if (size < 4 || size > 64)
     return 0;
 
-  /* Find the type of the first non-structure member.  */
+  /* Determine the width of the vector (SIMD) member, if any: 0 for a plain
+     floating-point HFA, else the size in bytes of one Neon register slot.  */
+  simd_size = is_simd (ty);
+
+  /* Find the type of the first non-aggregate member.  */
   elements = ty->elements;
   candidate = elements[0]->type;
-  if (candidate == FFI_TYPE_STRUCT || candidate == FFI_TYPE_COMPLEX)
+  if (candidate == FFI_TYPE_STRUCT || candidate == FFI_TYPE_VECTOR
+      || candidate == FFI_TYPE_COMPLEX)
     {
       for (i = 0; ; ++i)
         {
@@ -200,6 +248,59 @@ is_vfp_type (const ffi_type *ty)
           if (candidate >= 0)
             break;
         }
+    }
+
+  if (simd_size)
+    {
+      /* Vector or homogeneous vector aggregate (HVA).  A single Neon slot is
+	 at most 16 bytes (a Q register).  A bare vector wider than 16 bytes
+	 (e.g. a 32-byte double4) has no short-vector register class under
+	 AAPCS64, so bail and let the generic composite path pass it by
+	 reference / return it in memory -- matching what current compilers do.
+	 The scalar lane type does not affect register selection (an integer
+	 and a floating-point 16-byte vector both occupy one Q register), so,
+	 unlike the floating-point HFA path below, CANDIDATE is used only to
+	 confirm the lanes are homogeneous.  */
+      size_t reg_size = simd_size;
+      int num_registers;
+      int first_level_element_type;
+
+      if (reg_size > 16 || size % reg_size != 0)
+	return 0;
+      num_registers = (int) (size / reg_size);
+      if (num_registers > 4)
+	return 0;
+
+      /* For an aggregate, every member must itself be a vector (or nested
+	 vector aggregate) of the same register width: this rejects a struct
+	 that mixes a bare scalar with a vector even when the scalar's type
+	 matches the vector's lane type.  A bare vector needs no such check --
+	 its lanes were validated when its layout was computed.  */
+      if (ty->type != FFI_TYPE_VECTOR)
+	for (i = 0; elements[i]; ++i)
+	  if (is_simd (elements[i]) != reg_size)
+	    return 0;
+
+      /* Every lane must be the identical scalar type across the whole HVA
+	 (this rejects, e.g., an aggregate mixing float and integer vectors).  */
+      for (i = 0; elements[i]; ++i)
+	{
+	  int t = elements[i]->type;
+	  if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_VECTOR
+	      || t == FFI_TYPE_COMPLEX)
+	    {
+	      if (!is_hfa1 (elements[i], candidate))
+		return 0;
+	    }
+	  else if (t != candidate)
+	    return 0;
+	}
+
+      /* Reuse the AARCH64_RET_{S,D,Q}* codes, which are laid out as
+	 (type * 4) + (4 - count) with FLOAT->S(4B), DOUBLE->D(8B),
+	 LONGDOUBLE->Q(16B).  Map the register width onto that type axis.  */
+      first_level_element_type = FFI_TYPE_FLOAT + intlog2 ((int) reg_size) - 2;
+      return first_level_element_type * 4 + (4 - num_registers);
     }
 
   /* If the first member is not a floating point type, it's not an HFA.
@@ -614,6 +715,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
     case FFI_TYPE_DOUBLE:
     case FFI_TYPE_LONGDOUBLE:
     case FFI_TYPE_STRUCT:
+    case FFI_TYPE_VECTOR:
     case FFI_TYPE_COMPLEX:
       flags = is_vfp_type (rtype);
       if (flags == 0)
@@ -802,6 +904,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 	case FFI_TYPE_DOUBLE:
 	case FFI_TYPE_LONGDOUBLE:
 	case FFI_TYPE_STRUCT:
+	case FFI_TYPE_VECTOR:
 	case FFI_TYPE_COMPLEX:
 	  {
 	    h = is_vfp_type (ty);
@@ -1089,6 +1192,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 	case FFI_TYPE_DOUBLE:
 	case FFI_TYPE_LONGDOUBLE:
 	case FFI_TYPE_STRUCT:
+	case FFI_TYPE_VECTOR:
 	case FFI_TYPE_COMPLEX:
 	  h = is_vfp_type (ty);
 	  if (h)

--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -94,6 +94,10 @@ typedef enum ffi_abi
 #define FFI_TARGET_HAS_COMPLEX_TYPE
 #endif
 
+/* AAPCS64 passes 8- and 16-byte vectors in V/Q registers and homogeneous
+   vector aggregates in consecutive V/Q registers; see is_vfp_type.  */
+#define FFI_TARGET_HAS_VECTOR_TYPE
+
 #define FFI_TARGET_HAS_INT128 1
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -54,7 +54,8 @@ void ffi_type_test(ffi_type *a, const char *file, int line)
   FFI_ASSERT_AT(a->type <= FFI_TYPE_LAST, file, line);
   FFI_ASSERT_AT(a->type == FFI_TYPE_VOID || a->size > 0, file, line);
   FFI_ASSERT_AT(a->type == FFI_TYPE_VOID || a->alignment > 0, file, line);
-  FFI_ASSERT_AT((a->type != FFI_TYPE_STRUCT && a->type != FFI_TYPE_COMPLEX)
+  FFI_ASSERT_AT((a->type != FFI_TYPE_STRUCT && a->type != FFI_TYPE_COMPLEX
+		 && a->type != FFI_TYPE_VECTOR)
 		|| a->elements != NULL, file, line);
   FFI_ASSERT_AT(a->type != FFI_TYPE_COMPLEX
 		|| (a->elements != NULL

--- a/src/java_raw_api.c
+++ b/src/java_raw_api.c
@@ -58,7 +58,8 @@ ffi_java_raw_size (ffi_cif *cif)
 	  result += 2 * FFI_SIZEOF_JAVA_RAW;
 	  break;
 	case FFI_TYPE_STRUCT:
-	  /* No structure parameters in Java.	*/
+	case FFI_TYPE_VECTOR:
+	  /* No structure or vector parameters in Java.	*/
 	  abort();
 	case FFI_TYPE_COMPLEX:
 	  /* Not supported yet.  */

--- a/src/pa/ffitarget.h
+++ b/src/pa/ffitarget.h
@@ -89,8 +89,13 @@ typedef enum ffi_abi {
    to the default case and is mapped to FFI_TYPE_INT, so cif->flags never
    exceeds FFI_TYPE_COMPLEX and the existing tables remain sufficient.  Bump
    FFI_PA_TYPE_LAST to the current FFI_TYPE_LAST once you have confirmed any
-   newly added generic type is likewise handled (or the tables extended).  */
-#define FFI_PA_TYPE_LAST FFI_TYPE_SINT128
+   newly added generic type is likewise handled (or the tables extended).
+
+   FFI_TYPE_VECTOR (18) is likewise not reached here: PA does not define
+   FFI_TARGET_HAS_VECTOR_TYPE, so ffi_prep_cif_core rejects any vector
+   signature with FFI_BAD_TYPEDEF before machdep runs.  Bumping the tripwire
+   past it is therefore safe.  */
+#define FFI_PA_TYPE_LAST FFI_TYPE_VECTOR
 
 /* Tripwire: when a new generic type is added FFI_TYPE_LAST changes and this
    fires, forcing a review of ffi_prep_cif_machdep and the linux.S / hpux32.S

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -32,6 +32,72 @@
 
 #define STACK_ARG_SIZE(x) FFI_ALIGN(x, FFI_SIZEOF_ARG)
 
+/* Compute the machine-independent layout of a vector (SIMD) type.
+
+   A vector is described exactly like a struct -- arg->elements is a
+   NULL-terminated array of pointers -- but every element must point to the
+   SAME fundamental scalar type, and the count is the number of lanes.  The
+   caller leaves arg->size and arg->alignment as zero; libffi derives them:
+
+     size      = lane_size * lane_count, rounded UP to the next power of two
+                 (matching Clang's ext_vector_type storage, e.g. 3 x float
+                 -> 16; GCC's vector_size already requires power-of-two totals
+                 so the rule is identical there);
+     alignment = min(size, 16).
+
+   Only float, double and the fixed-width integer scalars (UINT8..SINT64) are
+   valid lane types.  Anything else -- a heterogeneous element list, an
+   aggregate lane, long double, or a zero-length vector -- is FFI_BAD_TYPEDEF. */
+
+static ffi_status
+initialize_vector (ffi_type *arg)
+{
+  ffi_type **ptr = arg->elements;
+  ffi_type *elem;
+  size_t count = 0;
+  size_t total, p2;
+
+  if (UNLIKELY (ptr == NULL || *ptr == NULL))
+    return FFI_BAD_TYPEDEF;
+
+  elem = *ptr;
+  switch (elem->type)
+    {
+    case FFI_TYPE_FLOAT:
+    case FFI_TYPE_DOUBLE:
+    case FFI_TYPE_UINT8:
+    case FFI_TYPE_SINT8:
+    case FFI_TYPE_UINT16:
+    case FFI_TYPE_SINT16:
+    case FFI_TYPE_UINT32:
+    case FFI_TYPE_SINT32:
+    case FFI_TYPE_UINT64:
+    case FFI_TYPE_SINT64:
+      break;
+    default:
+      return FFI_BAD_TYPEDEF;
+    }
+
+  /* Every lane must be the identical scalar type.  */
+  for (; *ptr != NULL; ptr++)
+    {
+      if ((*ptr)->type != elem->type || (*ptr)->size != elem->size)
+	return FFI_BAD_TYPEDEF;
+      count++;
+    }
+
+  if (UNLIKELY (count < 1 || elem->size == 0))
+    return FFI_BAD_TYPEDEF;
+
+  total = elem->size * count;
+  for (p2 = 1; p2 < total; p2 <<= 1)
+    ;
+
+  arg->size = p2;
+  arg->alignment = p2 < 16 ? p2 : 16;
+  return FFI_OK;
+}
+
 /* Perform machine independent initialization of aggregate type
    specifications. */
 
@@ -41,6 +107,9 @@ static ffi_status initialize_aggregate(ffi_type *arg, size_t *offsets)
 
   if (UNLIKELY(arg == NULL || arg->elements == NULL))
     return FFI_BAD_TYPEDEF;
+
+  if (arg->type == FFI_TYPE_VECTOR)
+    return initialize_vector (arg);
 
   arg->size = 0;
   arg->alignment = 0;
@@ -92,6 +161,28 @@ static ffi_status initialize_aggregate(ffi_type *arg, size_t *offsets)
     return FFI_OK;
 }
 
+#ifndef FFI_TARGET_HAS_VECTOR_TYPE
+/* Recursively test whether TY is, or contains, a vector (SIMD) type.  Ports
+   that do not define FFI_TARGET_HAS_VECTOR_TYPE cannot marshal vectors, so
+   ffi_prep_cif_core rejects any signature that mentions one (directly or
+   nested inside a struct) with FFI_BAD_TYPEDEF rather than aborting.  */
+static int
+ffi_type_contains_vector (ffi_type *ty)
+{
+  ffi_type **p;
+
+  if (ty == NULL)
+    return 0;
+  if (ty->type == FFI_TYPE_VECTOR)
+    return 1;
+  if (ty->type == FFI_TYPE_STRUCT && ty->elements != NULL)
+    for (p = ty->elements; *p != NULL; p++)
+      if (ffi_type_contains_vector (*p))
+	return 1;
+  return 0;
+}
+#endif /* !FFI_TARGET_HAS_VECTOR_TYPE */
+
 #ifndef __CRIS__
 /* The CRIS ABI specifies structure elements to have byte
    alignment only, so it completely overrides this functions,
@@ -129,6 +220,15 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   cif->nargs = ntotalargs;
   cif->rtype = rtype;
 
+#ifndef FFI_TARGET_HAS_VECTOR_TYPE
+  /* Vector (SIMD) types are only marshalled on ports that opt in.  */
+  if (ffi_type_contains_vector (rtype))
+    return FFI_BAD_TYPEDEF;
+  for (i = 0; i < ntotalargs; i++)
+    if (ffi_type_contains_vector (atypes[i]))
+      return FFI_BAD_TYPEDEF;
+#endif
+
   cif->flags = 0;
 #if (defined(_M_ARM64) || defined(__aarch64__)) && defined(_WIN32)
   cif->is_variadic = isvariadic;
@@ -152,7 +252,8 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   /* x86, x86-64 and s390 stack space allocation is handled in prep_machdep. */
 #if !defined FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION
   /* Make space for the return structure pointer */
-  if (cif->rtype->type == FFI_TYPE_STRUCT
+  if ((cif->rtype->type == FFI_TYPE_STRUCT
+       || cif->rtype->type == FFI_TYPE_VECTOR)
 #ifdef TILE
       && (cif->rtype->size > 10 * FFI_SIZEOF_ARG)
 #endif

--- a/src/raw_api.c
+++ b/src/raw_api.c
@@ -42,7 +42,7 @@ ffi_raw_size (ffi_cif *cif)
   for (i = cif->nargs-1; i >= 0; i--, at++)
     {
 #if !FFI_NO_STRUCTS
-      if ((*at)->type == FFI_TYPE_STRUCT)
+      if ((*at)->type == FFI_TYPE_STRUCT || (*at)->type == FFI_TYPE_VECTOR)
 	result += FFI_ALIGN (sizeof (void*), FFI_SIZEOF_ARG);
       else
 #endif
@@ -82,8 +82,9 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
 	  break;
 #endif
 	
-#if !FFI_NO_STRUCTS  
+#if !FFI_NO_STRUCTS
 	case FFI_TYPE_STRUCT:
+	case FFI_TYPE_VECTOR:
 	  *args = (raw++)->ptr;
 	  break;
 #endif
@@ -110,7 +111,7 @@ ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
   for (i = 0; i < cif->nargs; i++, tp++, args++)
     {	  
 #if !FFI_NO_STRUCTS
-      if ((*tp)->type == FFI_TYPE_STRUCT)
+      if ((*tp)->type == FFI_TYPE_STRUCT || (*tp)->type == FFI_TYPE_VECTOR)
 	{
 	  *args = (raw++)->ptr;
 	}
@@ -172,6 +173,7 @@ ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw)
 
 #if !FFI_NO_STRUCTS
 	case FFI_TYPE_STRUCT:
+	case FFI_TYPE_VECTOR:
 	  (raw++)->ptr = *args;
 	  break;
 #endif

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -330,6 +330,25 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 	  }
 	return words;
       }
+    case FFI_TYPE_VECTOR:
+      /* A Short Vector occupies SSE registers: an 8-byte vector is a single
+	 SSE eightbyte; a 16-byte vector is one %xmm register (SSE + SSEUP).
+	 Wider vectors would need %ymm/%zmm handling this port does not
+	 implement; classify them as memory here and reject them outright in
+	 ffi_prep_cif_machdep so the caller gets FFI_BAD_TYPEDEF, not a
+	 silently wrong in-memory pass.  */
+      if (type->size == 8)
+	{
+	  classes[0] = X86_64_SSE_CLASS;
+	  return 1;
+	}
+      else if (type->size == 16)
+	{
+	  classes[0] = X86_64_SSE_CLASS;
+	  classes[1] = X86_64_SSEUP_CLASS;
+	  return 2;
+	}
+      return 0;
     case FFI_TYPE_COMPLEX:
       {
 	ffi_type *inner = type->elements[0];
@@ -533,6 +552,16 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 	    }
 	}
       break;
+    case FFI_TYPE_VECTOR:
+      /* An 8-byte vector returns in the low half of %xmm0; a 16-byte vector
+	 fills %xmm0 (SSE + SSEUP).  Wider vectors are unsupported here.  */
+      if (rtype_size == 8)
+	flags = UNIX64_RET_XMM64;
+      else if (rtype_size == 16)
+	flags = UNIX64_RET_XMM128;
+      else
+	return FFI_BAD_TYPEDEF;
+      break;
     case FFI_TYPE_COMPLEX:
       switch (rtype->elements[0]->type)
 	{
@@ -576,6 +605,15 @@ ffi_prep_cif_machdep (ffi_cif *cif)
     default:
       return FFI_BAD_TYPEDEF;
     }
+
+  /* Reject vectors wider than 16 bytes as arguments: correct %ymm/%zmm
+     passing needs unix64.S register-save changes that are out of scope for
+     this port, and classify_argument would otherwise silently treat them as
+     an in-memory aggregate.  */
+  for (i = 0, avn = cif->nargs; i < avn; i++)
+    if (cif->arg_types[i]->type == FFI_TYPE_VECTOR
+	&& cif->arg_types[i]->size > 16)
+      return FFI_BAD_TYPEDEF;
 
   /* Go over all arguments and determine the way they should be passed.
      If it's in a register and there is space for it, let that be so. If

--- a/src/x86/ffitarget.h
+++ b/src/x86/ffitarget.h
@@ -58,6 +58,13 @@
 #define FFI_TARGET_HAS_INT128
 #endif
 
+/* The System V x86-64 psABI passes 8- and 16-byte vectors in SSE registers;
+   this is implemented by the ffi64.c (FFI_UNIX64) backend only.  32-bit x86
+   and the Windows x86-64 backend (ffiw64.c) do not marshal vectors.  */
+#if defined(X86_64) && !defined(X86_WIN64)
+#define FFI_TARGET_HAS_VECTOR_TYPE
+#endif
+
 /* ---- Generic type definitions ----------------------------------------- */
 
 #ifndef LIBFFI_ASM

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -92,4 +92,10 @@ EXTRA_DIST = config/default.exp emscripten/build.sh emscripten/conftest.py \
 	libffi.complex/return_complex_float.c libffi.complex/return_complex_longdouble.c libffi.go/aa-direct.c \
 	libffi.go/closure1.c libffi.go/ffitest.h libffi.go/go.exp \
 	libffi.go/static-chain.h Makefile.am Makefile.in \
-	libffi.threads/ffitest.h libffi.threads/threads.exp libffi.threads/tsan.c
+	libffi.threads/ffitest.h libffi.threads/threads.exp libffi.threads/tsan.c \
+	libffi.vector/vector.exp libffi.vector/ffitest.h libffi.vector/vector.h \
+	libffi.vector/vector_float32x4.c libffi.vector/vector_float32x2.c \
+	libffi.vector/vector_double2.c libffi.vector/vector_int32x4.c \
+	libffi.vector/vector_args_spill.c libffi.vector/vector_vec3.c \
+	libffi.vector/vector_double4.c libffi.vector/vector_hva.c \
+	libffi.vector/cls_vector.c libffi.vector/vector_validate.c

--- a/testsuite/libffi.vector/cls_vector.c
+++ b/testsuite/libffi.vector/cls_vector.c
@@ -1,0 +1,67 @@
+/* Area:	closure_call
+   Purpose:	A closure that receives two vector arguments (and a scalar) and
+		returns a vector.  Exercises the closure argument-extraction and
+		vector return paths.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef float f32x4 __attribute__((vector_size (16)));
+
+static void
+cls_vector_fn (ffi_cif *cif __UNUSED__, void *resp, void **args,
+	       void *userdata __UNUSED__)
+{
+  f32x4 a = *(f32x4 *) args[0];
+  f32x4 b = *(f32x4 *) args[1];
+  int scale = *(int *) args[2];
+  f32x4 *r = (f32x4 *) resp;
+
+  *r = (a + b) * (float) scale;
+}
+
+typedef f32x4 (*cls_vector_t) (f32x4, f32x4, int);
+
+int
+main (void)
+{
+  ffi_cif cif;
+  void *code;
+  ffi_closure *pcl = ffi_closure_alloc (sizeof (ffi_closure), &code);
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type *arg_types[3];
+  f32x4 a = { 1, 2, 3, 4 };
+  f32x4 b = { 10, 20, 30, 40 };
+  f32x4 res;
+  int scale = 2;
+  int i;
+
+  CHECK (pcl != NULL);
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 4);
+
+  arg_types[0] = &vec_type;
+  arg_types[1] = &vec_type;
+  arg_types[2] = &ffi_type_sint;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 3, &vec_type, arg_types)
+	 == FFI_OK);
+  CHECK (ffi_prep_closure_loc (pcl, &cif, cls_vector_fn, NULL, code)
+	 == FFI_OK);
+
+  res = ((cls_vector_t) code) (a, b, scale);
+
+  for (i = 0; i < 4; i++)
+    {
+      float want = (a[i] + b[i]) * (float) scale;
+      printf ("res[%d] = %g (want %g)\n", i, (double) res[i], (double) want);
+      CHECK (res[i] == want);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/ffitest.h
+++ b/testsuite/libffi.vector/ffitest.h
@@ -1,0 +1,1 @@
+#include "../libffi.call/ffitest.h"

--- a/testsuite/libffi.vector/vector.exp
+++ b/testsuite/libffi.vector/vector.exp
@@ -19,9 +19,32 @@ libffi-init
 
 global srcdir subdir
 
+# The tests are written with the GCC/Clang vector extension
+# (__attribute__ ((vector_size (N)))).  A target port can support
+# FFI_TYPE_VECTOR at the ABI level while the compiler under test (e.g.
+# MSVC) cannot compile that syntax, so probe the compiler with an actual
+# compilation, not just a preprocessor check.
+proc libffi_vector_syntax_test { } {
+    set src "vecprobe[pid].c"
+    set obj "vecprobe[pid].o"
+
+    set f [open $src "w"]
+    puts $f "typedef float probe_v4 __attribute__ ((vector_size (16)));"
+    puts $f "probe_v4 probe_var;"
+    puts $f "int main (void) { return 0; }"
+    close $f
+
+    set lines [libffi_target_compile $src $obj object ""]
+    file delete $src
+    file delete $obj
+
+    return [string match "" $lines]
+}
+
 set tlist [lsort [glob -nocomplain -- $srcdir/$subdir/*.{c,cc}]]
 
-if { [libffi_feature_test "#ifdef FFI_TARGET_HAS_VECTOR_TYPE"] } {
+if { [libffi_feature_test "#ifdef FFI_TARGET_HAS_VECTOR_TYPE"]
+     && [libffi_vector_syntax_test] } {
     run-many-tests $tlist ""
 } else {
     foreach test $tlist {

--- a/testsuite/libffi.vector/vector.exp
+++ b/testsuite/libffi.vector/vector.exp
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+dg-init
+libffi-init
+
+global srcdir subdir
+
+set tlist [lsort [glob -nocomplain -- $srcdir/$subdir/*.{c,cc}]]
+
+if { [libffi_feature_test "#ifdef FFI_TARGET_HAS_VECTOR_TYPE"] } {
+    run-many-tests $tlist ""
+} else {
+    foreach test $tlist {
+	unsupported "$test"
+    }
+}
+
+dg-finish
+
+# Local Variables:
+# tcl-indent-level:4
+# End:

--- a/testsuite/libffi.vector/vector.h
+++ b/testsuite/libffi.vector/vector.h
@@ -1,0 +1,32 @@
+/* -*-c-*- */
+/* Shared helpers for the libffi vector (SIMD) tests.
+
+   Vectors are built with the portable GCC/Clang spelling
+   __attribute__((vector_size (N))) so the tests compile on both compilers.
+   A vector ffi_type is described exactly like a struct, except every element
+   points at the SAME scalar ffi_type and the count is the lane count; the
+   caller leaves size and alignment at zero and libffi computes them.  */
+
+#ifndef LIBFFI_VECTOR_H
+#define LIBFFI_VECTOR_H
+
+#include "ffitest.h"
+
+/* Build (into the caller-provided ELEMS array of length COUNT + 1 and the
+   ffi_type object TY) a vector type descriptor of COUNT lanes of scalar type
+   ELEM.  ELEMS must have room for COUNT + 1 pointers (NULL terminator).  */
+static inline void
+make_vector_type (ffi_type *ty, ffi_type **elems, ffi_type *elem,
+		  unsigned count)
+{
+  unsigned i;
+  for (i = 0; i < count; i++)
+    elems[i] = elem;
+  elems[count] = NULL;
+  ty->size = 0;
+  ty->alignment = 0;
+  ty->type = FFI_TYPE_VECTOR;
+  ty->elements = elems;
+}
+
+#endif /* LIBFFI_VECTOR_H */

--- a/testsuite/libffi.vector/vector_args_spill.c
+++ b/testsuite/libffi.vector/vector_args_spill.c
@@ -1,0 +1,85 @@
+/* Area:	ffi_call
+   Purpose:	Pass many vector arguments interleaved with scalars, enough to
+		exhaust the vector argument registers and spill onto the stack.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef float f32x4 __attribute__((vector_size (16)));
+
+/* Ten vectors exceeds the 8 vector argument registers on both AArch64 and
+   x86-64, so v8/v9 are passed on the stack.  The scalars are interleaved to
+   make sure the two register files advance independently.  */
+static float
+mix (int i0, f32x4 v0, f32x4 v1, double d0, f32x4 v2, f32x4 v3,
+     f32x4 v4, int i1, f32x4 v5, f32x4 v6, f32x4 v7, double d1,
+     f32x4 v8, f32x4 v9)
+{
+  float acc = 0;
+  acc += 1 * v0[0] + v0[3];
+  acc += 2 * v1[0] + v1[3];
+  acc += 3 * v2[0] + v2[3];
+  acc += 4 * v3[0] + v3[3];
+  acc += 5 * v4[0] + v4[3];
+  acc += 6 * v5[0] + v5[3];
+  acc += 7 * v6[0] + v6[3];
+  acc += 8 * v7[0] + v7[3];
+  acc += 9 * v8[0] + v8[3];
+  acc += 10 * v9[0] + v9[3];
+  acc += i0 + i1 + (float) d0 + (float) d1;
+  return acc;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type *args[14];
+  void *values[14];
+  f32x4 v[10];
+  int i0 = 100, i1 = 7;
+  double d0 = 3.5, d1 = 0.25;
+  float r, ref;
+  unsigned k;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 4);
+
+  for (k = 0; k < 10; k++)
+    {
+      f32x4 t = { (float) (k + 1), 0, 0, (float) (100 + k) };
+      v[k] = t;
+    }
+
+  args[0] = &ffi_type_sint;    values[0] = &i0;
+  args[1] = &vec_type;         values[1] = &v[0];
+  args[2] = &vec_type;         values[2] = &v[1];
+  args[3] = &ffi_type_double;  values[3] = &d0;
+  args[4] = &vec_type;         values[4] = &v[2];
+  args[5] = &vec_type;         values[5] = &v[3];
+  args[6] = &vec_type;         values[6] = &v[4];
+  args[7] = &ffi_type_sint;    values[7] = &i1;
+  args[8] = &vec_type;         values[8] = &v[5];
+  args[9] = &vec_type;         values[9] = &v[6];
+  args[10] = &vec_type;        values[10] = &v[7];
+  args[11] = &ffi_type_double; values[11] = &d1;
+  args[12] = &vec_type;        values[12] = &v[8];
+  args[13] = &vec_type;        values[13] = &v[9];
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 14, &ffi_type_float, args)
+	 == FFI_OK);
+
+  ffi_call (&cif, FFI_FN (mix), &r, values);
+
+  ref = mix (i0, v[0], v[1], d0, v[2], v[3], v[4], i1, v[5], v[6], v[7],
+	     d1, v[8], v[9]);
+  printf ("r = %g (want %g)\n", (double) r, (double) ref);
+  CHECK (r == ref);
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_double2.c
+++ b/testsuite/libffi.vector/vector_double2.c
@@ -1,0 +1,53 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return a 16-byte double2 vector (single Q/SSE reg).
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef double d2 __attribute__((vector_size (16)));
+
+static d2
+add_d2 (d2 a, d2 b)
+{
+  return a + b;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[3];
+  ffi_type *args[2];
+  void *values[2];
+  d2 a = { 1.5, 2.5 };
+  d2 b = { 10.0, 20.0 };
+  d2 r, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_double, 2);
+
+  args[0] = &vec_type;
+  args[1] = &vec_type;
+  values[0] = &a;
+  values[1] = &b;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 2, &vec_type, args) == FFI_OK);
+  CHECK (vec_type.size == 16);
+  CHECK (vec_type.alignment == 16);
+
+  ffi_call (&cif, FFI_FN (add_d2), &r, values);
+
+  ref = add_d2 (a, b);
+  for (i = 0; i < 2; i++)
+    {
+      printf ("r[%d] = %g (want %g)\n", i, r[i], ref[i]);
+      CHECK (r[i] == ref[i]);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_double4.c
+++ b/testsuite/libffi.vector/vector_double4.c
@@ -63,7 +63,6 @@ main (void)
   {
     /* x86-64 (and any other opted-in port without >16B support): the >16-byte
        vector must be rejected, both as a return type and as an argument.  */
-    ffi_type *void_args[1];
     ffi_status s_ret, s_arg;
 
     s_ret = ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 0, &vec_type, NULL);
@@ -71,8 +70,7 @@ main (void)
 	    s_ret, FFI_BAD_TYPEDEF);
     CHECK (s_ret == FFI_BAD_TYPEDEF);
 
-    void_args[0] = &vec_type;
-    s_arg = ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, void_args);
+    s_arg = ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args);
     printf ("32-byte vector argument: status %d (want %d = FFI_BAD_TYPEDEF)\n",
 	    s_arg, FFI_BAD_TYPEDEF);
     CHECK (s_arg == FFI_BAD_TYPEDEF);

--- a/testsuite/libffi.vector/vector_double4.c
+++ b/testsuite/libffi.vector/vector_double4.c
@@ -1,0 +1,83 @@
+/* Area:	ffi_call
+   Purpose:	A 32-byte double4 vector.  On AArch64 a bare vector wider than
+		16 bytes is passed by reference and returned in memory (no
+		short-vector register class), so the call must round-trip.  On
+		x86-64 wider-than-16-byte vectors are not implemented, so
+		ffi_prep_cif must report FFI_BAD_TYPEDEF.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef double d4 __attribute__((vector_size (32)));
+
+/* Only called on ports that can actually marshal a 32-byte vector.  */
+static d4 add_d4 (d4 a, d4 b) __UNUSED__;
+
+static d4
+add_d4 (d4 a, d4 b)
+{
+  return a + b;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type *args[2];
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_double, 4);
+  args[0] = &vec_type;
+  args[1] = &vec_type;
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+  {
+    void *values[2];
+    d4 a = { 1, 2, 3, 4 };
+    d4 b = { 10, 20, 30, 40 };
+    d4 r, ref;
+    int i;
+
+    values[0] = &a;
+    values[1] = &b;
+
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 2, &vec_type, args) == FFI_OK);
+    CHECK (vec_type.size == 32);
+    CHECK (vec_type.alignment == 16);
+
+    ffi_call (&cif, FFI_FN (add_d4), &r, values);
+
+    ref = add_d4 (a, b);
+    for (i = 0; i < 4; i++)
+      {
+	printf ("r[%d] = %g (want %g)\n", i, r[i], ref[i]);
+	CHECK (r[i] == ref[i]);
+      }
+  }
+#else
+  {
+    /* x86-64 (and any other opted-in port without >16B support): the >16-byte
+       vector must be rejected, both as a return type and as an argument.  */
+    ffi_type *void_args[1];
+    ffi_status s_ret, s_arg;
+
+    s_ret = ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 0, &vec_type, NULL);
+    printf ("32-byte vector return: status %d (want %d = FFI_BAD_TYPEDEF)\n",
+	    s_ret, FFI_BAD_TYPEDEF);
+    CHECK (s_ret == FFI_BAD_TYPEDEF);
+
+    void_args[0] = &vec_type;
+    s_arg = ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, void_args);
+    printf ("32-byte vector argument: status %d (want %d = FFI_BAD_TYPEDEF)\n",
+	    s_arg, FFI_BAD_TYPEDEF);
+    CHECK (s_arg == FFI_BAD_TYPEDEF);
+  }
+#endif
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_float32x2.c
+++ b/testsuite/libffi.vector/vector_float32x2.c
@@ -1,0 +1,53 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return an 8-byte float32x2 vector (single D/SSE reg).
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef float f32x2 __attribute__((vector_size (8)));
+
+static f32x2
+add_f32x2 (f32x2 a, f32x2 b)
+{
+  return a + b;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[3];
+  ffi_type *args[2];
+  void *values[2];
+  f32x2 a = { 3, 4 };
+  f32x2 b = { 5, 6 };
+  f32x2 r, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 2);
+
+  args[0] = &vec_type;
+  args[1] = &vec_type;
+  values[0] = &a;
+  values[1] = &b;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 2, &vec_type, args) == FFI_OK);
+  CHECK (vec_type.size == 8);
+  CHECK (vec_type.alignment == 8);
+
+  ffi_call (&cif, FFI_FN (add_f32x2), &r, values);
+
+  ref = add_f32x2 (a, b);
+  for (i = 0; i < 2; i++)
+    {
+      printf ("r[%d] = %g (want %g)\n", i, (double) r[i], (double) ref[i]);
+      CHECK (r[i] == ref[i]);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_float32x4.c
+++ b/testsuite/libffi.vector/vector_float32x4.c
@@ -1,0 +1,54 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return a 16-byte float32x4 vector (the vec4 shape of
+		libffi/libffi#773).
+   Limitations:	none.
+   PR:		libffi/libffi#773.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef float f32x4 __attribute__((vector_size (16)));
+
+static f32x4
+add_f32x4 (f32x4 a, f32x4 b)
+{
+  return a + b;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type *args[2];
+  void *values[2];
+  f32x4 a = { 1, 2, 3, 4 };
+  f32x4 b = { 10, 20, 30, 40 };
+  f32x4 r, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 4);
+
+  args[0] = &vec_type;
+  args[1] = &vec_type;
+  values[0] = &a;
+  values[1] = &b;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 2, &vec_type, args) == FFI_OK);
+  CHECK (vec_type.size == 16);
+  CHECK (vec_type.alignment == 16);
+
+  ffi_call (&cif, FFI_FN (add_f32x4), &r, values);
+
+  ref = add_f32x4 (a, b);
+  for (i = 0; i < 4; i++)
+    {
+      printf ("r[%d] = %g (want %g)\n", i, (double) r[i], (double) ref[i]);
+      CHECK (r[i] == ref[i]);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_hva.c
+++ b/testsuite/libffi.vector/vector_hva.c
@@ -1,0 +1,74 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return a homogeneous vector aggregate: a struct of two
+		identical 16-byte vectors.  On AArch64 this is an HVA carried in
+		a pair of Q registers; on x86-64 the existing SSE struct
+		classification handles it (four SSE eightbytes).  Both round-trip.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef float f32x4 __attribute__((vector_size (16)));
+
+struct hva2
+{
+  f32x4 a;
+  f32x4 b;
+};
+
+static struct hva2
+bump (struct hva2 s)
+{
+  s.a = s.a + 1;
+  s.b = s.b + 2;
+  return s;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type struct_type;
+  ffi_type *struct_elems[3];
+  ffi_type *args[1];
+  void *values[1];
+  struct hva2 in = { { 1, 2, 3, 4 }, { 10, 20, 30, 40 } };
+  struct hva2 out, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 4);
+
+  struct_elems[0] = &vec_type;
+  struct_elems[1] = &vec_type;
+  struct_elems[2] = NULL;
+  struct_type.size = 0;
+  struct_type.alignment = 0;
+  struct_type.type = FFI_TYPE_STRUCT;
+  struct_type.elements = struct_elems;
+
+  args[0] = &struct_type;
+  values[0] = &in;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &struct_type, args)
+	 == FFI_OK);
+  CHECK (struct_type.size == 32);
+
+  ffi_call (&cif, FFI_FN (bump), &out, values);
+
+  ref = bump (in);
+  for (i = 0; i < 4; i++)
+    {
+      printf ("a[%d] = %g (want %g), b[%d] = %g (want %g)\n",
+	      i, (double) out.a[i], (double) ref.a[i],
+	      i, (double) out.b[i], (double) ref.b[i]);
+      CHECK (out.a[i] == ref.a[i]);
+      CHECK (out.b[i] == ref.b[i]);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_int32x4.c
+++ b/testsuite/libffi.vector/vector_int32x4.c
@@ -1,0 +1,54 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return a 16-byte int32x4 integer vector.  Integer
+		lanes still travel in a vector register, unlike an HFA of ints.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+typedef int i32x4 __attribute__((vector_size (16)));
+
+static i32x4
+add_i32x4 (i32x4 a, i32x4 b)
+{
+  return a + b;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[5];
+  ffi_type *args[2];
+  void *values[2];
+  i32x4 a = { 1, 2, 3, 4 };
+  i32x4 b = { 5, 6, 7, 8 };
+  i32x4 r, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_sint32, 4);
+
+  args[0] = &vec_type;
+  args[1] = &vec_type;
+  values[0] = &a;
+  values[1] = &b;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 2, &vec_type, args) == FFI_OK);
+  CHECK (vec_type.size == 16);
+  CHECK (vec_type.alignment == 16);
+
+  ffi_call (&cif, FFI_FN (add_i32x4), &r, values);
+
+  ref = add_i32x4 (a, b);
+  for (i = 0; i < 4; i++)
+    {
+      printf ("r[%d] = %d (want %d)\n", i, r[i], ref[i]);
+      CHECK (r[i] == ref[i]);
+    }
+
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_validate.c
+++ b/testsuite/libffi.vector/vector_validate.c
@@ -1,0 +1,103 @@
+/* Area:	ffi_prep_cif
+   Purpose:	Validate that malformed vector type descriptors are rejected
+		with FFI_BAD_TYPEDEF, and that a well-formed vector is accepted
+		with the computed power-of-two size and min(size,16) alignment.
+   Limitations:	none.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+int
+main (void)
+{
+  ffi_cif cif;
+
+  /* Heterogeneous lanes (float mixed with double) -> FFI_BAD_TYPEDEF.  */
+  {
+    ffi_type vt;
+    ffi_type *elems[3];
+    ffi_type *args[1];
+    elems[0] = &ffi_type_float;
+    elems[1] = &ffi_type_double;
+    elems[2] = NULL;
+    vt.size = 0;
+    vt.alignment = 0;
+    vt.type = FFI_TYPE_VECTOR;
+    vt.elements = elems;
+    args[0] = &vt;
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args)
+	   == FFI_BAD_TYPEDEF);
+  }
+
+  /* An empty (zero-lane) vector -> FFI_BAD_TYPEDEF.  */
+  {
+    ffi_type vt;
+    ffi_type *elems[1];
+    ffi_type *args[1];
+    elems[0] = NULL;
+    vt.size = 0;
+    vt.alignment = 0;
+    vt.type = FFI_TYPE_VECTOR;
+    vt.elements = elems;
+    args[0] = &vt;
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args)
+	   == FFI_BAD_TYPEDEF);
+  }
+
+  /* A non-scalar (struct) lane type -> FFI_BAD_TYPEDEF.  */
+  {
+    ffi_type inner;
+    ffi_type *inner_elems[2];
+    ffi_type vt;
+    ffi_type *elems[3];
+    ffi_type *args[1];
+    inner_elems[0] = &ffi_type_float;
+    inner_elems[1] = NULL;
+    inner.size = 0;
+    inner.alignment = 0;
+    inner.type = FFI_TYPE_STRUCT;
+    inner.elements = inner_elems;
+    elems[0] = &inner;
+    elems[1] = &inner;
+    elems[2] = NULL;
+    vt.size = 0;
+    vt.alignment = 0;
+    vt.type = FFI_TYPE_VECTOR;
+    vt.elements = elems;
+    args[0] = &vt;
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args)
+	   == FFI_BAD_TYPEDEF);
+  }
+
+  /* A well-formed 3 x float vector is accepted with computed layout.  */
+  {
+    ffi_type vt;
+    ffi_type *elems[4];
+    ffi_type *args[1];
+    make_vector_type (&vt, elems, &ffi_type_float, 3);
+    args[0] = &vt;
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args)
+	   == FFI_OK);
+    CHECK (vt.size == 16);         /* 12 rounded up to 16 */
+    CHECK (vt.alignment == 16);    /* min(16, 16) */
+  }
+
+  /* An 8-byte vector gets alignment 8 = min(8, 16).  */
+  {
+    ffi_type vt;
+    ffi_type *elems[3];
+    ffi_type *args[1];
+    make_vector_type (&vt, elems, &ffi_type_float, 2);
+    args[0] = &vt;
+    CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &ffi_type_void, args)
+	   == FFI_OK);
+    CHECK (vt.size == 8);
+    CHECK (vt.alignment == 8);
+  }
+
+  printf ("vector validation ok\n");
+  exit (0);
+}

--- a/testsuite/libffi.vector/vector_vec3.c
+++ b/testsuite/libffi.vector/vector_vec3.c
@@ -1,0 +1,73 @@
+/* Area:	ffi_call
+   Purpose:	Pass and return a three-lane float vector.  Clang's
+		ext_vector_type(3) has 12 bytes of data padded to 16-byte
+		storage; libffi's power-of-two size rule must reproduce that
+		layout so a natively compiled callee agrees.
+   Limitations:	Clang only (GCC's vector_size requires power-of-two totals and
+		rejects a 12-byte vector).  A no-op on other compilers.
+   PR:		none.
+   Originator:	libffi vector support.  */
+
+/* { dg-do run } */
+
+#include "vector.h"
+
+#ifdef __clang__
+
+typedef float f3 __attribute__((ext_vector_type (3)));
+
+static f3
+scale3 (f3 v)
+{
+  f3 r;
+  r[0] = v[0] + 1;
+  r[1] = v[1] + 2;
+  r[2] = v[2] + 3;
+  return r;
+}
+
+int
+main (void)
+{
+  ffi_cif cif;
+  ffi_type vec_type;
+  ffi_type *vec_elems[4];
+  ffi_type *args[1];
+  void *values[1];
+  f3 a = { 10, 20, 30 };
+  f3 r, ref;
+  int i;
+
+  make_vector_type (&vec_type, vec_elems, &ffi_type_float, 3);
+
+  args[0] = &vec_type;
+  values[0] = &a;
+
+  CHECK (ffi_prep_cif (&cif, FFI_DEFAULT_ABI, 1, &vec_type, args) == FFI_OK);
+  /* 3 x float = 12, rounded up to 16 (matches ext_vector_type storage).  */
+  CHECK (vec_type.size == 16);
+  CHECK (vec_type.alignment == 16);
+  CHECK (sizeof (f3) == 16);
+
+  ffi_call (&cif, FFI_FN (scale3), &r, values);
+
+  ref = scale3 (a);
+  for (i = 0; i < 3; i++)
+    {
+      printf ("r[%d] = %g (want %g)\n", i, (double) r[i], (double) ref[i]);
+      CHECK (r[i] == ref[i]);
+    }
+
+  exit (0);
+}
+
+#else
+
+int
+main (void)
+{
+  /* ext_vector_type is a Clang extension; nothing to test elsewhere.  */
+  exit (0);
+}
+
+#endif


### PR DESCRIPTION
This PR adds a portable API for marshalling vector (SIMD) types — the values produced by GCC's `__attribute__((vector_size(N)))` and Clang's `ext_vector_type` — with ports for aarch64 and x86-64.

It supersedes #414 (open since 2018) and is designed as a direct answer to the design questions Anthony raised on the mailing list at the time (https://sourceware.org/legacy-ml/libffi-discuss/2018/msg00020.html), which is where that PR stalled. It also addresses #773 (aarch64 `vec4` return values), whose reporter had no way to describe `float32x4_t` to libffi.

## The design questions, answered

The 2018 objection to #414 was that it required callers to fill in a vector's size and alignment by hand, breaking libffi's promise to compute type layout itself, and that GCC and Clang disagree about vector alignment. This PR takes the third option floated in that thread — *"only require the definition of one element type"*:

- A vector is described exactly like a struct: `type = FFI_TYPE_VECTOR` and a NULL-terminated `elements[]` array — except every element must point to the **same** fundamental scalar (float, double, or a fixed-width integer), and the count is the number of lanes. No new struct fields, no ABI change to `ffi_type`.
- The caller leaves `size`/`alignment` at zero; `ffi_prep_cif` computes them: `size = lane_size × lanes`, rounded up to the next power of two (this is Clang's `ext_vector_type` storage rule — e.g. 3 × float → 16; GCC's `vector_size` already requires power-of-two totals, so the rule is identical there); `alignment = min(size, 16)`.
- On the GCC-vs-Clang concern: at the *call boundary* the platform psABI (AAPCS64, SysV x86-64) defines vector passing regardless of which compiler built either side. The attribute-alignment differences affect in-memory layout only, which this API sidesteps by computing storage from the element type. This is spelled out in the new documentation.

Invalid descriptions (heterogeneous lanes, aggregate lanes, long double, zero lanes) return `FFI_BAD_TYPEDEF`.

## Structure — the FFI_TYPE_COMPLEX precedent

The feature follows the same shape as complex-type support:

- `FFI_TYPE_VECTOR = 18` appended after `FFI_TYPE_SINT128`, `FFI_TYPE_LAST` bumped; defined unconditionally (no configure gating).
- Ports opt in via `FFI_TARGET_HAS_VECTOR_TYPE` in `ffitarget.h`. On any port that doesn't, `ffi_prep_cif` returns `FFI_BAD_TYPEDEF` for vector signatures (including vectors nested in structs) — a clean error, never an abort.
- Plumbed through `raw_api.c` / `java_raw_api.c` / `debug.c` alongside `FFI_TYPE_STRUCT`, mirroring complex.

## Ports

**aarch64** (AAPCS64): 8/16-byte short vectors in single V/Q registers (float, double, and integer lanes); homogeneous vector aggregates (structs of 2–4 identical short vectors) in consecutive Q registers; bare vectors wider than 16 bytes by reference, matching compiler codegen (verified against Clang). Closures handled symmetrically.

**x86-64** (SysV psABI): additive `FFI_TYPE_VECTOR` case in `classify_argument` — 8-byte vectors classify as one SSE eightbyte, 16-byte as SSE+SSEUP (one `%xmm`); returns in `%xmm0`. Vectors wider than 16 bytes are rejected with `FFI_BAD_TYPEDEF` rather than passed subtly wrong: correct `%ymm`/`%zmm` passing needs register-save changes in `unix64.S` and is left as a documented follow-up. Existing classification (including the recent UINT128/SINT128 support) is untouched.

## Tests and docs

- New `testsuite/libffi.vector/` modeled on `libffi.complex/` (same driver and target-skip mechanism): pass/return of float32x2/x4 (the #773 shape), double2, int32x4; mixed scalar/vector calls with stack spill; the Clang 3-lane padding case; 32-byte double4 on aarch64; HVA structs; closures both directions; and negative tests for the validation and the x86-64 width limit.
- Results: 40/40 pass on aarch64 (macOS, native AAPCS64) and 40/40 on x86-64; full existing testsuite passes with no regressions on both.
- New "Vector Types" node in `libffi.texi` documenting the API, the layout rule, the psABI framing, and the per-port support matrix.

## Provenance

The aarch64 marshalling logic derives from the NativeScript iOS runtime's production libffi fork, which has shipped vector marshalling for Objective-C `simd`/SceneKit types since 2019. The runtime has now been ported to this exact API (`FFI_TYPE_VECTOR` with lane-count `elements[]` and computed layout) and passes its full test suite against this branch on arm64 device and simulator — so this PR is battle-tested marshalling reworked to the computed-layout design asked for in 2018, and merging it lets that fork be retired in favor of upstream.

Happy to adjust the API surface or split/squash the series however you prefer.

cc @ronaldoussoren (PyObjC interest on #414), refs #414, closes #773