### PR TITLE
Fix FFI_TYPE_LAST/vector jump-table desyncs on ia64, ppc64 (BE ELFv2), and aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ See the git log for details at http://github.com/libffi/libffi.
           (e.g. 64K-page aarch64).
         Fix ia64 return-value jump-table desync after the FFI_TYPE_LAST
           bump, which corrupted small-struct and HFA returns.
+        Fix powerpc64 big-endian ELFv2 closures returning 5-, 6-, or
+          7-byte structs: missing return jump-table entries produced a
+          wrong result and leaked a libffi code pointer.
         Add FFI_TYPE_VECTOR (SIMD) type support with libffi-computed
           layout, for aarch64 and x86-64 (#1000, closes #773).
         Add powerpc64 ELFv2 _Complex long double support for both

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ See the git log for details at http://github.com/libffi/libffi.
           page size exceeds the trampoline table mapping, avoiding
           redundant re-initialization on every closure allocation
           (e.g. 64K-page aarch64).
+        Fix ia64 return-value jump-table desync after the FFI_TYPE_LAST
+          bump, which corrupted small-struct and HFA returns.
         Add FFI_TYPE_VECTOR (SIMD) type support with libffi-computed
           layout, for aarch64 and x86-64 (#1000, closes #773).
         Add powerpc64 ELFv2 _Complex long double support for both

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -265,7 +265,11 @@ is_vfp_type (const ffi_type *ty)
       int num_registers;
       int first_level_element_type;
 
-      if (reg_size > 16 || size % reg_size != 0)
+      /* A Neon register slot is an S (4B), D (8B) or Q (16B).  A lane narrower
+	 than 4 bytes has no short-vector register class under AAPCS64 and would
+	 map below AARCH64_RET_S4, making extend_hfa_type() branch before its
+	 jump table; reject it and let the generic aggregate path handle it.  */
+      if (reg_size < 4 || reg_size > 16 || size % reg_size != 0)
 	return 0;
       num_registers = (int) (size / reg_size);
       if (num_registers > 4)

--- a/src/ia64/ia64_flags.h
+++ b/src/ia64/ia64_flags.h
@@ -38,3 +38,14 @@
 #define FFI_IA64_TYPE_HFA_FLOAT		(FFI_TYPE_LAST + 2)
 #define FFI_IA64_TYPE_HFA_DOUBLE	(FFI_TYPE_LAST + 3)
 #define FFI_IA64_TYPE_HFA_LDOUBLE	(FFI_TYPE_LAST + 4)
+
+/* Tripwire: the .Lst_table / .Lld_table return-value jump tables in unix.S place
+   the FFI_IA64_TYPE_* pseudo-types (which are FFI_TYPE_LAST-relative) immediately
+   after the generic FFI_TYPE_* codes.  Adding a new generic type bumps
+   FFI_TYPE_LAST, shifts those codes, and desyncs the tables -- silently
+   misdispatching small-struct/HFA returns.  When this fires: add a matching slot
+   for the new type to both tables in unix.S, then bump FFI_IA64_TYPE_LAST.  */
+#define FFI_IA64_TYPE_LAST FFI_TYPE_VECTOR
+#if FFI_TYPE_LAST != FFI_IA64_TYPE_LAST
+# error "new FFI_TYPE_* added: sync the unix.S jump tables and bump FFI_IA64_TYPE_LAST"
+#endif

--- a/src/ia64/unix.S
+++ b/src/ia64/unix.S
@@ -553,6 +553,9 @@ ffi_closure_unix:
 	data8	@pcrel(.Lst_void)		// FFI_TYPE_STRUCT
 	data8	@pcrel(.Lst_int64)		// FFI_TYPE_POINTER
 	data8	@pcrel(.Lst_void)		// FFI_TYPE_COMPLEX (not implemented)
+	data8	@pcrel(.Lst_void)		// FFI_TYPE_UINT128 (not implemented)
+	data8	@pcrel(.Lst_void)		// FFI_TYPE_SINT128 (not implemented)
+	data8	@pcrel(.Lst_void)		// FFI_TYPE_VECTOR  (rejected in ffi_prep_cif_core)
 	data8 	@pcrel(.Lst_small_struct)	// FFI_IA64_TYPE_SMALL_STRUCT
 	data8	@pcrel(.Lst_hfa_float)		// FFI_IA64_TYPE_HFA_FLOAT
 	data8	@pcrel(.Lst_hfa_double)		// FFI_IA64_TYPE_HFA_DOUBLE
@@ -575,6 +578,9 @@ ffi_closure_unix:
 	data8	@pcrel(.Lld_void)		// FFI_TYPE_STRUCT
 	data8	@pcrel(.Lld_int)		// FFI_TYPE_POINTER
 	data8	@pcrel(.Lld_void)		// FFI_TYPE_COMPLEX (not implemented)
+	data8	@pcrel(.Lld_void)		// FFI_TYPE_UINT128 (not implemented)
+	data8	@pcrel(.Lld_void)		// FFI_TYPE_SINT128 (not implemented)
+	data8	@pcrel(.Lld_void)		// FFI_TYPE_VECTOR  (rejected in ffi_prep_cif_core)
 	data8 	@pcrel(.Lld_small_struct)	// FFI_IA64_TYPE_SMALL_STRUCT
 	data8	@pcrel(.Lld_hfa_float)		// FFI_IA64_TYPE_HFA_FLOAT
 	data8	@pcrel(.Lld_hfa_double)		// FFI_IA64_TYPE_HFA_DOUBLE

--- a/src/powerpc/linux64_closure.S
+++ b/src/powerpc/linux64_closure.S
@@ -345,6 +345,21 @@ E PPC64_LD_STRUCT_3
 	lwz %r3, RETVAL+4(%r1)
 	srd %r3, %r3, 8
 	epilogue
+
+E PPC64_LD_STRUCT_5
+	ld %r3, RETVAL+0(%r1)
+	srdi %r3, %r3, 24
+	epilogue
+
+E PPC64_LD_STRUCT_6
+	ld %r3, RETVAL+0(%r1)
+	srdi %r3, %r3, 16
+	epilogue
+
+E PPC64_LD_STRUCT_7
+	ld %r3, RETVAL+0(%r1)
+	srdi %r3, %r3, 8
+	epilogue
 #endif
 
 .Lmoredouble:


### PR DESCRIPTION
Follow-up to #1008, which fixed the Win64 small-struct return regression caused by the `FFI_TYPE_VECTOR` / `FFI_TYPE_LAST` bump (and, earlier, the `__int128` bump in 3.6.0). Sweeping the rest of `src/` for the **same class** of bug — hand-written asm indexing return jump tables / register-class codes by values those additions silently shifted — turned up three more. All are fixed here; two are reproduced end-to-end under emulation.

## Commits

**1. ia64: return jump-table desync after `FFI_TYPE_LAST` bump**
`FFI_IA64_TYPE_SMALL_STRUCT`/`HFA_*` (`ia64_flags.h`) are `FFI_TYPE_LAST`-relative, but `.Lst_table`/`.Lld_table` in `unix.S` hardcode 20 entries assuming `FFI_TYPE_LAST == FFI_TYPE_COMPLEX (15)`. Since 3.6.0 advanced it to 18, an ordinary small-struct return dispatches to the HFA-ldouble handler's 16-byte `stfe` — an out-of-bounds write past `rvalue`. Adds the missing `UINT128/SINT128/VECTOR` slots plus a `FFI_TYPE_LAST` tripwire, mirroring the `pa` and Win64 guards. (Static analysis only — no ia64 emulation available.)

**2. powerpc64: big-endian ELFv2 closures returning 5/6/7-byte structs**
`ffi_closure_helper_LINUX64` emits `PPC64_LD_STRUCT_5/6/7` (17/18/19) on BE ELFv2, but `linux64_closure.S` only defined table entries through `STRUCT_3` (16); the `E()` macro is `.align 4` with no `.org`, so those codes fell through into `.Lmoredouble` and returned a stale value / libffi code pointer in r3. Adds the three handlers. **Verified** on big-endian ppc64 ELFv2 (Adélie Linux under `qemu-ppc64`): `cls_{5,6,7}_1_byte` abort before, pass after.

**3. aarch64: reject sub-4-byte vector lanes in HVA classification**
A homogeneous vector aggregate whose lanes are < 4 bytes (which `initialize_vector` accepts) makes `is_vfp_type` return a code below `AARCH64_RET_S4`, so `extend_hfa_type` branches before its jump table — a wild computed branch during argument marshalling. Rejecting it at the source (`is_vfp_type`) covers both the argument and return paths. **Verified** on aarch64 (Fedora under `qemu-aarch64`): a call passing such an HVA segfaults before, returns correctly after.

## Note on CI coverage
The BE-ppc64-ELFv2 path (commit #2) has no CI job here. I prototyped one (Adélie container under `qemu-ppc64`), but GitHub-hosted runners cannot reach Adélie's package mirror (its single server firewalls datacenter IPs, and it has no CDN mirror), and no other distro offers BE-ppc64-ELFv2 as a ready OCI image. A durable job wants a **prebuilt image published to `quay.io/moxielogic`**, matching the existing cross/foreign jobs — left as a maintainer follow-up. The three fixes here are validated (all arch jobs pass; #2 and #3 reproduced under emulation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)