### PR TITLE
x86: fix Win64 small-struct returns broken by FFI_TYPE_VECTOR

### DIFF
--- a/src/x86/ffitarget.h
+++ b/src/x86/ffitarget.h
@@ -145,6 +145,18 @@ typedef enum ffi_abi {
 #define FFI_TYPE_SMALL_STRUCT_4B (FFI_TYPE_LAST + 3)
 #define FFI_TYPE_MS_STRUCT       (FFI_TYPE_LAST + 4)
 
+/* Tripwire: the win64.S / win64_intel.S return-value jump tables use one
+   8-byte slot per code value and place the FFI_TYPE_SMALL_STRUCT_* pseudo-types
+   (which are FFI_TYPE_LAST-relative) immediately after the generic FFI_TYPE_*
+   codes.  Adding a new generic type bumps FFI_TYPE_LAST, shifts those codes,
+   and opens a gap in the tables that silently misaligns small-struct returns.
+   When this fires: add a matching E() slot for the new type in both win64.S
+   and win64_intel.S, then bump FFI_X86_TYPE_LAST to match.  */
+#define FFI_X86_TYPE_LAST FFI_TYPE_VECTOR
+#if FFI_TYPE_LAST != FFI_X86_TYPE_LAST
+# error "new FFI_TYPE_* added: sync the win64.S/win64_intel.S jump tables and bump FFI_X86_TYPE_LAST"
+#endif
+
 #if defined (X86_64) || defined(X86_WIN64) \
     || (defined (__x86_64__) && defined (X86_DARWIN))
 /* 4 bytes of ENDBR64 + 7 bytes of LEA + 6 bytes of JMP + 7 bytes of NOP

--- a/src/x86/win64.S
+++ b/src/x86/win64.S
@@ -151,6 +151,11 @@ E(0b, FFI_TYPE_UINT128)
 E(0b, FFI_TYPE_SINT128)
 	movdqu	%xmm0, (%r8)
 	epilogue
+/* Win64 does not marshal vectors (ffi_prep_cif_core rejects them), but the
+   FFI_TYPE_SMALL_STRUCT_* codes are FFI_TYPE_LAST-relative, so this slot must
+   exist to keep the table contiguous and the small-struct entries aligned.  */
+E(0b, FFI_TYPE_VECTOR)
+	call	PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
 	movb	%al, (%r8)
 	epilogue

--- a/src/x86/win64_intel.S
+++ b/src/x86/win64_intel.S
@@ -152,6 +152,11 @@ E(0b, FFI_TYPE_UINT128)
 E(0b, FFI_TYPE_SINT128)
 	movdqu	xmmword ptr [r8], xmm0
 	epilogue
+/* Win64 does not marshal vectors (ffi_prep_cif_core rejects them), but the
+   FFI_TYPE_SMALL_STRUCT_* codes are FFI_TYPE_LAST-relative, so this slot must
+   exist to keep the table contiguous and the small-struct entries aligned.  */
+E(0b, FFI_TYPE_VECTOR)
+	call	PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
 	mov byte ptr [r8], al ; movb	%al, (%r8)
 	epilogue


### PR DESCRIPTION
## Problem

The `Windows 64-bit Visual C++` CI job regressed to **14 unexpected failures** starting with the merge of #1000 (vector types) — deterministic across both re-run attempts, on the identical VS 2026 (v18) preview toolchain. Bisect: last-good `d257b0849` (#1004, 792 pass / 0 fail) → first-bad `ce77ca10` (#1000, 771 pass / 14 fail).

Failing tests are all small-struct-by-value returns / closures: `s55`, `struct3`, `struct_by_value_small`, `struct_return_2H`, `cls_1_1byte`, `cls_3byte1/2`, `cls_4_1byte`, `cls_4byte`, `single_entry_structs1/3`, and `bhaible` DGTEST 47/53/55.

## Root cause

#1000 added `FFI_TYPE_VECTOR 18` and moved `FFI_TYPE_LAST` from `FFI_TYPE_SINT128` (17) to `FFI_TYPE_VECTOR` (18). The Win64 return pseudo-types are `FFI_TYPE_LAST`-relative:

```c
#define FFI_TYPE_SMALL_STRUCT_1B (FFI_TYPE_LAST + 1)   /* 18 -> 19 */
#define FFI_TYPE_SMALL_STRUCT_2B (FFI_TYPE_LAST + 2)   /* 19 -> 20 */
#define FFI_TYPE_SMALL_STRUCT_4B (FFI_TYPE_LAST + 3)   /* 20 -> 21 */
```

The `win64.S` / `win64_intel.S` return dispatch is a computed jump table indexed `base + flags*8`, with handlers emitted contiguously right after `SINT128` and **no slot for value 18**. Under the sequential `E()` variant (`.balign 8` / `ALIGN 8`, no `.org`/`ORG`) the MSVC/`ml64` build uses, `ffiw64.c` now emits `flags` = 19/20/21 for size-1/2/4 struct returns while the handlers still sit at slots 18/19/20 — an off-by-one that writes the wrong width or falls off the table into `abort`.

32-bit x86 is unaffected: `sysv.S` indexes its store table by the independent `X86_RET_*` enum, not `FFI_TYPE_LAST`. (The `ffi64.c` changes in #1000 are dead under MSVC, which defines `_M_AMD64`, not `__x86_64__`.)

## Fix

- Insert an `E(0b, FFI_TYPE_VECTOR)` abort stub between `SINT128` and `SMALL_STRUCT_1B` in **both** `win64.S` and `win64_intel.S`, so the table is gap-free and the small-struct entries realign with their shifted code values (and it no longer depends on assembler `.org`/`ORG` self-healing). Win64 rejects vectors at `ffi_prep_cif_core`, so the slot is never reached at runtime.
- Add a `pa`-style compile-time tripwire to `src/x86/ffitarget.h` so the next generic type added `#error`s until the Win64 tables are updated in step.

## Verification (native x86-64)

- Clean build against current headers; `ffiw64.c` + `win64.S` compile; tripwire does not misfire.
- Tripwire negative test `#error`s on a simulated new type.
- Sequential-variant (clang) disassembly confirms slots 18/19/20/21 = `abort` / `movb` / `movw` / `movl`, now exactly matching the flag values `ffiw64.c` emits.

The actual MSVC/`ml64` assembly of `win64_intel.S` couldn't be run locally (it's a line-for-line mirror of `win64.S`, which was assembled and disassembled) — the Windows CI job here is the final confirmation.

No ABI change: existing `FFI_TYPE_*` codes 0–17 and all struct layouts are unchanged; the `FFI_TYPE_SMALL_STRUCT_*` codes are internal `cif->flags` encodings never exchanged across the library boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)