### PR TITLE
closures: handle page size lookup failure

### DIFF
--- a/src/closures.c
+++ b/src/closures.c
@@ -800,6 +800,8 @@ allocate_space (int fd, off_t len)
   /* Obtain system page size. */
   if (!page_size)
     page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0)
+    return -1;
 
   unsigned char buf[page_size];
   memset (buf, 0, page_size);


### PR DESCRIPTION
### Problem

`allocate_space()` uses the result of `sysconf(_SC_PAGESIZE)` directly as the size of a local variable-length array.

If the page-size query fails or returns an invalid value, the function may attempt to create an invalid local buffer.

### Fix

Check the page size before declaring or using the local buffer and return an error when the value is not positive.

### Testing

Built libffi and ran the full test suite successfully:

```text
2,564 expected passes
```
