### PR TITLE
Added `subsections_via_symbols` for Apple platforms

### DIFF
--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -728,3 +728,7 @@ CNAME(ffi_go_closure_SYSV):
 	.section .note.GNU-stack,"",%progbits
 FEATURE_1_AND_MARK(AARCH64_BTI | AARCH64_POINTER_AUTH | AARCH64_GCS)
 #endif
+
+#ifdef __APPLE__
+	.subsections_via_symbols
+#endif


### PR DESCRIPTION
`.subsections_via_symbols` is an assembler directive for Apple/Mach-O targets that tells the linker that a section can be safely split into independent, fine-grained subsections. This is on for x86_64 targets but was missing for arm64. Handcrafted assembly files must explicitly include .subsections_via_symbols at the end of the file to enable dead-stripping.