### PR TITLE
x86: return small structs in registers on the BSD i386 targets

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -118,7 +118,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       break;
     case FFI_TYPE_STRUCT:
       {
-#if defined(X86_WIN32) || defined(X86_DARWIN)
+#if defined(X86_WIN32) || defined(X86_DARWIN) || defined(X86_FREEBSD)
         size_t size = cif->rtype->size;
         if (size == 1)
           flags = X86_RET_STRUCT_1B;


### PR DESCRIPTION
On i386 FreeBSD and OpenBSD a struct of 1, 2, 4 or 8 bytes is returned in eax and edx, as on Darwin and win32. gcc/config/i386/freebsd.h and gcc/config/i386/openbsdelf.h set DEFAULT_PCC_STRUCT_RETURN 0, and clang emits no sret parameter for those sizes. Sizes 3, 6 and 12 stay in memory.

ffi_prep_cif_machdep applies the size test only under X86_WIN32 and X86_DARWIN, so on these targets it records X86_RET_STRUCTPOP and allocates a return pointer the callee never writes. configure.host already maps i?86-*-freebsd* and i?86-*-openbsd* to TARGET=X86_FREEBSD, and include/ffi.h.in defines that name.

Measured with a 32-bit build on Linux, X86_FREEBSD defined and the test compiled -freg-struct-return: without the change a struct return through ffi_call or a closure segfaults, and with it sizes 1, 2, 3, 4, 6, 8 and 12 are correct. Building src/x86/ffi.c without X86_FREEBSD gives a byte identical object.

struct1.c, struct3.c and struct5.c return 8, 4 and 2 bytes, so the existing tests cover it.

i386 DragonFly has the same convention, but configure.host gives it TARGET=X86.
