### PR TITLE
call_plan: add ffi_call_plan_size to report a plan's allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ History
 See the git log for details at http://github.com/libffi/libffi.
 
     Development source only -- no release yet
+        Add ffi_call_plan_size to report the total memory a reusable call
+          plan owns, for embedders that account for the memory held by
+          long-lived plans.
         Cache the static trampoline "unsupported" result on hosts whose
           page size exceeds the trampoline table mapping, avoiding
           redundant re-initialization on every closure allocation

--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -941,6 +941,16 @@ Releases a plan returned by @code{ffi_call_plan_alloc}.  Passing
 not affected.
 @end defun
 
+@findex ffi_call_plan_size
+@defun size_t ffi_call_plan_size (ffi_call_plan *@var{plan})
+Returns the total number of bytes @code{libffi} allocated for @var{plan},
+including any internal argument-placement data it owns.  Returns zero when
+@var{plan} is @code{NULL}.  The result does not include the
+@code{ffi_cif}, which the caller owns.  This is intended for embedders that
+account for the memory held by long-lived plans and would otherwise have to
+guess at the size of an opaque type.
+@end defun
+
 @node The Closure API
 @section The Closure API
 

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -536,7 +536,11 @@ void ffi_call(ffi_cif *cif,
    ffi_call_plan_alloc returns NULL only on allocation failure; a signature
    with no fast path is still valid and ffi_call_plan_invoke falls back to
    ffi_call for it.  A plan is immutable once built, so it may be shared and
-   invoked concurrently from multiple threads.  */
+   invoked concurrently from multiple threads.
+
+   ffi_call_plan_size reports the total number of bytes libffi allocated for a
+   plan, so that callers tracking the footprint of long-lived plans do not have
+   to guess at the size of an opaque type.  */
 typedef struct ffi_call_plan ffi_call_plan;
 
 FFI_API
@@ -550,6 +554,9 @@ void ffi_call_plan_invoke (ffi_call_plan *plan,
 
 FFI_API
 void ffi_call_plan_free (ffi_call_plan *plan);
+
+FFI_API
+size_t ffi_call_plan_size (ffi_call_plan *plan);
 
 FFI_API
 ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,

--- a/libffi.map.in
+++ b/libffi.map.in
@@ -69,6 +69,15 @@ LIBFFI_CALL_PLAN_8.4 {
     ffi_call_plan_free;
 } LIBFFI_BASE_8.1;
 
+/* ----------------------------------------------------------------------
+   Call plan footprint query (ffi_call_plan_size).  A fresh node because
+   LIBFFI_CALL_PLAN_8.4 has already shipped.
+   -------------------------------------------------------------------- */
+LIBFFI_CALL_PLAN_8.5 {
+  global:
+    ffi_call_plan_size;
+} LIBFFI_CALL_PLAN_8.4;
+
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 LIBFFI_COMPLEX_8.0 {
   global:

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -417,4 +417,11 @@ ffi_call_plan_free (ffi_call_plan *plan)
   free (plan);
 }
 
+size_t
+ffi_call_plan_size (ffi_call_plan *plan)
+{
+  /* The generic plan is a bare handle; there is no separate move-list.  */
+  return plan != NULL ? sizeof (struct ffi_call_plan) : 0;
+}
+
 #endif /* generic ffi_call_plan fallback */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -820,6 +820,7 @@ typedef struct
   unsigned fast;        /* nonzero -> lean trampoline eligible             */
   unsigned retcode;     /* UNIX64_RET_* (low byte of flags) for the store  */
   int      thunk_n;     /* >=0 -> ffi_gp_thunks[thunk_n], else -1          */
+  unsigned alloc_bytes; /* malloc'd size, reported by ffi_call_plan_size   */
   ffi_move moves[];
 } ffi_plan;
 
@@ -866,7 +867,7 @@ build_plan (ffi_cif *cif)
   unsigned i, avn = cif->nargs;
   enum x86_64_reg_class classes[MAX_CLASSES];
   unsigned nm, gprcount, ssecount;
-  size_t argp_off;
+  size_t argp_off, nbytes;
   ffi_plan *plan;
   int all_gp64 = 1;	/* every arg is exactly one 64-bit GP move? */
 
@@ -886,9 +887,11 @@ build_plan (ffi_cif *cif)
     }
 
   /* One self-contained allocation: header + moves, released with plain free(). */
-  plan = malloc (sizeof (ffi_plan) + sizeof (ffi_move) * (2 * avn + 1));
+  nbytes = sizeof (ffi_plan) + sizeof (ffi_move) * (2 * avn + 1);
+  plan = malloc (nbytes);
   if (plan == NULL)
     return NULL;
+  plan->alloc_bytes = (unsigned) nbytes;
 
   nm = gprcount = ssecount = 0;
   argp_off = 0;
