### PR TITLE
tramp: cache the static trampoline "unsupported" verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ History
 
 See the git log for details at http://github.com/libffi/libffi.
 
+    3.7.2 (in development)
+        Cache the static trampoline "unsupported" result on hosts whose
+          page size exceeds the trampoline table mapping, avoiding
+          redundant re-initialization on every closure allocation
+          (e.g. 64K-page aarch64).
+
     3.7.1 July-10-2026
         Fix aarch64 ffi_call memory corruption when passing many large
           structs by value.

--- a/src/tramp.c
+++ b/src/tramp.c
@@ -417,9 +417,19 @@ ffi_tramp_init (void)
     &tramp_globals.map_size);
   tramp_globals.ntramp = tramp_globals.map_size / tramp_globals.size;
 
+  /*
+   * The trampoline code table is a single, fixed-size mapping.  If the
+   * system page size is larger than that mapping, the static trampoline
+   * mechanism cannot be used.  Both values are invariant for the life of
+   * the process, so cache the FAILED verdict rather than re-running the
+   * whole initialization on every allocation.
+   */
   page_size = sysconf (_SC_PAGESIZE);
   if (page_size >= 0 && (size_t)page_size > tramp_globals.map_size)
-    return 0;
+    {
+      tramp_globals.status = TRAMP_GLOBALS_FAILED;
+      return 0;
+    }
 
   if (ffi_tramp_init_os ())
     {


### PR DESCRIPTION
## Summary

`ffi_tramp_init()` returned `0` with a bare `return 0` when the system page
size exceeds the trampoline code table mapping, **without** setting
`tramp_globals.status = TRAMP_GLOBALS_FAILED`. That early return was the only
failure exit leaving `status` as `UNINITIALIZED`, so every later
`ffi_tramp_alloc()` / `ffi_tramp_is_supported()` call re-ran the whole
initialization (`ffi_tramp_arch()`, `sysconf()`, …) instead of short-circuiting
on the cached verdict the way the other two failure paths already do.

## Why caching is safe

The branch compares two process-lifetime invariants:

- **`map_size`** — a compile-time constant returned by `ffi_tramp_arch()` (e.g. `AARCH64_TRAMP_MAP_SIZE` = 16384).
- **`page_size`** — `sysconf(_SC_PAGESIZE)`, fixed for the life of the process, and only consulted here when it returned a valid (`>= 0`) value.

Neither can change, so `page_size > map_size` cannot flip from true to false. The
verdict is permanent, which is exactly the precondition for caching it. The two
neighboring failure exits (`ffi_tramp_arch == NULL` and `ffi_tramp_init_os()`
failure) already cache `FAILED`; this aligns the page-size exit with them.

## Impact

Hosts with pages larger than the 16K table — in practice **64K-page aarch64**
kernels — where static trampolines are correctly declined but the decline was
recomputed on every closure allocation. **No functional change** on 4K/16K-page
hosts (the branch is never taken there).

## Testing

- `src/tramp.c` compiles clean (no warnings); full `libffi.a` links.
- Closure smoke test (`ffi_closure_alloc` → `ffi_prep_closure_loc` → invoke) returns the expected value on the normal (4K-page) static-trampoline path — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)