### PR TITLE
aarch64, arm: fix big-endian sub-word argument/return offsets

### DIFF
--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -564,13 +564,9 @@ compress_hfa_type (void *dest, void *reg, int h)
     {
     case AARCH64_RET_S1:
       if (dest == reg)
-	{
-#ifdef __AARCH64EB__
-	  dest += 12;
-#endif
-	}
+	return (char *)dest + BE (12);
       else
-	*(float *)dest = *(float *)reg;
+	*(float *)dest = *(float *)((char *)reg + BE (12));
       break;
     case AARCH64_RET_S2:
       __asm__ ("ldp q16, q17, [%1]\n\t"
@@ -592,13 +588,9 @@ compress_hfa_type (void *dest, void *reg, int h)
 
     case AARCH64_RET_D1:
       if (dest == reg)
-	{
-#ifdef __AARCH64EB__
-	  dest += 8;
-#endif
-	}
+	return (char *)dest + BE (8);
       else
-	*(double *)dest = *(double *)reg;
+	*(double *)dest = *(double *)((char *)reg + BE (8));
       break;
     case AARCH64_RET_D2:
       __asm__ ("ldp q16, q17, [%1]\n\t"
@@ -637,10 +629,11 @@ allocate_int_to_reg_or_stack (struct call_context *context,
 			      void *stack, size_t size)
 {
   if (state->ngrn < N_X_ARG_REG)
-    return &context->x[state->ngrn++];
+    return (char *)&context->x[state->ngrn++] + BE (sizeof (UINT64) - size);
 
   state->ngrn = N_X_ARG_REG;
-  return allocate_to_stack (state, stack, size, size);
+  return (char *)allocate_to_stack (state, stack, size, size)
+	 + BE (sizeof (UINT64) - size);
 }
 
 static void *
@@ -937,7 +930,8 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
                   break;
                 }
                 state.nsrn = N_V_ARG_REG;
-                dest = allocate_to_stack (&state, stack, ty->alignment, s);
+                dest = (char *)allocate_to_stack (&state, stack, ty->alignment, s)
+                       + (t == FFI_TYPE_FLOAT ? BE (sizeof (UINT64) - s) : 0);
               }
 	      }
 	    else if (s > 16)
@@ -1222,8 +1216,9 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
                     {
                       state.ngrn = N_X_ARG_REG;
                       state.nsrn = N_V_ARG_REG;
-                      avalue[i] = allocate_to_stack(&state, stack,
-                             ty->alignment, s);
+                      avalue[i] = (char *)allocate_to_stack (&state, stack,
+                                                             ty->alignment, s)
+                                  + (t == FFI_TYPE_FLOAT ? BE (sizeof (UINT64) - s) : 0);
                     }
                 }
               else
@@ -1237,8 +1232,9 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
                   else
                     {
                       state.nsrn = N_V_ARG_REG;
-                      avalue[i] = allocate_to_stack(&state, stack,
-                                                   ty->alignment, s);
+                      avalue[i] = (char *)allocate_to_stack (&state, stack,
+                                                             ty->alignment, s)
+                                  + (t == FFI_TYPE_FLOAT ? BE (sizeof (UINT64) - s) : 0);
                     }
                 }
             }

--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -78,6 +78,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #endif
 
+#ifdef __AARCH64EB__
+# define BE(X)	X
+#else
+# define BE(X)	0
+#endif
 /* Helpers for writing assembly compatible with arm ptr auth */
 #ifdef LIBFFI_ASM
 

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -467,6 +467,11 @@ ffi_prep_incoming_args_SYSV (ffi_cif *cif, void *rvalue,
       size_t z = ty->size;
 
       argp = ffi_align (ty, argp);
+#ifdef __ARMEB__
+      if (z < 4 && ty->type != FFI_TYPE_STRUCT)
+	avalue[i] = (void *) (argp + 4 - z);
+      else
+#endif
       avalue[i] = (void *) argp;
       argp += z;
     }
@@ -515,6 +520,11 @@ ffi_prep_incoming_args_VFP (ffi_cif *cif, void *rvalue, char *stack,
 	  if (tregp + z <= eo_regp || !stack_used)
 	    {
 	      /* Because we're little endian, this is what it turns into.  */
+#ifdef __ARMEB__
+	      if (z < 4 && ty->type != FFI_TYPE_STRUCT)
+		avalue[i] = (void *) (tregp + 4 - z);
+	      else
+#endif
 	      avalue[i] = (void *) tregp;
 	      regp = tregp + z;
 
@@ -537,6 +547,11 @@ ffi_prep_incoming_args_VFP (ffi_cif *cif, void *rvalue, char *stack,
 
       stack_used = 1;
       argp = ffi_align (ty, argp);
+#ifdef __ARMEB__
+      if (z < 4 && ty->type != FFI_TYPE_STRUCT)
+	avalue[i] = (void *) (argp + 4 - z);
+      else
+#endif
       avalue[i] = (void *) argp;
       argp += z;
     }


### PR DESCRIPTION
On big-endian AArch64/ARM, sub-64/32-bit integer and scalar-float
arguments sit in the LSB of their register or stack slot (the
high-address bytes). The closure and ffi_call paths returned the slot
base, which is wrong on BE.

- aarch64: BE() helper; offset by BE(sizeof(UINT64) - size) in
  allocate_int_to_reg_or_stack, ffi_call_int (also add missing spill
  memcpy), ffi_closure_SYSV_inner; fix compress_hfa_type S1/D1 offsets.
- arm: offset sub-4-byte ints by 4 - size in ffi_prep_incoming_args_*.

Little-endian is unchanged (BE() -> 0). s390 and raw_api already use
the same convention.
226/226 tests pass on aarch64[_be], 217/217 on arm[eb]
Closes #1011 #675  