@@ -1106,6 +1109,17 @@ ffi_call_plan_free (ffi_call_plan *plan)
       free (plan->fast);
       free (plan);
     }
+}
+
+size_t
+ffi_call_plan_size (ffi_call_plan *plan)
+{
+  if (plan == NULL)
+    return 0;
+  /* The move-list carries its own size; a signature with no fast path owns
+     nothing beyond the handle.  */
+  return sizeof (struct ffi_call_plan)
+	 + (plan->fast != NULL ? plan->fast->alloc_bytes : 0);
 }
 
 extern void

--- a/testsuite/libffi.call/plan_size.c
+++ b/testsuite/libffi.call/plan_size.c
@@ -1,0 +1,77 @@
+/* Area:	ffi_call_plan_size
+   Purpose:	Check that a plan reports its own allocation size, that the
+		size is stable across invocations, and that a NULL plan has
+		no footprint.
+   Limitations:	The exact byte count is implementation defined, so this only
+		checks the invariants callers may rely on.
+   PR:		none.
+   Originator:	ffi_call_plan tests  */
+
+/* { dg-do run } */
+#include "ffitest.h"
+
+static uint64_t gp2(uint64_t a, uint64_t b)
+{
+  return a + b * 2;
+}
+
+static uint64_t gp6(uint64_t a, uint64_t b, uint64_t c,
+		    uint64_t d, uint64_t e, uint64_t f)
+{
+  return a + b * 2 + c * 3 + d * 4 + e * 5 + f * 6;
+}
+
+int main (void)
+{
+  ffi_cif cif2, cif6;
+  ffi_type *args[6];
+  void *values[6];
+  ffi_call_plan *plan2, *plan6;
+  size_t size2, size6;
+  uint64_t a[6], r;
+  int i;
+
+  for (i = 0; i < 6; i++)
+    {
+      args[i] = &ffi_type_uint64;
+      a[i] = (uint64_t) (i + 1);
+      values[i] = &a[i];
+    }
+
+  CHECK(ffi_prep_cif(&cif2, FFI_DEFAULT_ABI, 2, &ffi_type_uint64, args)
+	== FFI_OK);
+  CHECK(ffi_prep_cif(&cif6, FFI_DEFAULT_ABI, 6, &ffi_type_uint64, args)
+	== FFI_OK);
+
+  /* A NULL plan has no footprint, mirroring ffi_call_plan_free(NULL).  */
+  CHECK(ffi_call_plan_size(NULL) == 0);
+
+  plan2 = ffi_call_plan_alloc(&cif2);
+  CHECK(plan2 != NULL);
+  plan6 = ffi_call_plan_alloc(&cif6);
+  CHECK(plan6 != NULL);
+
+  size2 = ffi_call_plan_size(plan2);
+  size6 = ffi_call_plan_size(plan6);
+
+  /* Every plan owns at least its handle, and a wider signature never needs
+     less memory than a narrower one of the same shape.  Targets without a
+     fast path report the same constant for both.  */
+  CHECK(size2 > 0);
+  CHECK(size6 >= size2);
+
+  /* The plan is immutable, so querying it must not disturb invocation and
+     the reported size must not drift across calls.  */
+  ffi_call_plan_invoke(plan6, FFI_FN(gp6), &r, values);
+  CHECK(r == gp6(a[0], a[1], a[2], a[3], a[4], a[5]));
+  CHECK(ffi_call_plan_size(plan6) == size6);
+
+  ffi_call_plan_invoke(plan2, FFI_FN(gp2), &r, values);
+  CHECK(r == gp2(a[0], a[1]));
+  CHECK(ffi_call_plan_size(plan2) == size2);
+
+  ffi_call_plan_free(plan2);
+  ffi_call_plan_free(plan6);
+
+  exit(0);
+}


### PR DESCRIPTION
## Summary

`ffi_call_plan` is opaque, so an embedder that wants to account for the memory a long-lived plan holds has no way to ask how big it is. The only options today are to hardcode a guess or to hardcode knowledge of libffi's private struct layout, and both go stale silently on the next release.

This adds a one-line query:

```c
size_t ffi_call_plan_size (ffi_call_plan *plan);
```

It returns the total bytes libffi allocated for the plan (the handle plus the internal argument-placement data it owns), and 0 for a `NULL` plan, mirroring `ffi_call_plan_free (NULL)` being harmless. The `ffi_cif` is excluded, since the caller owns that.

## Motivation

Firefox's `js-ctypes` builds one plan per non-variadic `FunctionType` and holds it for the lifetime of the type object. SpiderMonkey's GC wants the malloc footprint of objects it owns so it can size collections, so it has to report a number for each plan.

With no size query, we currently hardcode `2 * sizeof(void*)`, which is right for the handle on x86-64 but ignores the move-list behind the second pointer. Counting that too, a plan really costs 68 bytes for a 0-argument signature and 388 for an 8-argument one in 3.7.1, so the 16 we report is 4x to 24x low. There is no way to do better from outside libffi, and no way to notice if the layout changes, because the type is incomplete at our call site, so `sizeof` will not compile.

## Implementation

The size is recorded at allocation time rather than recomputed, so it cannot drift from the allocation it describes:

- **`src/x86/ffi64.c`**: `ffi_plan` gains an `alloc_bytes` field set to the exact value passed to `malloc`. `ffi_call_plan_size` adds that to the handle size, treating a plan with no fast path as owning nothing beyond the handle.
- **`src/prep_cif.c`**: the generic plan is a bare handle with no move-list, so the query returns `sizeof (struct ffi_call_plan)`.

The counter lives in `ffi_plan` rather than in `struct ffi_call_plan` so that the handle does not grow at all: only plans that actually have a move-list pay for it (4 bytes, absorbed into a struct that is already all 4-byte fields), and plans without one pay nothing. Putting a `size_t` in the handle instead would have cost 8 bytes on every plan, including those that own nothing.

Deliberately avoided recomputing the size from `plan->cif->nargs` in the query: that duplicates `build_plan`'s allocation formula in a second place, and would report the wrong number if the cif were re-prepared with a different argument count after the plan was built.

## ABI

`struct ffi_call_plan` is only ever declared incomplete in `ffi.h`, so callers cannot `sizeof` it and adding a field is not an ABI change.

The new symbol goes in a **new** version node rather than into the existing `LIBFFI_CALL_PLAN_8.4`, which already shipped in 3.7.0. Adding to a released node would let a binary that needs `ffi_call_plan_size` look satisfiable against a 3.7.x library that exports the node without the symbol, turning a clean link error into a runtime failure.

The name `LIBFFI_CALL_PLAN_8.5` follows from the existing numbering rather than being picked arbitrarily: `libtool-version` is currently `12:1:4`, which yields `libffi.so.8.4.1` (`current-age` . `age` . `revision`), matching the existing `LIBFFI_CALL_PLAN_8.4`. Adding an interface means `current++`, `revision=0`, `age++` per rules 4 and 5 in `libtool-version`, i.e. `13:0:5` and an ABI version of 8.5.

`libtool-version` is deliberately **not** touched here: rule 2 in that file says to update version info only immediately before a public release, so the bump belongs to the release rather than to this PR. Until then the library still builds as 8.4.1 while exporting a node named for 8.5, which is cosmetic, since version script node names are independent of the soname. Happy to rename the node, or to fold the `libtool-version` bump in here instead, if you would rather it match the tree at all times.

## Testing

New `testsuite/libffi.call/plan_size.c`, following `plan.c`. Because the exact byte count is implementation defined, it asserts only the invariants a caller can rely on:

- `ffi_call_plan_size(NULL) == 0`
- a live plan reports a non-zero size
- a 6-argument signature reports at least as much as a 2-argument one (`>=`, not `>`, so it also holds on targets whose generic plan reports a constant)
- the size is unchanged after invoking, and invoking still returns correct results, i.e. the query does not disturb the plan

Verified locally on `x86_64-pc-linux-gnu`, gcc, against master:

- Static and shared builds both complete with **no new warnings**; the only warnings emitted are pre-existing deprecation notices in `java_raw_api.c`.
- `plan_size` passes, and the five pre-existing plan tests (`plan`, `plan_mixed`, `plan_spill`, `plan_struct`, `plan_var`) all still pass.
- The reported size matches `sizeof(struct ffi_call_plan) + sizeof(ffi_plan) + sizeof(ffi_move) * (2 * nargs + 1)` exactly at 0, 1, 2, 6 and 8 arguments (72/112/152/312/392 bytes), and a struct-argument signature, which has no fast plan, correctly reports just the 16-byte handle.
- Symbol versioning verified on the shared library: `readelf -V` shows `LIBFFI_CALL_PLAN_8.5` with `Parent 1: LIBFFI_CALL_PLAN_8.4`, and `ffi_call_plan_size@@LIBFFI_CALL_PLAN_8.5` while the original three remain at `@@LIBFFI_CALL_PLAN_8.4`. A test binary linked against the shared library records a dependency on `8.5` only for the new call.
- The generic `prep_cif.c` implementation is compiled out on x86-64, so it was syntax-checked separately by forcing its guard open (`-DX86_WIN64`, the only other use of which in that file is the guard itself); it compiles cleanly.

Not verified locally: `makeinfo` is unavailable in my environment, so the `doc/libffi.texi` addition was only checked structurally (`@defun`/`@end defun` balance) rather than rendered.

## Alternatives considered

- **Return only `sizeof (struct ffi_call_plan)`**: knowable but nearly useless, since it omits the bulk of the allocation.
- **A predictive `ffi_call_plan_size (ffi_cif *)` before allocating**: would have to duplicate `build_plan`'s fast-path eligibility rules to know whether a move-list will exist at all.
